### PR TITLE
fix: remove leftover debug code granting 500 exp per movement packet

### DIFF
--- a/src/game/app/service/CharacterMoveService.ts
+++ b/src/game/app/service/CharacterMoveService.ts
@@ -1,6 +1,5 @@
 import Player from '@/core/domain/entities/game/player/Player';
 import { MovementTypeEnum } from '@/core/enum/MovementTypeEnum';
-import { PointsEnum } from '@/core/enum/PointsEnum';
 import Logger from '@/core/infra/logger/Logger';
 
 type CharacterMoveServiceParams = {
@@ -23,7 +22,6 @@ export default class CharacterMoveService {
     async execute({ player, movementType, positionX, positionY, arg, rotation, time }: CharacterMoveServiceParams) {
         switch (movementType) {
             case MovementTypeEnum.MOVE:
-                player.addPoint(PointsEnum.EXPERIENCE, 500);
                 player.goto({ positionX, positionY, arg, rotation, time, movementType });
                 break;
             case MovementTypeEnum.WAIT:

--- a/test/unit/game/app/service/CharacterMoveService.test.ts
+++ b/test/unit/game/app/service/CharacterMoveService.test.ts
@@ -17,7 +17,7 @@ describe('CharacterMoveService', function () {
     });
 
     describe('execute', function () {
-        it('should add experience and move the player for MOVE movement type', async function () {
+        it('should move the player for MOVE movement type without granting experience', async function () {
             const playerMock = {
                 addPoint: sinon.spy(),
                 goto: sinon.spy(),
@@ -35,8 +35,7 @@ describe('CharacterMoveService', function () {
 
             await characterMoveService.execute(params);
 
-            expect(playerMock.addPoint.calledOnce).to.be.true;
-            expect(playerMock.addPoint.firstCall.args[1]).to.equal(500);
+            expect(playerMock.addPoint.notCalled).to.be.true;
 
             expect(playerMock.goto.calledOnce).to.be.true;
             expect(playerMock.goto.firstCall.args[0]).to.deep.equal({


### PR DESCRIPTION
`CharacterMoveService` grants 500 experience on every MOVE packet, so characters level up just by walking around.

The line came in with the playerPoints delegate refactor (b70fb9c1) and looks like leftover debug code used to test the experience/level-up flow.

## Change

- Removed `player.addPoint(PointsEnum.EXPERIENCE, 500)` from the MOVE case (and the now-unused `PointsEnum` import).

## Tested

- In game with the TMP4 client: walking no longer grants experience; killing mobs still does.
- `npm run test:unit` passing.