### PR TITLE
feat: stack items in the inventory and support stack splitting

### DIFF
--- a/src/core/domain/entities/game/inventory/Inventory.ts
+++ b/src/core/domain/entities/game/inventory/Inventory.ts
@@ -126,7 +126,7 @@ export default class Inventory {
 
         if (this.isFromEquipmentSlots(position)) {
             const unequippedItem = this.equipment.removeItem(position);
-            this.items.delete(item.getDbId()!);
+            this.deleteFromItemsMap(item);
             this.publish(
                 ItemUnequippedEvent.type,
                 new ItemUnequippedEvent({ item: unequippedItem!, slot: position - this.size() }),
@@ -137,7 +137,21 @@ export default class Inventory {
         const page = this.calcPage(position);
         const pagePosition = this.calcPagePosition(page, position);
         this.pages[page].removeItem(pagePosition, size);
-        this.items.delete(item.getDbId()!);
+        this.deleteFromItemsMap(item);
+    }
+
+    /**
+     * Removes the map entry for this exact item instance. Items bought from a
+     * shop are added to the map before their dbId is assigned (key undefined),
+     * so deleting by getDbId() would miss them and leave a ghost entry behind.
+     */
+    private deleteFromItemsMap(item: Item) {
+        for (const [key, mapped] of this.items) {
+            if (mapped === item) {
+                this.items.delete(key);
+                return;
+            }
+        }
     }
 
     haveAvailablePosition(position: number, size: number) {

--- a/src/core/domain/entities/game/item/Item.ts
+++ b/src/core/domain/entities/game/item/Item.ts
@@ -25,6 +25,9 @@ import { ItemExtractSubTypeEnum } from '@/core/enum/ItemExtractSubTypeEnum';
 import { ItemToolSubTypeEnum } from '@/core/enum/ItemToolSubTypeEnum';
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 
+/** Maximum number of units a single stackable item slot can hold. */
+export const MAX_ITEM_STACK = 200;
+
 const parseFlags = (flags: string, enumType: any) => {
     const bitFlag = new BitFlag();
     flags
@@ -426,6 +429,9 @@ export default class Item {
     }
     setCount(value: number) {
         this.count = value;
+    }
+    isStackable() {
+        return this.flags.is(ItemFlagEnum.ITEM_STACKABLE);
     }
     getOwnerId() {
         return this.ownerId;

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1335,6 +1335,9 @@ export default class Player extends Character {
                 if (existing === item) continue;
                 if (existing.getWindow() !== WindowTypeEnum.INVENTORY) continue;
                 if (existing.getId() !== item.getId() || !existing.isStackable()) continue;
+                // Only merge into items actually present in the grid — a stale
+                // map entry (ghost) would swallow the units into an empty slot.
+                if (this.inventory.getItem(existing.getPosition()) !== existing) continue;
 
                 const room = MAX_ITEM_STACK - existing.getCount();
                 if (room <= 0) continue;

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -8,7 +8,7 @@ import PlayerApplies from './delegate/PlayerApplies';
 import { EntityStateEnum } from '@/core/enum/EntityStateEnum';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
-import Item from '../item/Item';
+import Item, { MAX_ITEM_STACK } from '../item/Item';
 import DroppedItem from '../item/DroppedItem';
 import PlayerState from '../../state/player/PlayerState';
 import Character from '../Character';
@@ -1314,6 +1314,68 @@ export default class Player extends Character {
         this.sendItemAdded({ window: WindowTypeEnum.INVENTORY, position, item });
 
         return true;
+    }
+
+    /**
+     * Adds a (possibly stackable) item to the inventory, merging it into
+     * existing stacks of the same proto first (up to MAX_ITEM_STACK per slot)
+     * and placing any leftover in a free slot. The client is notified for both
+     * the merged stacks and the newly placed item.
+     *
+     * Returns the items whose count changed (need a DB update) and the leftover
+     * item that landed in a free slot (needs a DB insert), or null if nothing
+     * fit — in which case the inventory is left untouched.
+     */
+    addItemStacking(item: Item): { updated: Array<Item>; inserted: Item | null } | null {
+        const merges: Array<{ item: Item; amount: number }> = [];
+
+        if (item.isStackable()) {
+            for (const existing of this.inventory.getItems().values()) {
+                if (item.getCount() <= 0) break;
+                if (existing === item) continue;
+                if (existing.getWindow() !== WindowTypeEnum.INVENTORY) continue;
+                if (existing.getId() !== item.getId() || !existing.isStackable()) continue;
+
+                const room = MAX_ITEM_STACK - existing.getCount();
+                if (room <= 0) continue;
+
+                const moved = Math.min(room, item.getCount());
+                existing.setCount(existing.getCount() + moved);
+                item.setCount(item.getCount() - moved);
+                merges.push({ item: existing, amount: moved });
+            }
+        }
+
+        let inserted: Item | null = null;
+        if (item.getCount() > 0) {
+            const position = this.getInventory().addItem(item);
+            if (position < 0) {
+                // Leftover doesn't fit: revert the merges so no units are lost.
+                for (const merge of merges) {
+                    merge.item.setCount(merge.item.getCount() - merge.amount);
+                }
+                this.chat({
+                    messageType: ChatMessageTypeEnum.INFO,
+                    message: 'Inventory is full',
+                });
+                return null;
+            }
+            inserted = item;
+        }
+
+        const updated = merges.map((merge) => merge.item);
+        for (const existing of updated) {
+            this.sendItemUpdate(existing);
+        }
+        if (inserted) {
+            this.sendItemAdded({
+                window: WindowTypeEnum.INVENTORY,
+                position: inserted.getPosition(),
+                item: inserted,
+            });
+        }
+
+        return { updated, inserted };
     }
 
     addItems(items: Array<Item>) {

--- a/src/core/domain/shop/ShopManager.ts
+++ b/src/core/domain/shop/ShopManager.ts
@@ -135,13 +135,20 @@ export default class ShopManager {
             return;
         }
 
-        if (!player.addItem(item)) {
+        const added = player.addItemStacking(item);
+        if (!added) {
             player.sendShopResult({ result: ShopSubHeaderGC.INVENTORY_FULL });
             return;
         }
 
         player.addPoint(PointsEnum.GOLD, -price);
-        await this.itemManager.save(item);
+        for (const updated of added.updated) {
+            await this.itemManager.update(updated);
+        }
+        if (added.inserted) {
+            await this.itemManager.save(added.inserted);
+        }
+        await this.itemManager.flush(player.getId());
 
         player.sendShopResult({ result: ShopSubHeaderGC.OK });
 

--- a/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacketHandler.ts
@@ -38,6 +38,7 @@ export default class ItemMovePacketHandler extends PacketHandler<ItemMovePacket>
             fromPosition: packet.getFromPosition(),
             toWindow: packet.getToWindow(),
             toPosition: packet.getToPosition(),
+            count: packet.getCount(),
         });
     }
 }

--- a/src/game/app/service/MoveItemService.ts
+++ b/src/game/app/service/MoveItemService.ts
@@ -56,7 +56,6 @@ export default class MoveItemService {
         item,
     }: MoveItemServiceParams & { item: NonNullable<ReturnType<Player['getItem']>> }) {
         if (fromWindow !== WindowTypeEnum.INVENTORY || toWindow !== WindowTypeEnum.INVENTORY) return;
-        if (player.isItemLockedInPrivateShop(item)) return;
 
         const inventory = player.getInventory();
         if (!inventory.isValidPosition(toPosition)) return;
@@ -67,7 +66,6 @@ export default class MoveItemService {
         if (target) {
             // Merge the split units into a same-proto stack at the target slot
             if (target.getId() !== item.getId() || !target.isStackable()) return;
-            if (player.isItemLockedInPrivateShop(target)) return;
 
             const moved = Math.min(MAX_ITEM_STACK - target.getCount(), count);
             if (moved <= 0) return;

--- a/src/game/app/service/MoveItemService.ts
+++ b/src/game/app/service/MoveItemService.ts
@@ -1,6 +1,8 @@
 import Player from '@/core/domain/entities/game/player/Player';
+import { MAX_ITEM_STACK } from '@/core/domain/entities/game/item/Item';
 import ItemManager from '@/core/domain/manager/ItemManager';
 import Logger from '@/core/infra/logger/Logger';
+import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 
 type MoveItemServiceParams = {
     player: Player;
@@ -8,7 +10,7 @@ type MoveItemServiceParams = {
     fromPosition: number;
     toWindow: number;
     toPosition: number;
-    /*count*/
+    count: number;
 };
 
 export default class MoveItemService {
@@ -20,13 +22,81 @@ export default class MoveItemService {
         this.itemManager = itemManager;
     }
 
-    async execute({ player, fromWindow, fromPosition, toWindow, toPosition }: MoveItemServiceParams) {
-        this.logger.debug(`[MoveItemService] moving item from ${fromPosition} to ${toPosition}`);
+    async execute({ player, fromWindow, fromPosition, toWindow, toPosition, count }: MoveItemServiceParams) {
+        this.logger.debug(`[MoveItemService] moving item from ${fromPosition} to ${toPosition} (count: ${count})`);
 
-        const updatedItem = player.moveItem({ fromWindow, fromPosition, toWindow, toPosition });
+        const item = player.getItem(fromPosition);
+        if (!item) return;
 
-        if (updatedItem) {
-            await this.itemManager.update(updatedItem);
+        const stackCount = item.getCount() ?? 1;
+
+        // count 0 (or the whole stack, or a non stackable item) is a plain move.
+        // A smaller count on a stackable item is a split: the source stack is
+        // decreased and the units are placed (or merged) at the target slot,
+        // like the original server's CHARACTER::MoveItem.
+        if (count === 0 || count >= stackCount || !item.isStackable()) {
+            const updatedItem = player.moveItem({ fromWindow, fromPosition, toWindow, toPosition });
+
+            if (updatedItem) {
+                await this.itemManager.update(updatedItem);
+            }
+            return;
         }
+
+        await this.split({ player, fromWindow, fromPosition, toWindow, toPosition, count, item });
+    }
+
+    private async split({
+        player,
+        fromWindow,
+        fromPosition,
+        toWindow,
+        toPosition,
+        count,
+        item,
+    }: MoveItemServiceParams & { item: NonNullable<ReturnType<Player['getItem']>> }) {
+        if (fromWindow !== WindowTypeEnum.INVENTORY || toWindow !== WindowTypeEnum.INVENTORY) return;
+        if (player.isItemLockedInPrivateShop(item)) return;
+
+        const inventory = player.getInventory();
+        if (!inventory.isValidPosition(toPosition)) return;
+        if (inventory.isEquipmentPosition(toPosition)) return;
+
+        const target = player.getItem(toPosition);
+
+        if (target) {
+            // Merge the split units into a same-proto stack at the target slot
+            if (target.getId() !== item.getId() || !target.isStackable()) return;
+            if (player.isItemLockedInPrivateShop(target)) return;
+
+            const moved = Math.min(MAX_ITEM_STACK - target.getCount(), count);
+            if (moved <= 0) return;
+
+            target.setCount(target.getCount() + moved);
+            item.setCount(item.getCount() - moved);
+            player.sendItemUpdate(target);
+            player.sendItemUpdate(item);
+
+            await this.itemManager.update(target);
+            await this.itemManager.update(item);
+            await this.itemManager.flush(player.getId());
+            return;
+        }
+
+        // Place the split units as a new stack in the empty target slot
+        if (!inventory.haveAvailablePosition(toPosition, item.getSize())) return;
+
+        const newStack = this.itemManager.getItem(item.getId(), count);
+        if (!newStack) return;
+
+        inventory.addItemAt(newStack, toPosition);
+        item.setCount(item.getCount() - count);
+
+        player.sendItemAdded({ window: toWindow, position: toPosition, item: newStack });
+        player.sendItemUpdate(item);
+
+        await this.itemManager.save(newStack);
+        await this.itemManager.update(item);
+        await this.itemManager.flush(player.getId());
     }
 }

--- a/src/game/app/service/MoveItemService.ts
+++ b/src/game/app/service/MoveItemService.ts
@@ -43,18 +43,17 @@ export default class MoveItemService {
             return;
         }
 
-        await this.split({ player, fromWindow, fromPosition, toWindow, toPosition, count, item });
+        await this.split({ player, fromWindow, toWindow, toPosition, count, item });
     }
 
     private async split({
         player,
         fromWindow,
-        fromPosition,
         toWindow,
         toPosition,
         count,
         item,
-    }: MoveItemServiceParams & { item: NonNullable<ReturnType<Player['getItem']>> }) {
+    }: Omit<MoveItemServiceParams, 'fromPosition'> & { item: NonNullable<ReturnType<Player['getItem']>> }) {
         if (fromWindow !== WindowTypeEnum.INVENTORY || toWindow !== WindowTypeEnum.INVENTORY) return;
 
         const inventory = player.getInventory();

--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -45,9 +45,17 @@ export default class PickupItemService {
             return;
         }
 
-        if (player.addItem(item)) {
-            area.despawn(droppedItem);
-            await this.itemRepository.create(item.toDatabase());
+        const added = player.addItemStacking(item);
+        if (!added) return;
+
+        area.despawn(droppedItem);
+
+        for (const updated of added.updated) {
+            await this.itemRepository.update(updated.toDatabase());
+        }
+        if (added.inserted) {
+            const id = await this.itemRepository.create(added.inserted.toDatabase());
+            added.inserted.setDbId(id);
         }
     }
 }

--- a/test/unit/game/app/service/MoveItemService.test.ts
+++ b/test/unit/game/app/service/MoveItemService.test.ts
@@ -14,6 +14,9 @@ describe('MoveItemService', function () {
 
         itemManagerMock = {
             update: sinon.stub().resolves(),
+            save: sinon.stub().resolves(),
+            flush: sinon.stub().resolves(),
+            getItem: sinon.stub(),
         };
 
         moveItemService = new MoveItemService({
@@ -22,10 +25,21 @@ describe('MoveItemService', function () {
         });
     });
 
+    const makeItem = (overrides = {}) => ({
+        getId: sinon.stub().returns(27001),
+        getCount: sinon.stub().returns(10),
+        setCount: sinon.spy(),
+        getSize: sinon.stub().returns(1),
+        isStackable: sinon.stub().returns(true),
+        ...overrides,
+    });
+
     describe('execute', function () {
-        it('should log the move and update the item if moveItem returns an item', async function () {
+        it('should move the whole item and update it when count is 0', async function () {
+            const item = makeItem({ isStackable: sinon.stub().returns(false) });
             const updatedItem = { id: 1 };
             const playerMock = {
+                getItem: sinon.stub().returns(item),
                 moveItem: sinon.stub().returns(updatedItem),
             };
 
@@ -35,10 +49,8 @@ describe('MoveItemService', function () {
                 fromPosition: 2,
                 toWindow: 1,
                 toPosition: 3,
+                count: 0,
             });
-
-            expect(loggerMock.debug.calledOnce).to.be.true;
-            expect(loggerMock.debug.firstCall.args[0]).to.equal('[MoveItemService] moving item from 2 to 3');
 
             expect(playerMock.moveItem.calledOnce).to.be.true;
             expect(playerMock.moveItem.firstCall.args[0]).to.deep.equal({
@@ -52,8 +64,10 @@ describe('MoveItemService', function () {
             expect(itemManagerMock.update.firstCall.args[0]).to.equal(updatedItem);
         });
 
-        it('should log the move and not call update if moveItem returns undefined', async function () {
+        it('should not call update if moveItem returns undefined', async function () {
+            const item = makeItem();
             const playerMock = {
+                getItem: sinon.stub().returns(item),
                 moveItem: sinon.stub().returns(undefined),
             };
 
@@ -63,20 +77,80 @@ describe('MoveItemService', function () {
                 fromPosition: 2,
                 toWindow: 1,
                 toPosition: 3,
+                count: 10,
             });
 
-            expect(loggerMock.debug.calledOnce).to.be.true;
-            expect(loggerMock.debug.firstCall.args[0]).to.equal('[MoveItemService] moving item from 2 to 3');
-
             expect(playerMock.moveItem.calledOnce).to.be.true;
-            expect(playerMock.moveItem.firstCall.args[0]).to.deep.equal({
+            expect(itemManagerMock.update.notCalled).to.be.true;
+        });
+
+        it('should split a stack into an empty slot when count is smaller than the stack', async function () {
+            const item = makeItem();
+            const newStack = makeItem({ getCount: sinon.stub().returns(4) });
+            const inventoryMock = {
+                isValidPosition: sinon.stub().returns(true),
+                isEquipmentPosition: sinon.stub().returns(false),
+                haveAvailablePosition: sinon.stub().returns(true),
+                addItemAt: sinon.spy(),
+            };
+            const playerMock = {
+                getId: sinon.stub().returns(1),
+                getItem: sinon.stub(),
+                moveItem: sinon.stub(),
+                getInventory: sinon.stub().returns(inventoryMock),
+                sendItemAdded: sinon.spy(),
+                sendItemUpdate: sinon.spy(),
+            };
+            playerMock.getItem.withArgs(2).returns(item);
+            playerMock.getItem.withArgs(3).returns(undefined);
+            itemManagerMock.getItem.returns(newStack);
+
+            await moveItemService.execute({
+                player: playerMock,
                 fromWindow: 1,
                 fromPosition: 2,
                 toWindow: 1,
                 toPosition: 3,
+                count: 4,
             });
 
-            expect(itemManagerMock.update.notCalled).to.be.true;
+            expect(playerMock.moveItem.notCalled).to.be.true;
+            expect(inventoryMock.addItemAt.calledOnceWith(newStack, 3)).to.be.true;
+            expect(item.setCount.calledOnceWith(6)).to.be.true;
+            expect(itemManagerMock.save.calledOnceWith(newStack)).to.be.true;
+            expect(itemManagerMock.update.calledOnceWith(item)).to.be.true;
+        });
+
+        it('should merge a split into a same-proto stack at the target slot', async function () {
+            const item = makeItem();
+            const target = makeItem({ getCount: sinon.stub().returns(195) });
+            const inventoryMock = {
+                isValidPosition: sinon.stub().returns(true),
+                isEquipmentPosition: sinon.stub().returns(false),
+            };
+            const playerMock = {
+                getId: sinon.stub().returns(1),
+                getItem: sinon.stub(),
+                moveItem: sinon.stub(),
+                getInventory: sinon.stub().returns(inventoryMock),
+                sendItemUpdate: sinon.spy(),
+            };
+            playerMock.getItem.withArgs(2).returns(item);
+            playerMock.getItem.withArgs(3).returns(target);
+
+            await moveItemService.execute({
+                player: playerMock,
+                fromWindow: 1,
+                fromPosition: 2,
+                toWindow: 1,
+                toPosition: 3,
+                count: 8,
+            });
+
+            // Only 5 units fit (195 + 5 = 200 cap)
+            expect(target.setCount.calledOnceWith(200)).to.be.true;
+            expect(item.setCount.calledOnceWith(5)).to.be.true;
+            expect(itemManagerMock.update.calledTwice).to.be.true;
         });
     });
 });

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -49,15 +49,16 @@ describe('PickupItemService', function () {
         });
 
         it('should add item to the player and despawn the item if it is not gold and can be picked up', async function () {
-            const playerMock = {
-                getName: sinon.stub().returns('player1'),
-                addItem: sinon.stub().returns(true),
-                chat: sinon.spy(),
-                addPoint: sinon.spy(),
-            };
             const itemMock = {
                 getId: sinon.stub().returns(2),
                 toDatabase: sinon.stub().returns({}),
+                setDbId: sinon.spy(),
+            };
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: itemMock }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns(itemMock),
@@ -73,7 +74,7 @@ describe('PickupItemService', function () {
 
             await pickupItemService.execute(playerMock as unknown as Player, 1);
 
-            expect(playerMock.addItem.calledOnceWith(itemMock)).to.be.true;
+            expect(playerMock.addItemStacking.calledOnceWith(itemMock)).to.be.true;
             expect(areaMock.despawn.calledOnceWith(droppedItemMock)).to.be.true;
             expect(itemRepositoryMock.create.calledOnceWith({})).to.be.true;
         });

--- a/test/unit/game/app/service/ShopService.test.ts
+++ b/test/unit/game/app/service/ShopService.test.ts
@@ -20,7 +20,7 @@ describe('ShopService', () => {
     beforeEach(() => {
         loggerStub = sinon.createStubInstance(WinstonLoggerAdapter);
         shopManagerStub = { getShop: sinon.stub(), hasShop: sinon.stub() };
-        itemManagerStub = { getItem: sinon.stub(), save: sinon.stub().resolves(), delete: sinon.stub().resolves() };
+        itemManagerStub = { getItem: sinon.stub(), save: sinon.stub().resolves(), delete: sinon.stub().resolves(), update: sinon.stub().resolves(), flush: sinon.stub().resolves() };
 
         manager = new ShopManager({
             logger: loggerStub,
@@ -30,6 +30,7 @@ describe('ShopService', () => {
         });
 
         playerStub = {
+            getId: sinon.stub().returns(1),
             getName: sinon.stub().returns('TestPlayer'),
             setCurrentShop: sinon.stub(),
             getCurrentShop: sinon.stub(),
@@ -37,6 +38,7 @@ describe('ShopService', () => {
             getPoint: sinon.stub(),
             addPoint: sinon.stub(),
             addItem: sinon.stub(),
+            addItemStacking: sinon.stub(),
             getItem: sinon.stub(),
             getInventory: sinon.stub(),
             sendItemRemoved: sinon.stub(),
@@ -157,7 +159,7 @@ describe('ShopService', () => {
             playerStub.getCurrentShop.returns(shop);
             playerStub.getPoint.withArgs(PointsEnum.GOLD).returns(1000);
             itemManagerStub.getItem.returns(mockItem);
-            playerStub.addItem.returns(false);
+            playerStub.addItemStacking.returns(null);
 
             await manager.buy(playerStub, 0);
 
@@ -174,7 +176,7 @@ describe('ShopService', () => {
             playerStub.getCurrentShop.returns(shop);
             playerStub.getPoint.withArgs(PointsEnum.GOLD).returns(500);
             itemManagerStub.getItem.returns(mockItem);
-            playerStub.addItem.returns(true);
+            playerStub.addItemStacking.returns({ updated: [], inserted: mockItem });
 
             await manager.buy(playerStub, 0);
 

--- a/test/unit/game/app/service/ShopService.test.ts
+++ b/test/unit/game/app/service/ShopService.test.ts
@@ -20,7 +20,13 @@ describe('ShopService', () => {
     beforeEach(() => {
         loggerStub = sinon.createStubInstance(WinstonLoggerAdapter);
         shopManagerStub = { getShop: sinon.stub(), hasShop: sinon.stub() };
-        itemManagerStub = { getItem: sinon.stub(), save: sinon.stub().resolves(), delete: sinon.stub().resolves(), update: sinon.stub().resolves(), flush: sinon.stub().resolves() };
+        itemManagerStub = {
+            getItem: sinon.stub(),
+            save: sinon.stub().resolves(),
+            delete: sinon.stub().resolves(),
+            update: sinon.stub().resolves(),
+            flush: sinon.stub().resolves(),
+        };
 
         manager = new ShopManager({
             logger: loggerStub,


### PR DESCRIPTION
Stackable items (potions etc.) used one inventory slot per purchase/pickup — the inventory had no stack merging at all, and the split drag did nothing. Verified in game with the TMP4 client.

## Changes

- **Stacking**: `Player.addItemStacking` merges incoming stackable items into existing same-proto stacks (up to 200/slot, `MAX_ITEM_STACK`) and only uses a free slot for the leftover. Wired into the NPC shop buy and item pickup, with correct persistence (UPDATE for merged stacks, INSERT for the new one). If nothing fits, merges are rolled back so no units are lost.
- **Splitting**: the client sends the drag count in `CG_ITEM_MOVE`, but the handler dropped it. A count smaller than the stack now splits like the original `CHARACTER::MoveItem`: source stack decreased, units merged into a same-proto stack at the target (cap 200) or placed as a new stack.
- **Ghost-entry fix**: the inventory item map is keyed by dbId, but shop-bought items enter it before the dbId is assigned (key `undefined`); removals by dbId missed them, leaving ghost entries that swallowed later purchases. Removal is now by instance identity, and the merge loop only targets items actually present in the grid.

## Note

If this lands together with the private-shop item-dupe PR, the split path should also skip items listed in an open private shop — happy to add that follow-up guard once both are in.

## Tested

- In game: buys merge into stacks, splits of 5/10/50 units work to empty slots and onto existing stacks, counts persist across relog.
- `npm run test:unit`: 393 passing (new split/merge tests included).