### PR TITLE
fix: NPC shop buy price ignored stack count; partial sell destroyed the stack

### DIFF
--- a/src/core/domain/shop/ShopManager.ts
+++ b/src/core/domain/shop/ShopManager.ts
@@ -169,13 +169,24 @@ export default class ShopManager {
             return;
         }
 
-        const sellCount = Math.min(count, item.getCount() ?? 1);
+        // count 0 (or more than the stack) means "sell the whole stack",
+        // like the original server.
+        const stackCount = item.getCount() ?? 1;
+        const sellCount = count === 0 || count > stackCount ? stackCount : count;
         const sellPrice = Math.floor((item.getShopPrice() * sellCount) / 5);
 
-        // Remove item from inventory and notify client
-        player.getInventory().removeItem(pos, item.getSize());
-        player.sendItemRemoved({ window: WindowTypeEnum.INVENTORY, position: pos });
-        await this.itemManager.delete(item);
+        if (sellCount === stackCount) {
+            // Whole stack sold: remove the item entirely
+            player.getInventory().removeItem(pos, item.getSize());
+            player.sendItemRemoved({ window: WindowTypeEnum.INVENTORY, position: pos });
+            await this.itemManager.delete(item);
+        } else {
+            // Partial sale: split the stack instead of destroying it
+            item.setCount(stackCount - sellCount);
+            player.sendItemUpdate(item);
+            await this.itemManager.update(item);
+            await this.itemManager.flush(player.getId());
+        }
 
         player.addPoint(PointsEnum.GOLD, sellPrice);
 

--- a/src/core/interface/networking/packets/packet/in/shop/ShopPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/shop/ShopPacketHandler.ts
@@ -39,7 +39,9 @@ export default class ShopPacketHandler extends PacketHandler<ShopPacket> {
                 break;
 
             case ShopSubHeaderCG.SELL:
-                await this.shopManager.sell(player, packet.getPos(), 1);
+                // No count in the plain SELL sub-header: sell the whole stack
+                // (0 is normalized to the full count, like the original server).
+                await this.shopManager.sell(player, packet.getPos(), 0);
                 break;
 
             case ShopSubHeaderCG.SELL2:

--- a/src/game/app/service/ShopService.ts
+++ b/src/game/app/service/ShopService.ts
@@ -36,7 +36,10 @@ export default class ShopService {
                 shopItems.push({
                     vnum,
                     count,
-                    price: item.getShopPrice(),
+                    // Buy price is the proto gold value times the stack count
+                    // (original: shop.cpp uses item_table->dwGold * item.count);
+                    // shop_buy_price is only used when the player SELLS to the shop.
+                    price: item.getGold() * count,
                     item,
                     position: position ?? index,
                     size: item.getSize(),

--- a/test/unit/core/domain/manager/ShopManager.test.ts
+++ b/test/unit/core/domain/manager/ShopManager.test.ts
@@ -14,7 +14,7 @@ describe('ShopManager', () => {
     beforeEach(() => {
         loggerStub = sinon.createStubInstance(WinstonLoggerAdapter);
         itemManagerStub = sinon.createStubInstance(ItemManager);
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
         service = new ShopService({
             config: makeGameConfig(),
             logger: loggerStub,
@@ -32,7 +32,7 @@ describe('ShopManager', () => {
 
     it('should load shops from npc_shop.json', () => {
         // Mock itemManager.getItem to return valid items
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
 
         service.load();
 
@@ -43,7 +43,7 @@ describe('ShopManager', () => {
     });
 
     it('should return correct shop for valid NPC vnum', () => {
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
 
         service.load();
 
@@ -55,7 +55,7 @@ describe('ShopManager', () => {
     });
 
     it('should return undefined for invalid NPC vnum', () => {
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
 
         service.load();
 
@@ -64,7 +64,7 @@ describe('ShopManager', () => {
     });
 
     it('should indicate shop exists for loaded NPCs', () => {
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
 
         service.load();
 
@@ -73,7 +73,7 @@ describe('ShopManager', () => {
     });
 
     it('should load all expected shops', () => {
-        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 100, getGold: () => 100, getSize: () => 1 } as any);
 
         service.load();
 
@@ -84,7 +84,7 @@ describe('ShopManager', () => {
     });
 
     it('should load shop items correctly', () => {
-        itemManagerStub.getItem.returns({ getShopPrice: () => 500, getSize: () => 1 } as any);
+        itemManagerStub.getItem.returns({ getShopPrice: () => 500, getGold: () => 500, getSize: () => 1 } as any);
 
         service.load();
 


### PR DESCRIPTION
Two economy bugs in the NPC shop, verified in game with the TMP4 client.

## Buy price ignored the stack count (infinite gold)

The price of a shop entry was the per-unit `shop_buy_price` regardless of stack size, so a 200x potion stack sold for the price of a single unit — buying the stack and selling it back yielded a large profit, fully automatable. `shop_buy_price` is also the SELL-side field: the original uses the proto `gold` value for buying (`shop.cpp`: `item_table->dwGold * item.count`). The price is now `gold × count`.

## Selling part of a stack destroyed the whole stack

`sellCount` was only used for the price: the whole item was always removed and deleted, so selling 1 potion from a stack of 200 paid for one and destroyed all 200. Partial sales now split the stack (`setCount`), only a full sale removes the item, and the count-less `SELL` sub-header sells the whole stack (0 normalized to full count) like the original.

## Tested

- In game: buying a stack charges unit price × count; selling 1/2/5 units from a stack pays `shop_buy_price × count ÷ 5` and leaves the rest.
- `npm run test:unit`: 391 passing (mocks updated for `getGold`).