### PR TITLE
Make packet pack() safe to call more than once

### DIFF
--- a/src/core/domain/entities/game/mob/NPC.ts
+++ b/src/core/domain/entities/game/mob/NPC.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class NPC extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.NPC,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/entities/game/mob/Stone.ts
+++ b/src/core/domain/entities/game/mob/Stone.ts
@@ -2,18 +2,27 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { Mob, MobParams } from './Mob';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import AnimationManager from '@/core/domain/manager/AnimationManager';
+import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
 export default class Stone extends Mob {
     constructor(
         params: Omit<MobParams, 'virtualId' | 'entityType'>,
-        { animationManager, questManager }: { animationManager: AnimationManager; questManager: QuestManager },
+        {
+            animationManager,
+            questManager,
+            eventTimerManager,
+        }: {
+            animationManager: AnimationManager;
+            questManager: QuestManager;
+            eventTimerManager: GlobalEventTimerManager;
+        },
     ) {
         super(
             {
                 ...params,
                 entityType: EntityTypeEnum.METIN_STONE,
             },
-            { animationManager, questManager },
+            { animationManager, questManager, eventTimerManager },
         );
     }
 

--- a/src/core/domain/manager/MobManager.ts
+++ b/src/core/domain/manager/MobManager.ts
@@ -179,6 +179,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }
@@ -193,6 +194,7 @@ export default class MobManager {
                     {
                         animationManager: this.animationManager,
                         questManager: this.questManager,
+                        eventTimerManager: this.eventTimerManager,
                     },
                 );
             }

--- a/src/core/interface/networking/buffer/BufferWriter.ts
+++ b/src/core/interface/networking/buffer/BufferWriter.ts
@@ -8,6 +8,11 @@ export default class BufferWriter {
     }
 
     getBuffer(size?: number): Buffer {
+        // Reset the cursor so the next write sequence starts a fresh payload after
+        // the header. Every pack() ends by calling getBuffer(), so this makes packet
+        // instances safe to pack more than once (e.g. broadcasts to multiple
+        // connections) instead of writing past the end of the fixed-size buffer.
+        this.lastPos = 1;
         if (size) {
             return this.buffer.subarray(0, size);
         }

--- a/test/.mocharc.integration.json
+++ b/test/.mocharc.integration.json
@@ -4,6 +4,9 @@
     "color": true,
     "file": "test/setup.integration.ts",
     "timeout": 10000,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ]

--- a/test/.mocharc.unit.json
+++ b/test/.mocharc.unit.json
@@ -4,6 +4,9 @@
     ],
     "spec": "test/unit/**/*.test.ts",
     "color": true,
+    "node-option": [
+        "no-experimental-strip-types"
+    ],
     "require": [
         "ts-node/register"
     ],

--- a/test/unit/core/domain/factories/PlayerFactory.test.ts
+++ b/test/unit/core/domain/factories/PlayerFactory.test.ts
@@ -16,6 +16,8 @@ describe('PlayerFactory', () => {
     };
     const saveCharacterService: any = {};
     let questManager: any = {};
+    const eventTimerManager: any = {};
+    const mobManager: any = {};
 
     beforeEach(() => {
         config = {
@@ -57,6 +59,8 @@ describe('PlayerFactory', () => {
             logger,
             saveCharacterService,
             questManager,
+            eventTimerManager,
+            mobManager,
         });
     });
 

--- a/test/unit/core/interface/networking/buffer/BufferWriter.test.ts
+++ b/test/unit/core/interface/networking/buffer/BufferWriter.test.ts
@@ -1,4 +1,6 @@
 import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import CharacterInfoPacket from '@/core/interface/networking/packets/packet/out/CharacterInfoPacket';
+import CharacterSpawnPacket from '@/core/interface/networking/packets/packet/out/CharacterSpawnPacket';
 import { expect } from 'chai';
 
 describe('BufferWriter', function () {
@@ -49,5 +51,57 @@ describe('BufferWriter', function () {
         const buffer = bufferWriter.getBuffer();
 
         expect(buffer.readFloatLE(1)).to.be.closeTo(3.14, 0.00001);
+    });
+
+    it('should reset the cursor on getBuffer so the writer can be reused', function () {
+        bufferWriter.writeUint8(0x02).writeUint32LE(1234);
+        const first = Buffer.from(bufferWriter.getBuffer());
+
+        bufferWriter.writeUint8(0x02).writeUint32LE(1234);
+        const second = Buffer.from(bufferWriter.getBuffer());
+
+        expect(second.equals(first)).to.be.equal(true);
+    });
+
+    describe('packet reuse (single-use packet regression)', function () {
+        it('should allow packing the same fixed-size packet more than once', function () {
+            const packet = new CharacterSpawnPacket({
+                vid: 1,
+                playerClass: 0,
+                entityType: 6,
+                attackSpeed: 100,
+                movementSpeed: 100,
+                positionX: 100,
+                positionY: 200,
+                positionZ: 0,
+                rotation: 0,
+                affects: [0, 0],
+                state: 0,
+            });
+
+            const first = Buffer.from(packet.pack());
+            const second = Buffer.from(packet.pack());
+
+            expect(second.equals(first)).to.be.equal(true);
+        });
+
+        it('should allow packing a string-field packet more than once', function () {
+            const packet = new CharacterInfoPacket({
+                vid: 1,
+                playerName: 'Rider',
+                parts: [1, 2, 0, 3],
+                empireId: 1,
+                guildId: 0,
+                level: 25,
+                rankPoints: 0,
+                pkMode: 0,
+                mountId: 20101,
+            });
+
+            const first = Buffer.from(packet.pack());
+            const second = Buffer.from(packet.pack());
+
+            expect(second.equals(first)).to.be.equal(true);
+        });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "transpileOnly": true
+  },
   "compilerOptions": {
     "resolveJsonModule": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Problem

`BufferWriter` keeps its write cursor (`lastPos`) across `pack()` calls. Packing the same `PacketOut` instance twice therefore writes past the end of the fixed-size buffer and throws `ERR_OUT_OF_RANGE`, crashing the server.

This is an easy trap for any broadcast-style code that builds one packet and sends it to several connections — it's exactly what caused the "server crash when broadcasting now-riding state to other players" bug in #13 (`broadcastMountChange` reused one `CharacterSpawnPacket` for every nearby player; the second send crashed the game server).

## Fix

Every `pack()` implementation ends by calling `getBuffer()`, so the cursor is reset there — each `pack()` now starts a fresh payload right after the header byte. This makes **all** existing packets reusable with no per-packet changes and no behavior change for code that already packs once.

## Testing

- New regression tests: writer reuse, a fixed-size packet (`CharacterSpawnPacket`) packed twice, and a string-field packet (`CharacterInfoPacket`) packed twice
- `npm run test:unit`: 387 passing, 0 failing
- `npm run build`: clean

## Notes

Based on top of #14 (needs the test-runner fix for tests to run) — the diff will simplify once #14 is merged.