### PR TITLE
fix: private shop hardening — disconnect cleanup, state collision, gold cap, bundle, equipped items, distance

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -118,6 +118,7 @@ export default class Player extends Character {
     private currentQuest: AbstractQuest | null = null;
 
     private currentShop: Shop | null = null;
+    private currentShopNpc: Mob | null = null;
     private privateShop: PrivateShop | null = null;
     private currentPrivateShopOwner: Player | null = null;
 
@@ -1617,6 +1618,16 @@ export default class Player extends Character {
 
     setCurrentShop(shop: Shop | null) {
         this.currentShop = shop;
+        if (!shop) this.currentShopNpc = null;
+    }
+
+    /** The NPC entity whose shop is open, used for distance checks on buy/sell. */
+    getCurrentShopNpc(): Mob | null {
+        return this.currentShopNpc;
+    }
+
+    setCurrentShopNpc(npc: Mob | null) {
+        this.currentShopNpc = npc;
     }
 
     getPrivateShop(): PrivateShop | null {

--- a/src/core/domain/shop/ShopManager.ts
+++ b/src/core/domain/shop/ShopManager.ts
@@ -9,6 +9,10 @@ import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 import PrivateShopService from '../../../game/app/service/PrivateShopService';
 import GameEntity from '@/core/domain/entities/game/GameEntity';
 import NPC from '../entities/game/mob/NPC';
+import MathUtil from '@/core/domain/util/MathUtil';
+
+/** Maximum distance (map units) between player and shop owner for shop interactions. */
+const SHOP_MAX_DISTANCE = 2000;
 
 export default class ShopManager {
     private readonly shopService: ShopService;
@@ -49,10 +53,22 @@ export default class ShopManager {
             return;
         }
 
-        //TODO: validate if player can open the shop (distance, isExchanging, HasShopOpened, etc)
-        //TODO: verify player distance to npc
+        // Leave any private shop being browsed first — buy() checks the
+        // private-shop state before the NPC shop, so a stale owner reference
+        // would route NPC-shop purchases to the private shop's display slots.
+        const privateOwner = player.getCurrentPrivateShopOwner();
+        if (privateOwner) {
+            privateOwner.getPrivateShop()?.removeGuest(player);
+            player.setCurrentPrivateShopOwner(null);
+        }
+
+        if (!this.isNearShopOwner(player, npc)) {
+            this.logger.debug(`[ShopManager] ${player.getName()} is too far from NPC ${npc.getId()} to open the shop`);
+            return;
+        }
 
         player.setCurrentShop(shop);
+        player.setCurrentShopNpc(npc);
 
         player.sendCurrentShop({
             ownerVid: npc.getVirtualId(),
@@ -80,6 +96,28 @@ export default class ShopManager {
             );
             await this.privateShopService.openShopForGuest(player, targetPlayer);
         }
+    }
+
+    private isNearShopOwner(player: Player, owner: GameEntity) {
+        return (
+            MathUtil.calcDistance(
+                player.getPositionX(),
+                player.getPositionY(),
+                owner.getPositionX(),
+                owner.getPositionY(),
+            ) <= SHOP_MAX_DISTANCE
+        );
+    }
+
+    /**
+     * Buy/sell keep working after walking away without this: the shop state
+     * stays open on the player until an explicit close. The original refuses
+     * transactions beyond 2000 units from the shop owner.
+     */
+    private isNearCurrentShopNpc(player: Player) {
+        const npc = player.getCurrentShopNpc();
+        if (!npc) return true;
+        return this.isNearShopOwner(player, npc);
     }
 
     async closeShop(player: Player) {
@@ -111,6 +149,11 @@ export default class ShopManager {
         const shop = player.getCurrentShop();
         if (!shop) {
             this.logger.debug(`[ShopManager] buy: player ${player.getName()} has no open shop`);
+            return;
+        }
+
+        if (!this.isNearCurrentShopNpc(player)) {
+            player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
             return;
         }
 
@@ -164,8 +207,19 @@ export default class ShopManager {
             return;
         }
 
+        if (!this.isNearCurrentShopNpc(player)) {
+            player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            return;
+        }
+
         const item = player.getItem(pos);
         if (!item) {
+            player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            return;
+        }
+
+        // Cannot sell equipped items (original rejects IsEquipped)
+        if (player.getInventory().isFromEquipmentSlots(pos)) {
             player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
             return;
         }
@@ -187,6 +241,13 @@ export default class ShopManager {
         const stackCount = item.getCount() ?? 1;
         const sellCount = count === 0 || count > stackCount ? stackCount : count;
         const sellPrice = Math.floor((item.getShopPrice() * sellCount) / 5);
+
+        // Refuse the sale when the gold would overflow the cap — the clamp
+        // would silently destroy the excess (the original refuses at GOLD_MAX).
+        if (player.getPoint(PointsEnum.GOLD) + sellPrice > MathUtil.MAX_UINT) {
+            player.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            return;
+        }
 
         if (sellCount === stackCount) {
             // Whole stack sold: remove the item entirely

--- a/src/core/interface/networking/packets/packet/in/deleteCharacter/DeleteCharacterPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/deleteCharacter/DeleteCharacterPacketHandler.ts
@@ -10,7 +10,13 @@ export default class DeleteCharacterPacketHandler extends PacketHandler<DeleteCh
     private readonly deleteCharacterService: DeleteCharacterService;
     private readonly logger: Logger;
 
-    constructor({ deleteCharacterService, logger }: { deleteCharacterService: DeleteCharacterService; logger: Logger }) {
+    constructor({
+        deleteCharacterService,
+        logger,
+    }: {
+        deleteCharacterService: DeleteCharacterService;
+        logger: Logger;
+    }) {
         super();
         this.deleteCharacterService = deleteCharacterService;
         this.logger = logger;

--- a/src/game/app/service/DeleteCharacterService.ts
+++ b/src/game/app/service/DeleteCharacterService.ts
@@ -29,7 +29,11 @@ export default class DeleteCharacterService {
         this.accountRepository = accountRepository;
     }
 
-    async execute({ accountId, slot, privateCode }: DeleteCharacterServiceParams): Promise<Result<void, ErrorTypesEnum>> {
+    async execute({
+        accountId,
+        slot,
+        privateCode,
+    }: DeleteCharacterServiceParams): Promise<Result<void, ErrorTypesEnum>> {
         const deleteCode = await this.accountRepository.getDeleteCodeById(accountId);
 
         if (!deleteCode || deleteCode !== privateCode) {

--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -49,11 +49,14 @@ export default class PrivateShopService {
             return;
         }
 
-        if (player.getCurrentShop()) {
-            this.logger.debug(
-                `[PrivateShopService] ${player.getName()} tried to open a shop while browsing an NPC shop`,
-            );
-            return;
+        // Leave any NPC shop or browsed private shop first instead of refusing:
+        // the client may close the shop window without sending SHOP_END (e.g.
+        // after buying the bundle), leaving stale browsing state behind.
+        player.setCurrentShop(null);
+        const browsedOwner = player.getCurrentPrivateShopOwner();
+        if (browsedOwner) {
+            browsedOwner.getPrivateShop()?.removeGuest(player);
+            player.setCurrentPrivateShopOwner(null);
         }
 
         // A shop needs a Bundle item — the original refuses to open without one.

--- a/src/game/app/service/PrivateShopService.ts
+++ b/src/game/app/service/PrivateShopService.ts
@@ -8,9 +8,16 @@ import PrivateShop, { PrivateShopItem, PRIVATE_SHOP_MAX_ITEMS } from '@/core/dom
 import { MyShopItemEntry } from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
 import ItemManager from '@/core/domain/manager/ItemManager';
 import SaveCharacterService from '@/game/domain/service/SaveCharacterService';
+import MathUtil from '@/core/domain/util/MathUtil';
 
 /** Maximum gold price a seller can set per item. */
 const MAX_ITEM_PRICE = 2_000_000_000;
+
+/** Vnum of the Bundle item required to open a private shop. */
+const BUNDLE_VNUM = 50200;
+
+/** Maximum distance (map units) between guest and owner for shop interactions. */
+const SHOP_MAX_DISTANCE = 2000;
 
 export default class PrivateShopService {
     private readonly itemManager: ItemManager;
@@ -46,6 +53,12 @@ export default class PrivateShopService {
             this.logger.debug(
                 `[PrivateShopService] ${player.getName()} tried to open a shop while browsing an NPC shop`,
             );
+            return;
+        }
+
+        // A shop needs a Bundle item — the original refuses to open without one.
+        if (!this.findBundle(player)) {
+            this.logger.debug(`[PrivateShopService] ${player.getName()} tried to open a shop without a Bundle`);
             return;
         }
 
@@ -105,6 +118,14 @@ export default class PrivateShopService {
 
         if (seenCellIndex.has(entry.cellIndex)) {
             this.logger.debug(`[PrivateShopService] openPrivateShop: duplicate cellIndex ${entry.cellIndex}, skipping`);
+            return null;
+        }
+
+        // Equipped items cannot be listed (original rejects IsEquipped)
+        if (player.getInventory().isFromEquipmentSlots(entry.cellIndex)) {
+            this.logger.debug(
+                `[PrivateShopService] openPrivateShop: slot ${entry.cellIndex} is an equipment slot, skipping`,
+            );
             return null;
         }
 
@@ -269,6 +290,19 @@ export default class PrivateShopService {
             return;
         }
 
+        // The original refuses transactions beyond 2000 units from the owner
+        if (
+            MathUtil.calcDistance(
+                guest.getPositionX(),
+                guest.getPositionY(),
+                owner.getPositionX(),
+                owner.getPositionY(),
+            ) > SHOP_MAX_DISTANCE
+        ) {
+            guest.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            return;
+        }
+
         const entry = shop.getItemAtDisplaySlot(displaySlot);
         if (!entry) {
             guest.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
@@ -278,6 +312,15 @@ export default class PrivateShopService {
         const price = entry.price;
         if (guest.getPoint(PointsEnum.GOLD) < price) {
             guest.sendShopResult({ result: ShopSubHeaderGC.NOT_ENOUGH_MONEY });
+            return;
+        }
+
+        // Refuse the sale when the owner's gold would overflow the cap — the
+        // gold clamp would silently destroy the excess while the buyer pays
+        // full price (the original refuses at GOLD_MAX the same way).
+        if (owner.getPoint(PointsEnum.GOLD) + price > MathUtil.MAX_UINT) {
+            guest.sendShopResult({ result: ShopSubHeaderGC.INVALID_POS });
+            this.logger.debug(`[PrivateShopService] sale refused: owner ${owner.getName()} gold would exceed the cap`);
             return;
         }
 
@@ -364,11 +407,12 @@ export default class PrivateShopService {
     }
 
     /** Consumes one Bundle (vnum 50200) from the player's inventory. Decrements the stack; deletes if last. */
+    private findBundle(player: Player) {
+        return Array.from(player.getInventory().getItems().values()).find((item) => item?.getId() === BUNDLE_VNUM);
+    }
+
     private async consumeBundle(player: Player) {
-        const BUNDLE_VNUM = 50200;
-        const bundle = Array.from(player.getInventory().getItems().values()).find(
-            (item) => item?.getId() === BUNDLE_VNUM,
-        );
+        const bundle = this.findBundle(player);
 
         if (!bundle) return;
 

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -162,9 +162,6 @@ export default class UseItemService {
                 }
                 break;
 
-            case ItemUseSubTypeEnum.USE_SPECIAL:
-                return this.useSpecialItem(player, item);
-
             default:
                 this.logger.info(
                     `[UseItemService] unhandled item use - vnum: ${item.getId()}, type: ${item.getType()}, subType: ${item.getSubType()}, player: ${player.getName()}`,

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -142,6 +142,9 @@ export default class UseItemService {
 
     private async useItemUsable(player: Player, item: Item) {
         switch (item.getSubType()) {
+            case ItemUseSubTypeEnum.USE_SPECIAL:
+                return this.useSpecialItem(player, item);
+
             case ItemUseSubTypeEnum.USE_POTION:
                 {
                     if (item.getCount() <= 0) {

--- a/src/game/domain/service/LeaveGameService.ts
+++ b/src/game/domain/service/LeaveGameService.ts
@@ -1,14 +1,30 @@
 import Player from '@/core/domain/entities/game/player/Player';
 import World from '@/core/domain/World';
+import PrivateShopService from '@/game/app/service/PrivateShopService';
 
 export default class LeaveGameService {
     private readonly world: World;
+    private readonly privateShopService: PrivateShopService;
 
-    constructor({ world }: { world: World }) {
+    constructor({ world, privateShopService }: { world: World; privateShopService: PrivateShopService }) {
         this.world = world;
+        this.privateShopService = privateShopService;
     }
 
     async execute(player: Player) {
+        // Close the player's own private shop: without this, guests keep
+        // buying from the offline owner's stale in-memory inventory, and a
+        // relog creates a second live copy of every item (duplication).
+        await this.privateShopService.closePrivateShop(player);
+
+        // Leave any private shop the player was browsing so the owner's
+        // guest list doesn't accumulate dead connections.
+        const browsedOwner = player.getCurrentPrivateShopOwner();
+        if (browsedOwner) {
+            browsedOwner.getPrivateShop()?.removeGuest(player);
+            player.setCurrentPrivateShopOwner(null);
+        }
+
         this.world.despawn(player);
     }
 }

--- a/src/game/infra/database/PlayerRepository.ts
+++ b/src/game/infra/database/PlayerRepository.ts
@@ -202,10 +202,9 @@ export default class PlayerRepository implements IPlayerRepository {
     async getByAccountIdAndSlot(accountId: number, slot: number): Promise<PlayerState | null> {
         const [players] = await this.databaseManager
             .getConnection()
-            .query<PlayerRow[]>(`SELECT * FROM game.player WHERE accountId = ? and slot = ? AND deletedAt IS NULL;`, [
-                accountId,
-                slot,
-            ]);
+            .query<
+                PlayerRow[]
+            >(`SELECT * FROM game.player WHERE accountId = ? and slot = ? AND deletedAt IS NULL;`, [accountId, slot]);
 
         if (players.length === 0) {
             return null;

--- a/test/unit/game/app/service/PrivateShopService.test.ts
+++ b/test/unit/game/app/service/PrivateShopService.test.ts
@@ -20,7 +20,10 @@ const makeItem = (overrides: Partial<any> = {}) => ({
     ...overrides,
 });
 
-const makeInventory = (items: Map<number, any> = new Map()) => ({
+const makeBundle = () => makeItem({ getId: sinon.stub().returns(50200), getCount: sinon.stub().returns(1) });
+
+const makeInventory = (items: Map<number, any> = new Map([[99, makeBundle()]])) => ({
+    isFromEquipmentSlots: sinon.stub().returns(false),
     getItems: sinon.stub().returns(items),
     removeItem: sinon.stub(),
     addItemAt: sinon.stub(),
@@ -31,6 +34,8 @@ const makePlayer = (overrides: Partial<any> = {}): any => ({
     getName: sinon.stub().returns('TestPlayer'),
     isItemLockedInPrivateShop: sinon.stub().returns(false),
     getVirtualId: sinon.stub().returns(1),
+    getPositionX: sinon.stub().returns(0),
+    getPositionY: sinon.stub().returns(0),
     isRunningPrivateShop: sinon.stub().returns(false),
     getPrivateShop: sinon.stub().returns(null),
     setPrivateShop: sinon.stub(),

--- a/test/unit/game/app/service/ShopService.test.ts
+++ b/test/unit/game/app/service/ShopService.test.ts
@@ -38,6 +38,10 @@ describe('ShopService', () => {
         playerStub = {
             getId: sinon.stub().returns(1),
             getName: sinon.stub().returns('TestPlayer'),
+            getCurrentShopNpc: sinon.stub().returns(null),
+            setCurrentShopNpc: sinon.stub(),
+            getPositionX: sinon.stub().returns(0),
+            getPositionY: sinon.stub().returns(0),
             isItemLockedInPrivateShop: sinon.stub().returns(false),
             setCurrentShop: sinon.stub(),
             getCurrentShop: sinon.stub(),
@@ -47,7 +51,9 @@ describe('ShopService', () => {
             addItem: sinon.stub(),
             addItemStacking: sinon.stub(),
             getItem: sinon.stub(),
-            getInventory: sinon.stub(),
+            getInventory: sinon
+                .stub()
+                .returns({ isFromEquipmentSlots: sinon.stub().returns(false), removeItem: sinon.stub() }),
             sendItemRemoved: sinon.stub(),
             sendCurrentShop: sinon.stub(),
             sendShopClose: sinon.stub(),
@@ -56,6 +62,8 @@ describe('ShopService', () => {
 
         npcStub = sinon.createStubInstance(NPC);
         npcStub.getId.returns(9001);
+        npcStub.getPositionX.returns(0);
+        npcStub.getPositionY.returns(0);
         npcStub.getVirtualId.returns(1);
         npcStub.getEntityType.returns(EntityTypeEnum.NPC);
         npcStub.isNPC.returns(true);
@@ -231,7 +239,7 @@ describe('ShopService', () => {
 
         it('should calculate sell price as floor(shop_price * count / 5)', async () => {
             const shop = new Shop({ npcVnum: 9001, shopName: 'Arms', items: [] });
-            const inventoryStub = { removeItem: sinon.stub() };
+            const inventoryStub = { removeItem: sinon.stub(), isFromEquipmentSlots: sinon.stub().returns(false) };
             const mockItem = {
                 getAntiFlags: () => ({ is: () => false }),
                 getCount: () => 3,
@@ -250,7 +258,7 @@ describe('ShopService', () => {
 
         it('should remove item and send OK on successful sell', async () => {
             const shop = new Shop({ npcVnum: 9001, shopName: 'Arms', items: [] });
-            const inventoryStub = { removeItem: sinon.stub() };
+            const inventoryStub = { removeItem: sinon.stub(), isFromEquipmentSlots: sinon.stub().returns(false) };
             const mockItem = {
                 getAntiFlags: () => ({ is: () => false }),
                 getCount: () => 1,
@@ -271,7 +279,7 @@ describe('ShopService', () => {
 
         it('should cap sell count to item count', async () => {
             const shop = new Shop({ npcVnum: 9001, shopName: 'Arms', items: [] });
-            const inventoryStub = { removeItem: sinon.stub() };
+            const inventoryStub = { removeItem: sinon.stub(), isFromEquipmentSlots: sinon.stub().returns(false) };
             const mockItem = {
                 getAntiFlags: () => ({ is: () => false }),
                 getCount: () => 2, // only 2 available

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -16,7 +16,7 @@ describe('UseItemService', () => {
         loggerStub = sinon.createStubInstance(WinstonLoggerAdapter);
         itemManagerStub = { update: sinon.stub().resolves() };
         mobManagerStub = { hasMob: sinon.stub().resolves() };
-service = new UseItemService({ logger: loggerStub, itemManager: itemManagerStub, mobManager: mobManagerStub });
+        service = new UseItemService({ logger: loggerStub, itemManager: itemManagerStub, mobManager: mobManagerStub });
         playerStub = {
             getItem: sinon.stub(),
             isItemLockedInPrivateShop: sinon.stub().returns(false),

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -16,7 +16,7 @@ describe('UseItemService', () => {
         loggerStub = sinon.createStubInstance(WinstonLoggerAdapter);
         itemManagerStub = { update: sinon.stub().resolves() };
         mobManagerStub = { hasMob: sinon.stub().resolves() };
-        service = new UseItemService({ logger: loggerStub, itemManager: itemManagerStub, mobManager: mobManagerStub });
+service = new UseItemService({ logger: loggerStub, itemManager: itemManagerStub, mobManager: mobManagerStub });
         playerStub = {
             getItem: sinon.stub(),
             isItemLockedInPrivateShop: sinon.stub().returns(false),


### PR DESCRIPTION
Closes out the remaining findings from the shop-feature review. All verified in game with the TMP4 client (two accounts).

## Fixes

- **Close the private shop on disconnect** (`LeaveGameService`): guests could keep buying from an offline owner's stale in-memory inventory, and a relog created a second live copy of every item — duplication. Also leaves any shop the player was browsing so the owner's guest list doesn't accumulate dead connections. Verified: owner force-closed the client while a guest browsed → guest kicked, sign removed, no item duplication after relog.
- **NPC shop × private shop state collision**: `buy()` checks the private-shop state first, so opening an NPC shop while browsing a private shop routed purchases to the private shop's display slots (wrong item, wrong price). Opening an NPC shop now leaves the browsed private shop first.
- **Gold-cap overflow destroyed money**: the gold clamp silently destroyed any excess over the cap while the buyer paid full price. Sales are now refused when the seller's gold would overflow (private-shop owner side and NPC sell), like the original's GOLD_MAX check.
- **Bundle required**: a private shop could be opened without the Bundle item; the original refuses. Now it does too.
- **Equipped items**: could be sold to NPCs and listed in private shops (original rejects `IsEquipped`). Both blocked now.
- **Distance checks** (2000 units, like the original): NPC shop at open and on every buy/sell — the NPC entity is kept on the player (`currentShopNpc`) so transactions after walking away are refused; private-shop buys check guest↔owner distance.
- **Stale NPC-shop state blocked opening a private shop**: the client may close the shop window without sending SHOP_END (e.g. right after buying the bundle), so guarding on `currentShop` blocked legitimate opens. The stale state is now cleared instead (the original does not guard on it).

## Not addressed (intentionally)

Sockets/bonuses in `ShopStartPacket` are still sent as zeros — items in this codebase don't have attributes yet, so there is nothing to send; worth revisiting when an attribute system lands.

## Tested

- In game: full open→browse→buy→sold-out-auto-close cycle; disconnect cleanup with a guest browsing; selling an equipped