### PR TITLE
fix: prevent server crash from malformed packets and out-of-range shop slots

### DIFF
--- a/src/auth/interface/server/AuthServer.ts
+++ b/src/auth/interface/server/AuthServer.ts
@@ -19,7 +19,11 @@ export default class AuthServer extends Server {
         const packet = createPacket({});
         const handler = createHandler(this.container);
         this.logger.debug(`[IN][PACKET] name: ${handler.constructor.name}`);
-        handler.execute(connection, packet.unpack(data)).catch((err) => this.logger.error(err));
+
+        const unpacked = this.unpackPacket(connection, packet, data);
+        if (!unpacked) return;
+
+        handler.execute(connection, unpacked).catch((err) => this.logger.error(err));
     }
 
     createConnection(socket: Socket) {

--- a/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
@@ -56,6 +56,15 @@ export default class MyShopPacket extends PacketIn {
         this.sign = this.bufferReader.readString(SIGN_FIELD_LEN);
         this.count = Math.min(this.bufferReader.readUInt8(), PRIVATE_SHOP_MAX_ITEMS);
 
+        // The declared count must match the bytes actually sent — a malformed
+        // packet lying about its count would make the reads below run past the
+        // end of the buffer.
+        if (buffer.byteLength < FIXED_SIZE + this.count * ITEM_ENTRY_SIZE) {
+            throw new Error(
+                `MyShopPacket: buffer too short for declared item count (count: ${this.count}, bytes: ${buffer.byteLength})`,
+            );
+        }
+
         this.items = [];
         for (let i = 0; i < this.count; i++) {
             const vnum = this.bufferReader.readUInt32LE();

--- a/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
@@ -29,7 +29,9 @@ export default class ShopStartPacket extends PacketOut {
         this.bufferWriter.writeUint8(ShopSubHeaderGC.START); // subheader
         this.bufferWriter.writeUint32LE(this.ownerVid);
 
-        for (let i = 0; i < this.items.length; i++) {
+        // Never write more entries than the fixed-size buffer can hold, even if
+        // the items array somehow grew past the shop grid.
+        for (let i = 0; i < Math.min(this.items.length, SHOP_MAX_ITEMS); i++) {
             const shopItem = this.items[i];
 
             this.bufferWriter.writeUint32LE(shopItem?.vnum || 0);

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -29,6 +29,28 @@ export default abstract class Server {
     abstract createConnection(socket: Socket): Connection;
     abstract onData(connection: Connection, data: Buffer): Promise<void>;
 
+    /**
+     * Unpacks a packet, closing the connection instead of letting a malformed
+     * packet throw. A packet lying about its size makes unpack() read past the
+     * buffer and throw; if that rejection escaped the socket 'data' listener it
+     * would surface as an unhandledRejection and take the whole process down.
+     */
+    protected unpackPacket<T extends { unpack(data: Buffer): T; getName(): string }>(
+        connection: Connection,
+        packet: T,
+        data: Buffer,
+    ): T | null {
+        try {
+            return packet.unpack(data);
+        } catch (error) {
+            this.logger.error(
+                `[IN][PACKET] Malformed ${packet.getName()} packet from connection: ID: ${connection.getId()}, closing. ${error}`,
+            );
+            connection.close();
+            return null;
+        }
+    }
+
     onListener(socket: Socket) {
         socket.setNoDelay(true);
         const connection = this.createConnection(socket);

--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -4,9 +4,8 @@ import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
 import { ShopSubHeaderGC } from '@/core/enum/ShopSubHeaderEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
-import PrivateShop, { PrivateShopItem } from '@/core/domain/shop/PrivateShop';
+import PrivateShop, { PrivateShopItem, PRIVATE_SHOP_MAX_ITEMS } from '@/core/domain/shop/PrivateShop';
 import { MyShopItemEntry } from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
-import { PRIVATE_SHOP_MAX_ITEMS } from '@/core/domain/shop/PrivateShop';
 import ItemManager from '@/core/domain/manager/ItemManager';
 import SaveCharacterService from '@/game/domain/service/SaveCharacterService';
 
@@ -55,50 +54,8 @@ export default class PrivateShopService {
         const seenCellIndex = new Set<number>();
 
         for (const entry of itemEntries) {
-            // An out-of-range displayPos would grow the shop item array past the
-            // grid and overflow the fixed-size ShopStartPacket buffer later on.
-            if (entry.displayPos >= PRIVATE_SHOP_MAX_ITEMS) {
-                this.logger.debug(
-                    `[PrivateShopService] openPrivateShop: displayPos ${entry.displayPos} out of range, skipping`,
-                );
-                continue;
-            }
-
-            if (seenDisplayPos.has(entry.displayPos)) {
-                this.logger.debug(
-                    `[PrivateShopService] openPrivateShop: duplicate displayPos ${entry.displayPos}, skipping`,
-                );
-                continue;
-            }
-
-            if (seenCellIndex.has(entry.cellIndex)) {
-                this.logger.debug(
-                    `[PrivateShopService] openPrivateShop: duplicate cellIndex ${entry.cellIndex}, skipping`,
-                );
-                continue;
-            }
-
-            const item = player.getItem(entry.cellIndex);
-            if (!item) {
-                this.logger.debug(`[PrivateShopService] openPrivateShop: item not found at slot ${entry.cellIndex}`);
-                continue;
-            }
-
-            if (item.getAntiFlags().is(ItemAntiFlagEnum.ANTI_MYSHOP)) {
-                this.logger.debug(
-                    `[PrivateShopService] openPrivateShop: item at slot ${entry.cellIndex} has ANTI_MYSHOP flag`,
-                );
-                continue;
-            }
-
-            if (entry.price < 1) {
-                this.logger.debug(
-                    `[PrivateShopService] openPrivateShop: item at slot ${entry.cellIndex} has invalid price ${entry.price}`,
-                );
-                continue;
-            }
-
-            const price = Math.min(entry.price, MAX_ITEM_PRICE);
+            const item = this.validateShopEntry(player, entry, seenDisplayPos, seenCellIndex);
+            if (!item) continue;
 
             seenDisplayPos.add(entry.displayPos);
             seenCellIndex.add(entry.cellIndex);
@@ -106,7 +63,7 @@ export default class PrivateShopService {
             shopItems.push({
                 displayPos: entry.displayPos,
                 inventoryPos: entry.cellIndex,
-                price,
+                price: Math.min(entry.price, MAX_ITEM_PRICE),
                 item,
             });
         }
@@ -116,6 +73,65 @@ export default class PrivateShopService {
             return;
         }
 
+        await this.startPrivateShop(player, sign, shopItems);
+    }
+
+    /**
+     * Validates a single shop entry: in-range unique displayPos, unique
+     * cellIndex, an existing sellable item and a positive price.
+     * Returns the inventory item when the entry is valid, null otherwise.
+     */
+    private validateShopEntry(
+        player: Player,
+        entry: MyShopItemEntry,
+        seenDisplayPos: Set<number>,
+        seenCellIndex: Set<number>,
+    ) {
+        // An out-of-range displayPos would grow the shop item array past the
+        // grid and overflow the fixed-size ShopStartPacket buffer later on.
+        if (entry.displayPos >= PRIVATE_SHOP_MAX_ITEMS) {
+            this.logger.debug(
+                `[PrivateShopService] openPrivateShop: displayPos ${entry.displayPos} out of range, skipping`,
+            );
+            return null;
+        }
+
+        if (seenDisplayPos.has(entry.displayPos)) {
+            this.logger.debug(
+                `[PrivateShopService] openPrivateShop: duplicate displayPos ${entry.displayPos}, skipping`,
+            );
+            return null;
+        }
+
+        if (seenCellIndex.has(entry.cellIndex)) {
+            this.logger.debug(`[PrivateShopService] openPrivateShop: duplicate cellIndex ${entry.cellIndex}, skipping`);
+            return null;
+        }
+
+        const item = player.getItem(entry.cellIndex);
+        if (!item) {
+            this.logger.debug(`[PrivateShopService] openPrivateShop: item not found at slot ${entry.cellIndex}`);
+            return null;
+        }
+
+        if (item.getAntiFlags().is(ItemAntiFlagEnum.ANTI_MYSHOP)) {
+            this.logger.debug(
+                `[PrivateShopService] openPrivateShop: item at slot ${entry.cellIndex} has ANTI_MYSHOP flag`,
+            );
+            return null;
+        }
+
+        if (entry.price < 1) {
+            this.logger.debug(
+                `[PrivateShopService] openPrivateShop: item at slot ${entry.cellIndex} has invalid price ${entry.price}`,
+            );
+            return null;
+        }
+
+        return item;
+    }
+
+    private async startPrivateShop(player: Player, sign: string, shopItems: PrivateShopItem[]) {
         const privateShop = new PrivateShop({ owner: player, sign, items: shopItems });
         player.setPrivateShop(privateShop);
         player.setPolymorph(30000);

--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -6,6 +6,7 @@ import { PointsEnum } from '@/core/enum/PointsEnum';
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 import PrivateShop, { PrivateShopItem } from '@/core/domain/shop/PrivateShop';
 import { MyShopItemEntry } from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
+import { PRIVATE_SHOP_MAX_ITEMS } from '@/core/domain/shop/PrivateShop';
 import ItemManager from '@/core/domain/manager/ItemManager';
 import SaveCharacterService from '@/game/domain/service/SaveCharacterService';
 
@@ -54,6 +55,15 @@ export default class PrivateShopService {
         const seenCellIndex = new Set<number>();
 
         for (const entry of itemEntries) {
+            // An out-of-range displayPos would grow the shop item array past the
+            // grid and overflow the fixed-size ShopStartPacket buffer later on.
+            if (entry.displayPos >= PRIVATE_SHOP_MAX_ITEMS) {
+                this.logger.debug(
+                    `[PrivateShopService] openPrivateShop: displayPos ${entry.displayPos} out of range, skipping`,
+                );
+                continue;
+            }
+
             if (seenDisplayPos.has(entry.displayPos)) {
                 this.logger.debug(
                     `[PrivateShopService] openPrivateShop: duplicate displayPos ${entry.displayPos}, skipping`,
@@ -292,7 +302,7 @@ export default class PrivateShopService {
         // Remove entry from shop and notify all guests that this slot is now empty
         shop.removeItemAtDisplaySlot(displaySlot);
         this.broadcastUpdateItem(shop, displaySlot);
-        this.openShopForOwner(owner);
+        await this.openShopForOwner(owner);
 
         guest.sendShopResult({ result: ShopSubHeaderGC.OK });
 

--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -34,9 +34,13 @@ export default class GameServer extends Server {
         const packet = createPacket({});
         const handler = createHandler(this.container);
         this.logger.debug(`[IN][PACKET] processing packet: ${handler.constructor.name}`);
+
+        const unpacked = this.unpackPacket(connection, packet, data);
+        if (!unpacked) return;
+
         connection.cork();
         await handler
-            .execute(connection, packet.unpack(data))
+            .execute(connection, unpacked)
             .catch((err) => this.logger.error(err))
             .finally(() => {
                 connection.uncork();


### PR DESCRIPTION
A malformed packet makes `unpack()` read past the buffer and throw. The rejection escapes the socket `data` listener as an `unhandledRejection`, which `main.ts` turns into `process.exit(1)` — so a single crafted packet can kill the entire game or auth server remotely.

## Repro

- A `CG_MY_SHOP` (PLAYER_SHOP_IN) packet declaring 40 items but only a few bytes of body → `BufferReader.readUInt32LE` throws `RangeError` → server exits.
- A private shop opened with an out-of-range `displayPos` (uint8, 0–255) grows the shop item array past the 40-slot grid; a later `ShopStartPacket.pack` writes past its fixed 1728-byte buffer, and the un-awaited owner refresh turns it into an unhandled rejection.

## Fix

- **GameServer / AuthServer**: wrap `unpack()` in try/catch and close the offending connection instead of letting the rejection escape the `data` listener.
- **MyShopPacket**: reject packets whose buffer is too short for the declared item count before reading past the end.
- **PrivateShopService**: reject out-of-range `displayPos`; `await openShopForOwner` so its rejection is handled.
- **ShopStartPacket**: clamp the write loop to the buffer capacity.

## Tested

- `npm run test:unit`: 391 passing.
- In game com o cliente TMP4.