### PR TITLE
fix: reject non-attackable attack/target VIDs and enforce attack cooldown

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -86,6 +86,15 @@ const REGEN_INTERVAL = 3000;
 const MAX_DISTANCE_FROM_TARGET = 3500;
 const MAX_TIME_IDLE_IN_FIGHTING = 5_000;
 
+// Anti speed-hack: minimum time between two hits on the same victim, derived
+// from the attacker's attack speed. The reference is intentionally generous so
+// legitimate players (even with high attack speed) never trip it — it only
+// rejects packet floods, where hits arrive milliseconds apart. Mirrors the
+// original server's IS_SPEED_HACK check (which also builds in a large bonus so
+// normal play is never flagged).
+const ATTACK_SPEED_REFERENCE_MS = 15_000;
+const MIN_ATTACK_INTERVAL_MS = 80;
+
 export default class Player extends Character {
     private readonly accountId: number;
     private readonly playerClass: number;
@@ -114,6 +123,8 @@ export default class Player extends Character {
 
     //pos
     private lastTimeInBattle: number = 0;
+    private lastAttackTime: number = 0;
+    private lastAttackVictimVid: number = 0;
 
     //quests
     private readonly quests: Map<number, AbstractQuest> = new Map();
@@ -465,9 +476,29 @@ export default class Player extends Character {
             this.setPos(PositionEnum.STANDING);
             return;
         }
+
+        // Reject hits that arrive faster than the attack speed allows (packet
+        // flood / attack-speed hack). Only throttles repeated hits on the same
+        // victim, matching the original's per-target attack log.
+        const now = performance.now();
+        if (
+            victim.getVirtualId() === this.lastAttackVictimVid &&
+            now - this.lastAttackTime < this.getAttackCooldown()
+        ) {
+            return;
+        }
+        this.lastAttackVictimVid = victim.getVirtualId();
+        this.lastAttackTime = now;
+
         this.setPos(PositionEnum.FIGHTING);
-        this.lastTimeInBattle = performance.now();
+        this.lastTimeInBattle = now;
         this.battle.attack(attackType, victim);
+    }
+
+    /** Minimum milliseconds between two hits on the same victim. */
+    private getAttackCooldown() {
+        const attackSpeed = Math.max(1, this.getAttackSpeed());
+        return Math.max(MIN_ATTACK_INTERVAL_MS, Math.floor(ATTACK_SPEED_REFERENCE_MS / attackSpeed));
     }
 
     sendDetails() {

--- a/src/game/app/service/CharacterAttackService.ts
+++ b/src/game/app/service/CharacterAttackService.ts
@@ -14,10 +14,16 @@ export default class CharacterAttackService {
     }
 
     async execute(player: Player, attackType: AttackTypeEnum, victimVirtualId: number) {
-        const victim = this.entityManager.getEntity<Player | Monster>(victimVirtualId);
+        const victim = this.entityManager.getEntity(victimVirtualId);
 
-        if (!victim) {
-            this.logger.info(`[CharacterAttackService] Victim not found with virtualId ${victimVirtualId}`);
+        // Only players and monsters can be attacked. A client can send any VID
+        // it has in view (including dropped items, which are GameEntity but not
+        // Character), and getEntity's generic is only a cast — so validate the
+        // real type before the damage pipeline calls methods like isDead() that
+        // only exist on attackable entities. Without this a crafted VID crashes
+        // the server with an unhandled TypeError.
+        if (!(victim instanceof Player) && !(victim instanceof Monster)) {
+            this.logger.info(`[CharacterAttackService] Invalid attack victim with virtualId ${victimVirtualId}`);
             return;
         }
 

--- a/src/game/app/service/CharacterUpdateTargetService.ts
+++ b/src/game/app/service/CharacterUpdateTargetService.ts
@@ -18,7 +18,7 @@ export default class CharacterUpdateTargetService {
         // A client can send any VID in view, including dropped items (GameEntity
         // but not Character). getEntity's generic is only a cast, and setTarget
         // calls Character-only methods, so reject anything that isn't a Character
-        // (implements the "avoid hacking" TODO that was here).
+        // (this is the anti-hacking check that was previously left unimplemented).
         if (!(target instanceof Character)) {
             this.logger.info(`[CharacterUpdateTargetService] Invalid target with virtualId ${targetVirtualId}`);
             return;

--- a/src/game/app/service/CharacterUpdateTargetService.ts
+++ b/src/game/app/service/CharacterUpdateTargetService.ts
@@ -13,14 +13,14 @@ export default class CharacterUpdateTargetService {
     }
 
     async execute(player: Player, targetVirtualId: number) {
-        console.log(`[CharacterUpdateTargetService]: targetVirtualId -> ${targetVirtualId}`);
+        const target = this.entityManager.getEntity(targetVirtualId);
 
-        const target = this.entityManager.getEntity<Character>(targetVirtualId);
-
-        //TODO: validate id the target item is in the same map (avoid hacking)
-
-        if (!target) {
-            this.logger.info(`[CharacterUpdateTargetService] Target not found with virtualId ${targetVirtualId}`);
+        // A client can send any VID in view, including dropped items (GameEntity
+        // but not Character). getEntity's generic is only a cast, and setTarget
+        // calls Character-only methods, so reject anything that isn't a Character
+        // (implements the "avoid hacking" TODO that was here).
+        if (!(target instanceof Character)) {
+            this.logger.info(`[CharacterUpdateTargetService] Invalid target with virtualId ${targetVirtualId}`);
             return;
         }
 

--- a/test/unit/game/app/service/CharacterAttackService.test.ts
+++ b/test/unit/game/app/service/CharacterAttackService.test.ts
@@ -26,7 +26,7 @@ describe('CharacterAttackService', () => {
         });
     });
 
-    it('should log info when victim is not found', async () => {
+    it('should log info when victim is not an attackable entity', async () => {
         player.getPositionX.returns(100);
         player.getPositionY.returns(200);
         entityManager.getEntity.returns(null as any);
@@ -34,7 +34,7 @@ describe('CharacterAttackService', () => {
         await service.execute(player, AttackTypeEnum.NORMAL, 1);
 
         expect(logger.info.calledOnce).to.be.true;
-        expect(logger.info.calledWith('[CharacterAttackService] Victim not found with virtualId 1')).to.be.true;
+        expect(logger.info.calledWith('[CharacterAttackService] Invalid attack victim with virtualId 1')).to.be.true;
     });
 
     it('should execute battle service when victim is found', async () => {

--- a/test/unit/game/app/service/CharacterUpdateTargetService.test.ts
+++ b/test/unit/game/app/service/CharacterUpdateTargetService.test.ts
@@ -1,4 +1,5 @@
 import Player from '@/core/domain/entities/game/player/Player';
+import Monster from '@/core/domain/entities/game/mob/Monster';
 import CharacterUpdateTargetService from '@/game/app/service/CharacterUpdateTargetService';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -24,7 +25,7 @@ describe('CharacterUpdateTargetService', function () {
     });
 
     describe('execute', function () {
-        it('should log and return if target is not found', async function () {
+        it('should log and return if target is not a character', async function () {
             const playerMock = {
                 getPositionX: sinon.stub().returns(10),
                 getPositionY: sinon.stub().returns(20),
@@ -39,7 +40,7 @@ describe('CharacterUpdateTargetService', function () {
 
             expect(loggerMock.info.calledOnce).to.be.true;
             expect(loggerMock.info.firstCall.args[0]).to.equal(
-                '[CharacterUpdateTargetService] Target not found with virtualId 123',
+                '[CharacterUpdateTargetService] Invalid target with virtualId 123',
             );
         });
 
@@ -50,7 +51,7 @@ describe('CharacterUpdateTargetService', function () {
                 setTarget: sinon.spy(),
             };
 
-            const targetMock = {};
+            const targetMock = sinon.createStubInstance(Monster);
 
             entityManagerMock.getEntity.returns(targetMock);
 


### PR DESCRIPTION
Two combat-input issues found in a movement/combat audit and confirmed against the code.

## Server crash: attacking or targeting a non-attackable VID

A client can send any VID it currently has in view, and `EntityManager.getEntity<T>()`'s generic is only a cast — it does not check the real type. `CharacterAttackService` and `CharacterUpdateTargetService` then feed that entity into a pipeline that calls Character-only methods (`isDead()`, `getHealthPercentage()`). A dropped item (a `GameEntity`, not a `Character`) has none of these, so a crafted `AttackPacket` / `TargetPacket` pointing at a dropped-item VID crashes the server with an unhandled `TypeError`%