### PR TITLE
Fix battle formulas to match original server behavior

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -114,7 +114,7 @@ export default abstract class Character extends GameEntity {
     }
 
     getAttackRating() {
-        return Math.min(90, this.getPoint(PointsEnum.DX) * 4 + (this.getPoint(PointsEnum.LEVEL) * 2) / 6);
+        return Math.min(90, (this.getPoint(PointsEnum.DX) * 4 + this.getPoint(PointsEnum.LEVEL) * 2) / 6);
     }
 
     abstract getHealthPercentage(): number;

--- a/src/core/domain/entities/game/mob/NPC.ts
+++ b/src/core/domain/entities/game/mob/NPC.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class NPC extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.NPC,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/entities/game/mob/Stone.ts
+++ b/src/core/domain/entities/game/mob/Stone.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class Stone extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.METIN_STONE,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
@@ -1001,7 +1001,7 @@ export class PlayerPoints extends Points {
             this.attackPerDxPoint * this.dx;
         attack += this.attackBonus;
         const { physic } = this.player.getWeaponValues();
-        attack += MathUtil.getRandomInt(physic.max, physic.min) * 2;
+        attack += MathUtil.getRandomInt(physic.min, physic.max) * 2;
         attack += physic.bonus * 2;
         this.attackGrade = Math.floor(attack);
     }
@@ -1010,7 +1010,7 @@ export class PlayerPoints extends Points {
         let magicAttack = this.level * 2 + 2 * this.iq;
         magicAttack += this.magicAttGradeBonus;
         const { magic } = this.player.getWeaponValues();
-        magicAttack += MathUtil.getRandomInt(magic.max, magic.min) * 2;
+        magicAttack += MathUtil.getRandomInt(magic.min, magic.max) * 2;
         magicAttack += magic.bonus * 2;
         this.magicAttGrade = Math.floor(magicAttack);
     }

--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
@@ -202,13 +202,15 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
 
         const basePlayerAttack = this.attacker.getAttack();
 
-        const attack = Math.floor(basePlayerAttack * attackRating);
+        // level must be ignored when multiplying by the attack rating (see CalcMeleeDamage)
+        const levelAttack = this.attacker.getPoint(PointsEnum.LEVEL) * 2;
+        let attack = Math.floor((basePlayerAttack - levelAttack) * attackRating) + levelAttack;
+        attack = this.calculateRaceAttackBonus(attack, victim);
 
         this.applyAttackEffect(victim);
 
         const defense = victim.getDefense();
-        let damage = Math.max(0, attack - defense);
-        damage += this.calculateBonusRaceDamage(victim);
+        const damage = Math.max(0, attack - defense);
 
         this.applyDamage(damage, DamageTypeEnum.NORMAL, victim);
     }
@@ -312,45 +314,46 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
         }
     }
 
-    private calculateBonusRaceDamage(victim: Monster) {
-        let damage = 0;
-
+    private calculateRaceAttackBonus(attack: number, victim: Monster) {
         switch (true) {
             case victim.isRaceByFlag(MobRaceFlagEnum.ANIMAL):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_ANIMAL) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.DEVIL):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_DEVIL) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.DESERT):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_DESERT) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.INSECT):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_INSECT) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.FIRE):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_FIRE) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.ICE):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_ICE) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.MILGYO):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_MILGYO) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.HUMAN):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_HUMAN) / 100);
-                break;
-            case victim.isRaceByFlag(MobRaceFlagEnum.TREE):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_TREE) / 100);
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_ANIMAL) / 100);
                 break;
             case victim.isRaceByFlag(MobRaceFlagEnum.UNDEAD):
-                damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_UNDEAD) / 100);
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_UNDEAD) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.DEVIL):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_DEVIL) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.HUMAN):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_HUMAN) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.ORC):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_ORC) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.MILGYO):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_MILGYO) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.INSECT):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_INSECT) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.FIRE):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_FIRE) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.ICE):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_ICE) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.DESERT):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_DESERT) / 100);
+                break;
+            case victim.isRaceByFlag(MobRaceFlagEnum.TREE):
+                attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_TREE) / 100);
                 break;
         }
 
-        damage += damage * (this.attacker.getPoint(PointsEnum.ATTBONUS_MONSTER) / 100);
+        attack += attack * (this.attacker.getPoint(PointsEnum.ATTBONUS_MONSTER) / 100);
 
-        return damage;
+        return Math.floor(attack);
     }
 
     protected applyFire(victim: Monster) {

--- a/src/core/domain/manager/MobManager.ts
+++ b/src/core/domain/manager/MobManager.ts
@@ -179,6 +179,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }
@@ -193,6 +194,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }

--- a/test/.mocharc.integration.json
+++ b/test/.mocharc.integration.json
@@ -4,6 +4,9 @@
     "color": true,
     "file": "test/setup.integration.ts",
     "timeout": 10000,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ]

--- a/test/.mocharc.unit.json
+++ b/test/.mocharc.unit.json
@@ -4,6 +4,9 @@
     ],
     "spec": "test/unit/**/*.test.ts",
     "color": true,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ],

--- a/test/unit/core/domain/entities/game/Character.test.ts
+++ b/test/unit/core/domain/entities/game/Character.test.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import Character from '@/core/domain/entities/game/Character';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+
+class TestCharacter extends Character {
+    private readonly testPoints = new Map<PointsEnum, number>();
+
+    addPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, (this.testPoints.get(point) ?? 0) + value);
+    }
+    setPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, value);
+    }
+    getPoint(point: PointsEnum): number {
+        return this.testPoints.get(point) ?? 0;
+    }
+    getHealthPercentage(): number {
+        return 100;
+    }
+    getAttack(): number {
+        return 0;
+    }
+    getDefense(): number {
+        return 0;
+    }
+    onSpawn(): void {}
+    onDespawn(): void {}
+}
+
+const createCharacter = ({ dx, level }: { dx: number; level: number }) => {
+    const character = new TestCharacter(
+        {
+            id: 1,
+            classId: 1,
+            virtualId: 1,
+            entityType: EntityTypeEnum.PLAYER,
+            positionX: 0,
+            positionY: 0,
+            name: 'test',
+            empire: 1,
+        },
+        {
+            animationManager: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+        },
+    );
+    character.setPoint(PointsEnum.DX, dx);
+    character.setPoint(PointsEnum.LEVEL, level);
+    return character;
+};
+
+describe('Character', () => {
+    describe('getAttackRating', () => {
+        it('should calculate rating as (dx * 4 + level * 2) / 6', () => {
+            const character = createCharacter({ dx: 30, level: 30 });
+            expect(character.getAttackRating()).to.be.equal((30 * 4 + 30 * 2) / 6);
+        });
+
+        it('should not cap rating for average stats', () => {
+            const character = createCharacter({ dx: 60, level: 45 });
+            expect(character.getAttackRating()).to.be.equal((60 * 4 + 45 * 2) / 6);
+            expect(character.getAttackRating()).to.be.lessThan(90);
+        });
+
+        it('should cap rating at 90', () => {
+            const character = createCharacter({ dx: 200, level: 99 });
+            expect(character.getAttackRating()).to.be.equal(90);
+        });
+
+        it('should return 0 when character has no dexterity and no level', () => {
+            const character = createCharacter({ dx: 0, level: 0 });
+            expect(character.getAttackRating()).to.be.equal(0);
+        });
+    });
+});

--- a/test/unit/core/domain/factories/PlayerFactory.test.ts
+++ b/test/unit/core/domain/factories/PlayerFactory.test.ts
@@ -16,6 +16,8 @@ describe('PlayerFactory', () => {
     };
     const saveCharacterService: any = {};
     let questManager: any = {};
+    const eventTimerManager: any = {};
+    const mobManager: any = {};
 
     beforeEach(() => {
         config = {
@@ -57,6 +59,8 @@ describe('PlayerFactory', () => {
             logger,
             saveCharacterService,
             questManager,
+            eventTimerManager,
+            mobManager,
         });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "transpileOnly": true
+  },
   "compilerOptions": {
     "resolveJsonModule": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Problems found

1. **Attack rating saturates at 90**: `getAttackRating()` computes
   `dx * 4 + (level * 2) / 6` — misplaced parentheses. The original formula
   (original files, CalcAttackRating) is `(dx * 4 + level * 2) / 6`. Any character
   with DX >= 23 hit the cap, so dexterity barely affected accuracy.

2. **Race attack bonuses never apply**: `calculateBonusRaceDamage` started
   with `let damage = 0` and multiplied it by the bonus percentages, so
   ATTBONUS_ANIMAL/UNDEAD/DEVIL/etc. and ATTBONUS_MONSTER always returned 0.

3. **Weapon damage roll skewed**: `getRandomInt(physic.max, physic.min)` —
   swapped min/max args in `calcAttack`/`calcMagicAttack` biased the roll and
   excluded the minimum damage value.

## Changes

- Fix attack rating parentheses; add unit tests for it
- Apply race bonuses as a percentage of the attack value before defense
  subtraction (matching CalcAttBonus order), add missing ORC race
- Exclude `level * 2` from the attack-rating multiplication in melee attacks,
  matching the original ("level must be ignored when multiply by fAR")
- Fix swapped min/max in weapon damage rolls

## Notes

Based on top of #14 (needs the test-runner fix for tests to run) — will
rebase/simplify automatically once #14 is merged.

## Testing

- `npm run test:unit`: 388 passing (384 existing + 4 new)
- `npm run build`: compiles without errors