### PR TITLE
test: fix master CI — stub stopKeepalive on GameServer connection mocks

### DIFF
--- a/test/unit/game/interface/server/GameServer.test.ts
+++ b/test/unit/game/interface/server/GameServer.test.ts
@@ -18,6 +18,7 @@ const createConnection = (player: unknown) =>
     ({
         getId: () => 'connection-id',
         getPlayer: () => player,
+        stopKeepalive: sinon.stub(),
     }) as any;
 
 describe('GameServer', () => {


### PR DESCRIPTION
Master's build is currently red on the merge of #19 + #20: #19 made `Server.onClose` call `connection.stopKeepalive()`, and #20 added `GameServer.onClose` tests whose connection mocks predate it; each PR's CI ran before the other was merged, so the combination only failed after both landed.

One-line fix: stub `stopKeepalive` on the test connection mocks.

- `npm run test:unit`: 401 passing on top of current master.

Sorry for the breakage — both PRs were mine.