### PR TITLE
fix: private shop item duplication via same-vnum swap

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1279,6 +1279,7 @@ export default class Player extends Character {
         const item = this.getItem(fromPosition);
 
         if (!item) return;
+        if (this.isItemLockedInPrivateShop(item)) return;
         if (fromWindow !== WindowTypeEnum.INVENTORY || toWindow !== WindowTypeEnum.INVENTORY) return;
         if (!this.getInventory().isValidPosition(toPosition)) return;
         if (!this.getInventory().haveAvailablePosition(toPosition, item.getSize())) return;
@@ -1628,6 +1629,15 @@ export default class Player extends Character {
 
     isRunningPrivateShop(): boolean {
         return this.privateShop !== null;
+    }
+
+    /**
+     * Whether this exact item instance is listed in the player's open private
+     * shop. Listed items are locked against move/use/drop/sell so the owner
+     * can't swap them around while a guest buys the slot (duplication exploit).
+     */
+    isItemLockedInPrivateShop(item: Item): boolean {
+        return this.privateShop?.hasItemListed(item) ?? false;
     }
 
     /** Records the current timestamp as the moment the player's private shop was closed. */

--- a/src/core/domain/shop/PrivateShop.ts
+++ b/src/core/domain/shop/PrivateShop.ts
@@ -63,6 +63,18 @@ export default class PrivateShop {
     }
 
     /**
+     * Whether this exact item instance is listed for sale. Listed items are
+     * locked: the owner must not move/use/drop/sell them while the shop is
+     * open, or a same-vnum swap could dupe the sold item.
+     */
+    hasItemListed(item: Item): boolean {
+        for (const entry of this.items.values()) {
+            if (entry.item === item) return true;
+        }
+        return false;
+    }
+
+    /**
      * Removes an item from the shop after it has been sold.
      * Returns true when the slot was occupied.
      */

--- a/src/core/domain/shop/ShopManager.ts
+++ b/src/core/domain/shop/ShopManager.ts
@@ -176,6 +176,12 @@ export default class ShopManager {
             return;
         }
 
+        // Cannot sell items listed in the player's own open private shop
+        if (player.isItemLockedInPrivateShop(item)) {
+            player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            return;
+        }
+
         // count 0 (or more than the stack) means "sell the whole stack",
         // like the original server.
         const stackCount = item.getCount() ?? 1;

--- a/src/game/app/service/DropItemService.ts
+++ b/src/game/app/service/DropItemService.ts
@@ -30,6 +30,7 @@ export default class DropItemService {
         const item = player.getInventory().getItem(position);
 
         if (!item) return;
+        if (player.isItemLockedInPrivateShop(item)) return;
 
         if (count === item.getCount()) {
             player.getInventory().removeItem(position, item.getSize());

--- a/src/game/app/service/MoveItemService.ts
+++ b/src/game/app/service/MoveItemService.ts
@@ -55,6 +55,8 @@ export default class MoveItemService {
         item,
     }: Omit<MoveItemServiceParams, 'fromPosition'> & { item: NonNullable<ReturnType<Player['getItem']>> }) {
         if (fromWindow !== WindowTypeEnum.INVENTORY || toWindow !== WindowTypeEnum.INVENTORY) return;
+        // Items listed in the player's open private shop are locked
+        if (player.isItemLockedInPrivateShop(item)) return;
 
         const inventory = player.getInventory();
         if (!inventory.isValidPosition(toPosition)) return;
@@ -65,6 +67,7 @@ export default class MoveItemService {
         if (target) {
             // Merge the split units into a same-proto stack at the target slot
             if (target.getId() !== item.getId() || !target.isStackable()) return;
+            if (player.isItemLockedInPrivateShop(target)) return;
 
             const moved = Math.min(MAX_ITEM_STACK - target.getCount(), count);
             if (moved <= 0) return;

--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -283,9 +283,13 @@ export default class PrivateShopService {
 
         const item = entry.item;
 
-        // Verify the item is still in the owner's inventory at the expected slot
+        // Verify the exact listed item instance is still in the owner's
+        // inventory at the expected slot. Comparing by vnum here would let the
+        // owner swap another same-vnum item into the slot (moving the listed
+        // one elsewhere) and end up with both the sold item and a ghost copy —
+        // a duplication exploit.
         const ownerItem = owner.getItem(entry.inventoryPos);
-        if (ownerItem?.getId() !== item.getId()) {
+        if (ownerItem !== item) {
             shop.removeItemAtDisplaySlot(displaySlot);
             guest.sendShopResult({ result: ShopSubHeaderGC.SOLD_OUT });
             return;

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -36,6 +36,7 @@ export default class UseItemService {
         const item = player.getItem(position);
 
         if (!item) return;
+        if (player.isItemLockedInPrivateShop(item)) return;
 
         if (player.isWearable(item)) {
             await this.useWearableItem(player, item, position, window);

--- a/test/unit/game/app/service/DropItemService.test.ts
+++ b/test/unit/game/app/service/DropItemService.test.ts
@@ -32,7 +32,7 @@ describe('DropItemService', function () {
                 dropItem: sinon.spy(),
                 chat: sinon.spy(),
                 getName: sinon.stub().returns('TestPlayer'),
-            isItemLockedInPrivateShop: sinon.stub().returns(false),
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 addPoint: sinon.spy(),
             };
 
@@ -55,7 +55,7 @@ describe('DropItemService', function () {
                 dropItem: sinon.spy(),
                 chat: sinon.spy(),
                 getName: sinon.stub().returns('TestPlayer'),
-            isItemLockedInPrivateShop: sinon.stub().returns(false),
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 addPoint: sinon.spy(),
             };
 

--- a/test/unit/game/app/service/DropItemService.test.ts
+++ b/test/unit/game/app/service/DropItemService.test.ts
@@ -32,6 +32,7 @@ describe('DropItemService', function () {
                 dropItem: sinon.spy(),
                 chat: sinon.spy(),
                 getName: sinon.stub().returns('TestPlayer'),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
                 addPoint: sinon.spy(),
             };
 
@@ -54,6 +55,7 @@ describe('DropItemService', function () {
                 dropItem: sinon.spy(),
                 chat: sinon.spy(),
                 getName: sinon.stub().returns('TestPlayer'),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
                 addPoint: sinon.spy(),
             };
 
@@ -82,6 +84,7 @@ describe('DropItemService', function () {
             };
 
             const playerMock = {
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 getInventory: sinon.stub().returns({
                     getItem: sinon.stub().returns(itemMock),
                     removeItem: sinon.spy(),
@@ -113,6 +116,7 @@ describe('DropItemService', function () {
             };
 
             const playerMock = {
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 getInventory: sinon.stub().returns({
                     getItem: sinon.stub().returns(itemMock),
                 }),
@@ -136,6 +140,7 @@ describe('DropItemService', function () {
 
         it('should do nothing if item is not found', async function () {
             const playerMock = {
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 getInventory: sinon.stub().returns({
                     getItem: sinon.stub().returns(undefined),
                 }),

--- a/test/unit/game/app/service/MoveItemService.test.ts
+++ b/test/unit/game/app/service/MoveItemService.test.ts
@@ -95,6 +95,7 @@ describe('MoveItemService', function () {
             };
             const playerMock = {
                 getId: sinon.stub().returns(1),
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 getItem: sinon.stub(),
                 moveItem: sinon.stub(),
                 getInventory: sinon.stub().returns(inventoryMock),
@@ -130,6 +131,7 @@ describe('MoveItemService', function () {
             };
             const playerMock = {
                 getId: sinon.stub().returns(1),
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
                 getItem: sinon.stub(),
                 moveItem: sinon.stub(),
                 getInventory: sinon.stub().returns(inventoryMock),

--- a/test/unit/game/app/service/PrivateShopService.test.ts
+++ b/test/unit/game/app/service/PrivateShopService.test.ts
@@ -29,7 +29,7 @@ const makeInventory = (items: Map<number, any> = new Map()) => ({
 const makePlayer = (overrides: Partial<any> = {}): any => ({
     getId: sinon.stub().returns(1),
     getName: sinon.stub().returns('TestPlayer'),
-            isItemLockedInPrivateShop: sinon.stub().returns(false),
+    isItemLockedInPrivateShop: sinon.stub().returns(false),
     getVirtualId: sinon.stub().returns(1),
     isRunningPrivateShop: sinon.stub().returns(false),
     getPrivateShop: sinon.stub().returns(null),

--- a/test/unit/game/app/service/PrivateShopService.test.ts
+++ b/test/unit/game/app/service/PrivateShopService.test.ts
@@ -29,6 +29,7 @@ const makeInventory = (items: Map<number, any> = new Map()) => ({
 const makePlayer = (overrides: Partial<any> = {}): any => ({
     getId: sinon.stub().returns(1),
     getName: sinon.stub().returns('TestPlayer'),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
     getVirtualId: sinon.stub().returns(1),
     isRunningPrivateShop: sinon.stub().returns(false),
     getPrivateShop: sinon.stub().returns(null),

--- a/test/unit/game/app/service/ShopService.test.ts
+++ b/test/unit/game/app/service/ShopService.test.ts
@@ -38,6 +38,7 @@ describe('ShopService', () => {
         playerStub = {
             getId: sinon.stub().returns(1),
             getName: sinon.stub().returns('TestPlayer'),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
             setCurrentShop: sinon.stub(),
             getCurrentShop: sinon.stub(),
             getCurrentPrivateShopOwner: sinon.stub().returns(null),

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -19,6 +19,7 @@ describe('UseItemService', () => {
         service = new UseItemService({ logger: loggerStub, itemManager: itemManagerStub, mobManager: mobManagerStub });
         playerStub = {
             getItem: sinon.stub(),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
             getInventory: sinon.stub(),
             sendItemRemoved: sinon.stub(),
             sendItemAdded: sinon.stub(),


### PR DESCRIPTION
The private-shop buy path verified the listed item by **vnum** (`getId`), not by instance, and listed items were not locked while the shop was open.

## Exploit

The owner lists item A, opens the shop, moves A elsewhere and places another same-vnum item B into the listed inventory slot. An accomplice buys the slot: the guest receives object A (row reassigned), item B is removed from the in-memory inventory only (its row untouched — returns on relog), and A's ghost copy still sits in the owner's grid, droppable and re-pickupable as a brand-new DB row — a hard item dupe.

## Fix

- `buy`: compare the exact item instance at the listed inventory position (`ownerItem !== item` → SOLD_OUT).
- Lock listed items while the shop is open: `PrivateShop.hasItemListed` (instance identity) + `Player.isItemLockedInPrivateShop`, guarded in `moveItem`, `UseItemService`, `DropItemService` and NPC `sell`.

## Tested

- `npm run test:unit`: 391 passing.