### PR TITLE
Add keepalive ping so clients stay connected

### DIFF
--- a/src/core/enum/PacketHeaderEnum.ts
+++ b/src/core/enum/PacketHeaderEnum.ts
@@ -46,8 +46,13 @@ export default {
     AFFECT_ADD: 0x7e,
     SPECIAL_EFFECT: 0x72,
     ITEM_UPDATE: 0x19,
-    INTERNAL_PING: 254,
-    INTERNAL_PONG: 253,
+    // 240/239 are outside the client protocol range — used only by internal tooling
+    // (e.g. the performance ping flow). The 0xfc-0xff range belongs to the client:
+    // 0xfe is CG_PONG, the client's reply to the keepalive GC_PING (44).
+    INTERNAL_PING: 240,
+    INTERNAL_PONG: 239,
+    PING: 44,
+    PONG: 254,
     ON_CLICK: 0x1a,
     QUEST_SCRIPT: 0x2d,
     QUEST_ANSWER: 0x1d,

--- a/src/core/interface/networking/Connection.ts
+++ b/src/core/interface/networking/Connection.ts
@@ -4,6 +4,9 @@ import ConnectionStatePacket from './packets/packet/out/ConnectionStatePacket';
 import { ConnectionStateEnum } from '../../enum/ConnectionStateEnum';
 import Logger from '@/core/infra/logger/Logger';
 import HandshakePacket from './packets/packet/bidirectional/handshake/HandshakePacket';
+import PingPacket from './packets/packet/out/PingPacket';
+
+const KEEPALIVE_INTERVAL_MS = 60_000;
 
 export default abstract class Connection {
     protected id: string;
@@ -12,11 +15,44 @@ export default abstract class Connection {
     protected logger: Logger;
 
     private lastHandshake: HandshakePacket | null = null;
+    private keepaliveTimer: NodeJS.Timeout | null = null;
+    private pongReceived = true;
 
     constructor({ socket, logger }: { socket: Socket; logger: Logger }) {
         this.id = randomUUID();
         this.socket = socket;
         this.logger = logger;
+    }
+
+    /**
+     * Periodically ping the client (GC_PING) like the original server does:
+     * the client answers with CG_PONG and treats the traffic as proof the
+     * connection is alive — without it, the client drops the link after a
+     * few idle minutes. Connections that stop answering are closed.
+     */
+    startKeepalive(intervalMs: number = KEEPALIVE_INTERVAL_MS) {
+        if (this.keepaliveTimer) return;
+
+        this.keepaliveTimer = setInterval(() => {
+            if (!this.pongReceived) {
+                this.logger.debug(`[KEEPALIVE] No pong from connection: ID: ${this.id}, closing`);
+                this.close();
+                return;
+            }
+
+            this.pongReceived = false;
+            this.send(new PingPacket());
+        }, intervalMs);
+    }
+
+    stopKeepalive() {
+        if (!this.keepaliveTimer) return;
+        clearInterval(this.keepaliveTimer);
+        this.keepaliveTimer = null;
+    }
+
+    onPongReceived() {
+        this.pongReceived = true;
     }
 
     setLastHandshake(value: HandshakePacket) {
@@ -60,6 +96,7 @@ export default abstract class Connection {
     abstract send<T>(packet: T): void;
 
     close() {
+        this.stopKeepalive();
         this.socket.destroy();
     }
 }

--- a/src/core/interface/networking/packets/Packets.ts
+++ b/src/core/interface/networking/packets/Packets.ts
@@ -37,6 +37,8 @@ import Packet from './packet/Packet';
 import PacketHandler from './packet/PacketHandler';
 import InternalPingPacket from './packet/in/internalPing/InternalPingPacket';
 import InternalPingPacketHandler from './packet/in/internalPing/InternalPingPacketHandler';
+import PongPacket from './packet/in/pong/PongPacket';
+import PongPacketHandler from './packet/in/pong/PongPacketHandler';
 import OnClickPacket from './packet/in/onclick/OnClickPacket';
 import OnClickPacketHandler from './packet/in/onclick/OnClickPacketHandler';
 import QuestAnswerPacket from './packet/in/questAnswer/QuestAnswerPacket';
@@ -184,6 +186,13 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new InternalPingPacket(params),
             createHandler: (params) => new InternalPingPacketHandler(params),
+        },
+    ],
+    [
+        PacketHeaderEnum.PONG,
+        {
+            createPacket: () => new PongPacket(),
+            createHandler: () => new PongPacketHandler(),
         },
     ],
     [

--- a/src/core/interface/networking/packets/packet/in/pong/PongPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/pong/PongPacket.ts
@@ -1,0 +1,20 @@
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import PacketIn from '../PacketIn';
+
+/**
+ * CG_PONG (header 254) — the client's header-only reply to the keepalive
+ * GC_PING. Receiving it proves the client is still alive.
+ */
+export default class PongPacket extends PacketIn {
+    constructor() {
+        super({
+            header: PacketHeaderEnum.PONG,
+            name: 'PongPacket',
+            size: 1,
+        });
+    }
+
+    unpack() {
+        return this;
+    }
+}

--- a/src/core/interface/networking/packets/packet/in/pong/PongPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/pong/PongPacketHandler.ts
@@ -1,0 +1,9 @@
+import Connection from '@/core/interface/networking/Connection';
+import PacketHandler from '../../PacketHandler';
+import PongPacket from './PongPacket';
+
+export default class PongPacketHandler extends PacketHandler<PongPacket> {
+    async execute(connection: Connection) {
+        connection.onPongReceived();
+    }
+}

--- a/src/core/interface/networking/packets/packet/out/PingPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/PingPacket.ts
@@ -1,0 +1,20 @@
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
+
+/**
+ * Keepalive ping (GC_PING, header 44) sent periodically to every connection.
+ * The client answers with CG_PONG (header 254). Header-only packet.
+ */
+export default class PingPacket extends PacketOut {
+    constructor() {
+        super({
+            header: PacketHeaderEnum.PING,
+            name: 'PingPacket',
+            size: 1,
+        });
+    }
+
+    pack() {
+        return this.bufferWriter.getBuffer();
+    }
+}

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -36,6 +36,7 @@ export default abstract class Server {
 
         this.logger.debug(`[IN][CONNECT SOCKET EVENT] New connection: ID: ${connection.getId()}`);
         connection.startHandShake();
+        connection.startKeepalive();
 
         socket.on('close', this.onClose.bind(this, connection));
         socket.on('data', this.onData.bind(this, connection));
@@ -50,6 +51,7 @@ export default abstract class Server {
 
     async onClose(connection: Connection) {
         this.logger.debug(`[IN][CLOSE SOCKET EVENT] Closing connection: ID: ${connection.getId()}`);
+        connection.stopKeepalive();
         this.connections.delete(connection.getId());
     }
 

--- a/test/unit/core/interface/networking/Connection.test.ts
+++ b/test/unit/core/interface/networking/Connection.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Connection from '@/core/interface/networking/Connection';
+import PingPacket from '@/core/interface/networking/packets/packet/out/PingPacket';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+class TestConnection extends Connection {
+    public readonly sentPackets: unknown[] = [];
+
+    onHandshakeSuccess(): void {}
+
+    send<T>(packet: T): void {
+        this.sentPackets.push(packet);
+    }
+}
+
+const KEEPALIVE_INTERVAL_MS = 60_000;
+
+describe('Connection', () => {
+    describe('keepalive', () => {
+        let clock: sinon.SinonFakeTimers;
+        let socket: any;
+        let connection: TestConnection;
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers();
+            socket = { destroy: sinon.spy() };
+            connection = new TestConnection({ socket, logger });
+        });
+
+        afterEach(() => {
+            connection.stopKeepalive();
+            clock.restore();
+        });
+
+        it('should send a ping after each interval while the client answers', () => {
+            connection.startKeepalive();
+
+            clock.tick(KEEPALIVE_INTERVAL_MS);
+            expect(connection.sentPackets.length).to.be.equal(1);
+            expect(connection.sentPackets[0]).to.be.instanceOf(PingPacket);
+
+            connection.onPongReceived();
+            clock.tick(KEEPALIVE_INTERVAL_MS);
+            expect(connection.sentPackets.length).to.be.equal(2);
+            expect(socket.destroy.called).to.be.equal(false);
+        });
+
+        it('should close the connection when the client does not answer the ping', () => {
+            connection.startKeepalive();
+
+            clock.tick(KEEPALIVE_INTERVAL_MS);
+            expect(connection.sentPackets.length).to.be.equal(1);
+
+            clock.tick(KEEPALIVE_INTERVAL_MS);
+            expect(socket.destroy.called).to.be.equal(true);
+            expect(connection.sentPackets.length).to.be.equal(1);
+        });
+
+        it('should not ping anymore after stopKeepalive', () => {
+            connection.startKeepalive();
+            connection.stopKeepalive();
+
+            clock.tick(KEEPALIVE_INTERVAL_MS * 3);
+            expect(connection.sentPackets.length).to.be.equal(0);
+        });
+
+        it('should not create a second timer if started twice', () => {
+            connection.startKeepalive();
+            connection.startKeepalive();
+
+            clock.tick(KEEPALIVE_INTERVAL_MS);
+            expect(connection.sentPackets.length).to.be.equal(1);
+        });
+
+        it('should stop the keepalive when the connection is closed', () => {
+            connection.startKeepalive();
+            connection.close();
+
+            clock.tick(KEEPALIVE_INTERVAL_MS * 2);
+            expect(connection.sentPackets.length).to.be.equal(0);
+            expect(socket.destroy.called).to.be.equal(true);
+        });
+    });
+});

--- a/test/unit/core/interface/networking/Connection.test.ts
+++ b/test/unit/core/interface/networking/Connection.test.ts
@@ -38,12 +38,12 @@ describe('Connection', () => {
             connection.startKeepalive();
 
             clock.tick(KEEPALIVE_INTERVAL_MS);
-            expect(connection.sentPackets.length).to.be.equal(1);
+            expect(connection.sentPackets).to.have.lengthOf(1);
             expect(connection.sentPackets[0]).to.be.instanceOf(PingPacket);
 
             connection.onPongReceived();
             clock.tick(KEEPALIVE_INTERVAL_MS);
-            expect(connection.sentPackets.length).to.be.equal(2);
+            expect(connection.sentPackets).to.have.lengthOf(2);
             expect(socket.destroy.called).to.be.equal(false);
         });
 
@@ -51,11 +51,11 @@ describe('Connection', () => {
             connection.startKeepalive();
 
             clock.tick(KEEPALIVE_INTERVAL_MS);
-            expect(connection.sentPackets.length).to.be.equal(1);
+            expect(connection.sentPackets).to.have.lengthOf(1);
 
             clock.tick(KEEPALIVE_INTERVAL_MS);
             expect(socket.destroy.called).to.be.equal(true);
-            expect(connection.sentPackets.length).to.be.equal(1);
+            expect(connection.sentPackets).to.have.lengthOf(1);
         });
 
         it('should not ping anymore after stopKeepalive', () => {
@@ -63,7 +63,7 @@ describe('Connection', () => {
             connection.stopKeepalive();
 
             clock.tick(KEEPALIVE_INTERVAL_MS * 3);
-            expect(connection.sentPackets.length).to.be.equal(0);
+            expect(connection.sentPackets).to.have.lengthOf(0);
         });
 
         it('should not create a second timer if started twice', () => {
@@ -71,7 +71,7 @@ describe('Connection', () => {
             connection.startKeepalive();
 
             clock.tick(KEEPALIVE_INTERVAL_MS);
-            expect(connection.sentPackets.length).to.be.equal(1);
+            expect(connection.sentPackets).to.have.lengthOf(1);
         });
 
         it('should stop the keepalive when the connection is closed', () => {
@@ -79,7 +79,7 @@ describe('Connection', () => {
             connection.close();
 
             clock.tick(KEEPALIVE_INTERVAL_MS * 2);
-            expect(connection.sentPackets.length).to.be.equal(0);
+            expect(connection.sentPackets).to.have.lengthOf(0);
             expect(socket.destroy.called).to.be.equal(true);
         });
     });


### PR DESCRIPTION
## Problem

The client silently drops the connection after a few idle minutes in game. Root cause: the server never sends any periodic traffic. The original server pings every connection with `GC_PING` (header 44) every 60 seconds (`ping_event` in `desc.cpp`), the client answers `CG_PONG` (header 254), and both sides treat the traffic as proof the link is alive. open-mt2 never implemented this, so idle clients time out.

## Changes

- **`PingPacket`** (out, header 44, header-only) + a per-connection keepalive timer started on connect. Connections that stop answering pings are closed by the server, mirroring the original behavior. Timer is cleaned up on close/disconnect.
- **`PongPacket`** (in, header 254, header-only) + handler that marks the pong as received.
- **Protocol conflict fix**: the internal perf-test headers `INTERNAL_PING`/`INTERNAL_PONG` moved from 254/253 to 240/239. 254 collides with the client's real `CG_PONG` (a 1-byte packet, while `InternalPingPacket` expects 5 bytes — a real client pong would corrupt the packet stream), and 253 collides with `GC_PHASE` on the client side. The performance ping flow keeps working unchanged since it imports the enum values.

## Testing

- 5 new unit tests for the keepalive lifecycle (ping cadence, close on missed pong, stop on close, no double timer)
- `npm run test:unit`: 396 passing, 0 failing
- `npx tsc -p tsconfig.build.json --noEmit`: clean
- Verified in game with a TMP4 client: idle client no longer disconnects