### PR TITLE
Fix test runner on Node 22+ and missing eventTimerManager in NPC/Stone

### DIFF
--- a/src/core/domain/entities/game/mob/NPC.ts
+++ b/src/core/domain/entities/game/mob/NPC.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class NPC extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.NPC,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/entities/game/mob/Stone.ts
+++ b/src/core/domain/entities/game/mob/Stone.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class Stone extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.METIN_STONE,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/manager/MobManager.ts
+++ b/src/core/domain/manager/MobManager.ts
@@ -179,6 +179,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }
@@ -193,6 +194,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }

--- a/test/.mocharc.integration.json
+++ b/test/.mocharc.integration.json
@@ -4,6 +4,9 @@
     "color": true,
     "file": "test/setup.integration.ts",
     "timeout": 10000,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ]

--- a/test/.mocharc.unit.json
+++ b/test/.mocharc.unit.json
@@ -4,6 +4,9 @@
     ],
     "spec": "test/unit/**/*.test.ts",
     "color": true,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ],

--- a/test/unit/core/domain/factories/PlayerFactory.test.ts
+++ b/test/unit/core/domain/factories/PlayerFactory.test.ts
@@ -16,6 +16,8 @@ describe('PlayerFactory', () => {
     };
     const saveCharacterService: any = {};
     let questManager: any = {};
+    const eventTimerManager: any = {};
+    const mobManager: any = {};
 
     beforeEach(() => {
         config = {
@@ -57,6 +59,8 @@ describe('PlayerFactory', () => {
             logger,
             saveCharacterService,
             questManager,
+            eventTimerManager,
+            mobManager,
         });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "transpileOnly": true
+  },
   "compilerOptions": {
     "resolveJsonModule": true,
     "outDir": "./dist",


### PR DESCRIPTION
- Disable native TS type stripping in mocha runs so ts-node and tsconfig-paths handle .ts files and @/ path aliases again
- Enable ts-node transpileOnly to match dev scripts behavior
- Pass required eventTimerManager dependency to NPC and Stone constructors (was undefined at runtime), forwarded from MobManager
- Add missing eventTimerManager/mobManager stubs in PlayerFactory test