### PR TITLE
Fix quest dialog interaction (shop interleaving + window close)

### DIFF
--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -21,6 +21,10 @@ export abstract class AbstractQuest {
     private values: Map<string, any> = new Map();
     private hasReward: boolean = false;
     private status: QuestStatusEnum = QuestStatusEnum.NONE;
+    // Synchronous busy flag. Status only becomes SELECT/PAUSE after the callback
+    // reaches select()/nextPage() (several awaits in), leaving a window where a
+    // second click could start a concurrent run. This flag closes that window.
+    private running: boolean = false;
     private questFlags: BitFlag = new BitFlag();
 
     private readonly player: Player;
@@ -53,6 +57,22 @@ export abstract class AbstractQuest {
     public addState(state: State) {
         this.states.set(state.name, state);
         return this;
+    }
+
+    /**
+     * Entry point for interactive events (click, chat) triggered from a packet
+     * handler. Runs the state machine detached from the handler: the busy flag is
+     * set synchronously (re-entrancy guard) and only cleared when the coroutine —
+     * including any suspended select()/nextPage() — fully settles. Because the
+     * caller does not await this, quest packets are sent after the handler has
+     * returned and uncorked the socket, so they never interleave with other
+     * handlers' output.
+     */
+    run(context: StateExecutionContextBase): void {
+        this.running = true;
+        void this.runState(context).finally(() => {
+            this.running = false;
+        });
     }
 
     async runState(context: StateExecutionContextBase) {
@@ -339,6 +359,6 @@ export abstract class AbstractQuest {
     }
 
     isRunning() {
-        return this.status !== QuestStatusEnum.NONE;
+        return this.running || this.status !== QuestStatusEnum.NONE;
     }
 }

--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -8,6 +8,9 @@ import { PlayerQuest } from './facade/PlayerQuest';
 import ItemManager from '../manager/ItemManager';
 import MathUtil from '../util/MathUtil';
 
+// Sent by the client when the quest window is closed instead of picking an option.
+const CLOSE_WINDOW_ANSWER = 254;
+
 export abstract class AbstractQuest {
     private readonly id!: number;
     private name!: string;
@@ -201,6 +204,22 @@ export abstract class AbstractQuest {
 
     public unpause() {
         this.nextPagePromise.resolve();
+    }
+
+    /**
+     * Release whatever the quest is currently waiting on (the player closed the
+     * quest window). A pending select resolves with the out-of-range close answer,
+     * so option checks in the quest script simply don't match and the quest ends.
+     */
+    public cancel() {
+        if (this.status === QuestStatusEnum.SELECT) {
+            this.currentChoicePromise.resolve(CLOSE_WINDOW_ANSWER);
+            return;
+        }
+
+        if (this.status === QuestStatusEnum.PAUSE) {
+            this.nextPagePromise.resolve();
+        }
     }
 
     protected async select(options: Array<string>, done: boolean = false) {

--- a/src/core/domain/quests/QuestManager.ts
+++ b/src/core/domain/quests/QuestManager.ts
@@ -248,13 +248,23 @@ export class QuestManager {
 
             quest.unselect(answer);
         } else {
-            const quest = player.getQuestByStatus(QuestStatusEnum.PAUSE);
-
-            if (!quest) {
-                this.logger.error(`[QUEST_MANAGER] No active quest paused, playerId: ${player.getId()}`);
+            // Values above 250 come from the [NEXT] button or from the player
+            // closing the quest window. Release whatever the quest is waiting on —
+            // otherwise a quest left in SELECT stays running forever and blocks
+            // every further NPC interaction for this player.
+            const pausedQuest = player.getQuestByStatus(QuestStatusEnum.PAUSE);
+            if (pausedQuest) {
+                pausedQuest.unpause();
                 return;
             }
-            quest.unpause();
+
+            const selectQuest = player.getQuestByStatus(QuestStatusEnum.SELECT);
+            if (selectQuest) {
+                selectQuest.cancel();
+                return;
+            }
+
+            this.logger.error(`[QUEST_MANAGER] No active quest paused or awaiting select, playerId: ${player.getId()}`);
         }
     }
 

--- a/src/core/domain/quests/QuestManager.ts
+++ b/src/core/domain/quests/QuestManager.ts
@@ -275,7 +275,7 @@ export class QuestManager {
 
         if (player.isQuestRunning()) {
             this.logger.info(
-                `[QUEST_MANAGER] Player ${player.getId()} logged in with running quest ${player.getCurrentQuest()?.getName()}`,
+                `[QUEST_MANAGER] Player ${player.getId()} clicked an NPC while quest ${player.getCurrentQuest()?.getName()} is running`,
             );
             return false;
         }

--- a/src/core/domain/quests/QuestManager.ts
+++ b/src/core/domain/quests/QuestManager.ts
@@ -277,7 +277,12 @@ export class QuestManager {
             const current = quest.getCurrentState()?.name;
             if (!current) continue;
             if (states.has(current)) {
-                await quest.runState({
+                // Dispatch detached: the quest may suspend on a dialog answer, and
+                // awaiting it here would keep the click handler (and its corked
+                // socket) alive until the player replies, interleaving quest and
+                // shop packets. run() marks the quest busy synchronously so a
+                // second click is still rejected above.
+                quest.run({
                     eventType: QuestEventEnum.CLICK,
                     npc: new NpcQuest({ npc, shopManager: this.shopManager, player }),
                 });

--- a/test/unit/core/domain/quests/AbstractQuest.test.ts
+++ b/test/unit/core/domain/quests/AbstractQuest.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { AbstractQuest } from '@/core/domain/quests/AbstractQuest';
+import { QuestEventEnum } from '@/core/enum/QuestEventEnum';
+import { QuestStatusEnum } from '@/core/domain/quests/decorators/QuestDecorator';
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+class TestQuest extends AbstractQuest {
+    public readonly sent: string[] = [];
+
+    constructor(player: any) {
+        super({ player });
+        (this as any).id = 1;
+        (this as any).name = 'TestQuest';
+    }
+
+    // Expose protected helpers for the test scenario.
+    public async selectFlow() {
+        this.title('Welcome');
+        const answer = await (this as any).select(['A', 'B']);
+        this.sent.push(`resolved:${answer}`);
+    }
+}
+
+const createPlayer = () => {
+    let currentQuest: any = null;
+    return {
+        setCurrentQuest: (q: any) => (currentQuest = q),
+        getCurrentQuest: () => currentQuest,
+        sendQuestScript: () => {},
+    };
+};
+
+const buildQuest = () => {
+    const player = createPlayer();
+    const quest = new TestQuest(player);
+    quest.addState({
+        name: 'START',
+        tasks: [{ when: QuestEventEnum.CLICK, callback: () => quest.selectFlow() }],
+    });
+    (quest as any).currentState = { name: 'START', tasks: (quest as any).states.get('START').tasks };
+    return quest;
+};
+
+describe('AbstractQuest', () => {
+    describe('run (detached interactive dispatch)', () => {
+        it('should mark the quest running synchronously, before any await', () => {
+            const quest = buildQuest();
+            expect(quest.isRunning()).to.be.equal(false);
+
+            quest.run({ eventType: QuestEventEnum.CLICK } as any);
+
+            // Synchronous: no awaits yet, but the quest already reports running.
+            expect(quest.isRunning()).to.be.equal(true);
+        });
+
+        it('should stay running while suspended on a select and settle after the answer', async () => {
+            const quest = buildQuest();
+            quest.run({ eventType: QuestEventEnum.CLICK } as any);
+            await tick();
+
+            expect(quest.getStatus()).to.be.equal(QuestStatusEnum.SELECT);
+            expect(quest.isRunning()).to.be.equal(true);
+
+            quest.unselect(0);
+            await tick();
+            await tick();
+
+            expect(quest.getStatus()).to.be.equal(QuestStatusEnum.NONE);
+            expect(quest.isRunning()).to.be.equal(false);
+            expect(quest.sent).to.include('resolved:0');
+        });
+
+        it('should recover to a non-running state across repeated interactions', async () => {
+            const quest = buildQuest();
+
+            for (let i = 0; i < 3; i++) {
+                quest.run({ eventType: QuestEventEnum.CLICK } as any);
+                await tick();
+                expect(quest.isRunning()).to.be.equal(true);
+                quest.unselect(i);
+                await tick();
+                await tick();
+                expect(quest.isRunning()).to.be.equal(false);
+            }
+        });
+    });
+});

--- a/test/unit/core/domain/quests/QuestManager.test.ts
+++ b/test/unit/core/domain/quests/QuestManager.test.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { QuestManager } from '@/core/domain/quests/QuestManager';
+import { QuestStatusEnum } from '@/core/domain/quests/decorators/QuestDecorator';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const CLOSE_WINDOW_ANSWER = 254;
+
+describe('QuestManager', () => {
+    describe('onAnswer', () => {
+        let questManager: QuestManager;
+
+        beforeEach(() => {
+            questManager = new QuestManager({ logger, shopManager: {} as any });
+        });
+
+        const createPlayer = (questsByStatus: Partial<Record<QuestStatusEnum, any>>) =>
+            ({
+                getId: () => 1,
+                getQuestByStatus: (status: QuestStatusEnum) => questsByStatus[status] ?? undefined,
+            }) as any;
+
+        it('should unselect the quest awaiting select for valid answers', () => {
+            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            questManager.onAnswer(createPlayer({ [QuestStatusEnum.SELECT]: quest }), 1);
+
+            expect(quest.unselect.calledOnceWith(1)).to.be.equal(true);
+            expect(quest.cancel.called).to.be.equal(false);
+        });
+
+        it('should unpause a paused quest when the next button is pressed', () => {
+            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            questManager.onAnswer(createPlayer({ [QuestStatusEnum.PAUSE]: quest }), CLOSE_WINDOW_ANSWER);
+
+            expect(quest.unpause.calledOnce).to.be.equal(true);
+        });
+
+        it('should cancel a quest stuck awaiting select when the window is closed', () => {
+            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            questManager.onAnswer(createPlayer({ [QuestStatusEnum.SELECT]: quest }), CLOSE_WINDOW_ANSWER);
+
+            expect(quest.cancel.calledOnce).to.be.equal(true);
+            expect(quest.unselect.called).to.be.equal(false);
+        });
+
+        it('should not throw when there is no active quest', () => {
+            expect(() => questManager.onAnswer(createPlayer({}), CLOSE_WINDOW_ANSWER)).to.not.throw();
+        });
+    });
+});


### PR DESCRIPTION
## Problem

NPCs backed by a shop quest (e.g. the Saleswoman) worked only **once**, then blocked all further NPC interaction. Two related quest-dialog bugs:

1. **Packet interleaving.** The click handler awaited the quest to completion, so the OnClick packet handler stayed alive — with the socket corked — until the player answered the dialog, which arrives as a *separate* packet. Quest and shop packets from the two overlapping handlers interleaved, and the client rejected them with `CPythonNetworkStream::RecvShopPacket: Unknown subheader`. The quest could also be left in a non-`NONE` state.

2. **Window close ignored.** Closing the quest window (client answer `254`) was only handled for *paused* quests, so a quest waiting on a `select()` stayed in `SELECT` forever and `isQuestRunning()` blocked every later click.

The storekeeper (a direct shop, no quest) always worked — confirming the fault was in the quest-mediated path.

## Fix

- **`AbstractQuest.run()`** — dispatch the state machine *detached* from the packet handler instead of awaiting it. A synchronous `running` flag guards re-entrancy and is cleared when the coroutine — including any suspended dialog — settles. `QuestManager.onClick` now dispatches through `run()` and returns immediately, so the handler uncorks the socket *before* the quest sends anything. This mirrors the original server, which suspends a Lua coroutine and returns from the packet handler.
- **`AbstractQuest.cancel()` + `onAnswer`** — a close answer (`254`) now releases a pending `select` as well as a paused page, so the quest always returns to a non-running state.

## Testing

- New unit tests: `AbstractQuest.run` lifecycle and `QuestManager.onAnswer` (select, pause, cancel-on-close, no active quest)
- `npm run test:unit`: 398 passing, 0 failing
- `npx tsc -p tsconfig.build.json --noEmit`: clean
- Verified in game with a TMP4 client: the Saleswoman shop quest now works every time, no more `Unknown subheader`