### PR TITLE
fix: opening a private shop duplicated the bundle stack in the DB

### DIFF
--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -345,7 +345,10 @@ export default class PrivateShopService {
         if (bundle.getCount() > 1) {
             bundle.decreaseCount(1);
             player.sendItemUpdate(bundle);
-            await this.itemManager.save(bundle);
+            // update, not save: save() INSERTs a new row and reassigns the dbId,
+            // duplicating the bundle stack in the DB on every shop open.
+            await this.itemManager.update(bundle);
+            await this.itemManager.flush(player.getId());
         } else {
             const position = bundle.getPosition();
             player.getInventory().removeItem(position, bundle.getSize());

--- a/test/unit/game/app/service/PrivateShopService.test.ts
+++ b/test/unit/game/app/service/PrivateShopService.test.ts
@@ -27,6 +27,7 @@ const makeInventory = (items: Map<number, any> = new Map()) => ({
 });
 
 const makePlayer = (overrides: Partial<any> = {}): any => ({
+    getId: sinon.stub().returns(1),
     getName: sinon.stub().returns('TestPlayer'),
     getVirtualId: sinon.stub().returns(1),
     isRunningPrivateShop: sinon.stub().returns(false),
@@ -68,6 +69,7 @@ describe('PrivateShopService', () => {
             save: sinon.stub().resolves(),
             delete: sinon.stub().resolves(),
             update: sinon.stub().resolves(),
+            flush: sinon.stub().resolves(),
         };
         const saveCharacterServiceStub = { execute: sinon.stub().resolves() } as any;
         service = new PrivateShopService({
@@ -244,7 +246,9 @@ describe('PrivateShopService', () => {
 
             expect(bundle.decreaseCount.calledWith(1)).to.be.true;
             expect(player.sendItemUpdate.calledOnceWith(bundle)).to.be.true;
-            expect(itemManagerStub.save.calledOnceWith(bundle)).to.be.true;
+            // update, not save: save() would INSERT a new row and duplicate the stack
+            expect(itemManagerStub.update.calledOnceWith(bundle)).to.be.true;
+            expect(itemManagerStub.save.called).to.be.false;
             expect(itemManagerStub.delete.called).to.be.false;
             expect(inventory.removeItem.called).to.be.false;
         });


### PR DESCRIPTION
`consumeBundle` called `itemManager.save()` for bundle stacks with count > 1. `save()` INSERTs a new row and reassigns the dbId — the original row was never decremented, so every shop open left an extra bundle stack behind after relog (bundles also NPC-sell for gold, so this is farmable).

The decrement is now persisted with `update` + `flush` instead.

## Tested

- `npm run test:unit`: 391 passing (test updated to assert update-not-save).