### PR TITLE
Despawn player when the connection closes

### DIFF
--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -5,18 +5,34 @@ import { Socket } from 'net';
 import { Logger } from 'winston';
 import { GameConfig } from '@/game/infra/config/GameConfig';
 import { PacketMapValue } from '@/core/interface/networking/packets/Packets';
+import LogoutService from '@/game/app/service/LogoutService';
 
 export default class GameServer extends Server {
     private readonly world: World;
+    private readonly logoutService: LogoutService;
 
     constructor(container: {
         logger: Logger;
         config: GameConfig;
         packets: Map<number, PacketMapValue<any>>;
         world: World;
+        logoutService: LogoutService;
     }) {
         super(container);
         this.world = container.world;
+        this.logoutService = container.logoutService;
+    }
+
+    async onClose(connection: GameConnection) {
+        const player = connection.getPlayer();
+
+        if (player) {
+            await this.logoutService
+                .execute(player)
+                .catch((err) => this.logger.error(`[GameServer] Error despawning player on disconnect: ${err}`));
+        }
+
+        await super.onClose(connection);
     }
 
     async onData(connection: GameConnection, data: Buffer) {

--- a/test/unit/game/interface/server/GameServer.test.ts
+++ b/test/unit/game/interface/server/GameServer.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import GameServer from '@/game/interface/server/GameServer';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const createGameServer = (logoutService: any) => {
+    return new GameServer({
+        logger,
+        config: {} as any,
+        packets: new Map(),
+        world: {} as any,
+        logoutService,
+    });
+};
+
+const createConnection = (player: unknown) =>
+    ({
+        getId: () => 'connection-id',
+        getPlayer: () => player,
+    }) as any;
+
+describe('GameServer', () => {
+    describe('onClose', () => {
+        it('should despawn the player when the connection closes', async () => {
+            const logoutService = { execute: sinon.stub().resolves() };
+            const server = createGameServer(logoutService);
+            const player = { getName: () => 'Test' };
+
+            await server.onClose(createConnection(player));
+
+            expect(logoutService.execute.calledOnceWith(player)).to.be.equal(true);
+        });
+
+        it('should not call logout when the connection has no player selected', async () => {
+            const logoutService = { execute: sinon.stub().resolves() };
+            const server = createGameServer(logoutService);
+
+            await server.onClose(createConnection(null));
+
+            expect(logoutService.execute.called).to.be.equal(false);
+        });
+
+        it('should not throw when the logout fails', async () => {
+            const logoutService = { execute: sinon.stub().rejects(new Error('boom')) };
+            const server = createGameServer(logoutService);
+
+            await server.onClose(createConnection({ getName: () => 'Test' }));
+
+            expect(logoutService.execute.calledOnce).to.be.equal(true);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

When a client disconnects abruptly (crash, network loss, timeout), nothing removes the player from the world: `LogoutService` existed but was never called from anywhere. The disconnected player stays spawned as a **ghost** — visible to everyone, targetable, and duplicated once the account reconnects (two copies of the same character standing in the world).

Easy to reproduce: kill the client process while in game, reconnect — the old copy is still there.

## Fix

Wire `GameServer.onClose` (socket close event) to the existing `LogoutService` → `LeaveGameService` → `World.despawn` flow. `Player.onDespawn` already does the right cleanup — saves the character, clears timers and notifies nearby players — it just was never reached on disconnect.

Errors during the logout flow are logged and don't prevent the connection from being cleaned up.

## Testing

- 3 new unit tests for `GameServer.onClose` (despawns the player, skips when no player selected, resilient to logout errors)
- `npm run test:unit`: 394 passing, 0 failing
- `npx tsc -p tsconfig.build.json --noEmit`: clean
- Verified in game with a TMP4 client: killing the client and reconnecting no longer leaves a ghost copy