### PR TITLE
fix: quest info packet desyncs the client stream and crashes the client

### DIFF
--- a/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
@@ -68,74 +68,69 @@ export default class QuestInfoPacket extends PacketOut {
         this.iconFile = iconFile;
     }
 
+    // ISBEGIN is semantic (begin/end vs update), so it is honored from the
+    // caller's flags; every other bit is derived from field presence so the
+    // flag byte can never disagree with the payload.
+    private getFieldsToSend() {
+        const fields = [
+            {
+                present: (this.flags & QuestFlagEnum.ISBEGIN) !== 0,
+                bit: QuestFlagEnum.ISBEGIN,
+                size: IS_BEGIN_SIZE,
+                write: () => this.bufferWriter.writeUint8(this.wasStated ? 1 : 0),
+            },
+            {
+                present: Boolean(this.title),
+                bit: QuestFlagEnum.TITLE,
+                size: TITLE_SIZE,
+                write: () => this.bufferWriter.writeString(this.title, TITLE_SIZE),
+            },
+            {
+                present: Boolean(this.clockName),
+                bit: QuestFlagEnum.CLOCK_NAME,
+                size: CLOCK_NAME_SIZE,
+                write: () => this.bufferWriter.writeString(this.clockName!, CLOCK_NAME_SIZE),
+            },
+            {
+                present: this.clockValue !== undefined,
+                bit: QuestFlagEnum.CLOCK_VALUE,
+                size: INT_SIZE,
+                write: () => this.bufferWriter.writeUint32LE(this.clockValue!),
+            },
+            {
+                present: Boolean(this.counterName),
+                bit: QuestFlagEnum.COUNTER_NAME,
+                size: COUNTER_NAME_SIZE,
+                write: () => this.bufferWriter.writeString(this.counterName!, COUNTER_NAME_SIZE),
+            },
+            {
+                present: this.counterValue !== undefined,
+                bit: QuestFlagEnum.COUNTER_VALUE,
+                size: INT_SIZE,
+                write: () => this.bufferWriter.writeUint32LE(this.counterValue!),
+            },
+            {
+                present: Boolean(this.iconFile),
+                bit: QuestFlagEnum.ICON_FILE,
+                size: ICON_FILE_SIZE,
+                write: () => this.bufferWriter.writeString(this.iconFile!, ICON_FILE_SIZE),
+            },
+        ];
+
+        return fields.filter((field) => field.present);
+    }
+
     pack() {
-        // ISBEGIN is semantic (begin/end vs update), so it is honored from the
-        // caller's flags; every other bit is derived from field presence so the
-        // flag byte can never disagree with the payload.
-        const sendIsBegin = (this.flags & QuestFlagEnum.ISBEGIN) !== 0;
-        const sendTitle = Boolean(this.title);
-        const sendClockName = Boolean(this.clockName);
-        const sendClockValue = this.clockValue !== undefined;
-        const sendCounterName = Boolean(this.counterName);
-        const sendCounterValue = this.counterValue !== undefined;
-        const sendIconFile = Boolean(this.iconFile);
-
-        let flags = 0;
-        let totalSize = BASIC_SIZE;
-
-        if (sendIsBegin) {
-            flags |= QuestFlagEnum.ISBEGIN;
-            totalSize += IS_BEGIN_SIZE;
-        }
-        if (sendTitle) {
-            flags |= QuestFlagEnum.TITLE;
-            totalSize += TITLE_SIZE;
-        }
-        if (sendClockName) {
-            flags |= QuestFlagEnum.CLOCK_NAME;
-            totalSize += CLOCK_NAME_SIZE;
-        }
-        if (sendClockValue) {
-            flags |= QuestFlagEnum.CLOCK_VALUE;
-            totalSize += INT_SIZE;
-        }
-        if (sendCounterName) {
-            flags |= QuestFlagEnum.COUNTER_NAME;
-            totalSize += COUNTER_NAME_SIZE;
-        }
-        if (sendCounterValue) {
-            flags |= QuestFlagEnum.COUNTER_VALUE;
-            totalSize += INT_SIZE;
-        }
-        if (sendIconFile) {
-            flags |= QuestFlagEnum.ICON_FILE;
-            totalSize += ICON_FILE_SIZE;
-        }
+        const fields = this.getFieldsToSend();
+        const totalSize = fields.reduce((size, field) => size + field.size, BASIC_SIZE);
+        const flags = fields.reduce((bits, field) => bits | field.bit, 0);
 
         this.bufferWriter.writeUint16LE(totalSize);
         this.bufferWriter.writeUint16LE(this.id);
         this.bufferWriter.writeUint8(flags);
 
-        if (sendIsBegin) {
-            this.bufferWriter.writeUint8(this.wasStated ? 1 : 0);
-        }
-        if (sendTitle) {
-            this.bufferWriter.writeString(this.title, TITLE_SIZE);
-        }
-        if (sendClockName) {
-            this.bufferWriter.writeString(this.clockName!, CLOCK_NAME_SIZE);
-        }
-        if (sendClockValue) {
-            this.bufferWriter.writeUint32LE(this.clockValue!);
-        }
-        if (sendCounterName) {
-            this.bufferWriter.writeString(this.counterName!, COUNTER_NAME_SIZE);
-        }
-        if (sendCounterValue) {
-            this.bufferWriter.writeUint32LE(this.counterValue!);
-        }
-        if (sendIconFile) {
-            this.bufferWriter.writeString(this.iconFile!, ICON_FILE_SIZE);
+        for (const field of fields) {
+            field.write();
         }
 
         return this.bufferWriter.getBuffer(totalSize);

--- a/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
@@ -1,4 +1,5 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { QuestFlagEnum } from '@/core/enum/QuestSendFlagEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
 type QuestInfoPacketParams = {
@@ -14,7 +15,19 @@ type QuestInfoPacketParams = {
 };
 
 const BASIC_SIZE = 6;
-const FULL_FIZE = BASIC_SIZE + 99;
+const FULL_SIZE = BASIC_SIZE + 99;
+
+// Field sizes mirror the client's RecvQuestInfoPacket buffers exactly:
+// char szTitle[30+1], char szClockName[16+1], int, char szCounterName[16+1],
+// int, char szIconFileName[24+1]. The client consumes each field only when the
+// matching flag bit is set, so what gets flagged and what gets written must
+// always agree or the stream desynchronizes.
+const IS_BEGIN_SIZE = 1;
+const TITLE_SIZE = 31;
+const CLOCK_NAME_SIZE = 17;
+const COUNTER_NAME_SIZE = 17;
+const ICON_FILE_SIZE = 25;
+const INT_SIZE = 4;
 
 export default class QuestInfoPacket extends PacketOut {
     private readonly id: number;
@@ -41,7 +54,7 @@ export default class QuestInfoPacket extends PacketOut {
         super({
             header: PacketHeaderEnum.QUEST_INFO,
             name: 'QuestInfoPacket',
-            size: FULL_FIZE,
+            size: FULL_SIZE,
         });
 
         this.id = id;
@@ -56,44 +69,73 @@ export default class QuestInfoPacket extends PacketOut {
     }
 
     pack() {
-        this.bufferWriter.writeUint16LE(this.size);
-        this.bufferWriter.writeUint16LE(this.id);
-        this.bufferWriter.writeUint8(this.flags);
+        // ISBEGIN is semantic (begin/end vs update), so it is honored from the
+        // caller's flags; every other bit is derived from field presence so the
+        // flag byte can never disagree with the payload.
+        const sendIsBegin = (this.flags & QuestFlagEnum.ISBEGIN) !== 0;
+        const sendTitle = Boolean(this.title);
+        const sendClockName = Boolean(this.clockName);
+        const sendClockValue = this.clockValue !== undefined;
+        const sendCounterName = Boolean(this.counterName);
+        const sendCounterValue = this.counterValue !== undefined;
+        const sendIconFile = Boolean(this.iconFile);
+
+        let flags = 0;
         let totalSize = BASIC_SIZE;
 
-        if (this.wasStated === 0 || this.wasStated === 1) {
-            this.bufferWriter.writeUint8(this.wasStated);
-            totalSize += 1;
+        if (sendIsBegin) {
+            flags |= QuestFlagEnum.ISBEGIN;
+            totalSize += IS_BEGIN_SIZE;
+        }
+        if (sendTitle) {
+            flags |= QuestFlagEnum.TITLE;
+            totalSize += TITLE_SIZE;
+        }
+        if (sendClockName) {
+            flags |= QuestFlagEnum.CLOCK_NAME;
+            totalSize += CLOCK_NAME_SIZE;
+        }
+        if (sendClockValue) {
+            flags |= QuestFlagEnum.CLOCK_VALUE;
+            totalSize += INT_SIZE;
+        }
+        if (sendCounterName) {
+            flags |= QuestFlagEnum.COUNTER_NAME;
+            totalSize += COUNTER_NAME_SIZE;
+        }
+        if (sendCounterValue) {
+            flags |= QuestFlagEnum.COUNTER_VALUE;
+            totalSize += INT_SIZE;
+        }
+        if (sendIconFile) {
+            flags |= QuestFlagEnum.ICON_FILE;
+            totalSize += ICON_FILE_SIZE;
         }
 
-        if (this.title) {
-            this.bufferWriter.writeString(this.title, 32);
-            totalSize += 32;
-        }
+        this.bufferWriter.writeUint16LE(totalSize);
+        this.bufferWriter.writeUint16LE(this.id);
+        this.bufferWriter.writeUint8(flags);
 
-        if (this.clockName) {
-            this.bufferWriter.writeString(this.clockName, 17);
-            totalSize += 17;
+        if (sendIsBegin) {
+            this.bufferWriter.writeUint8(this.wasStated ? 1 : 0);
         }
-
-        if (this.clockValue) {
-            this.bufferWriter.writeUint32LE(this.clockValue);
-            totalSize += 4;
+        if (sendTitle) {
+            this.bufferWriter.writeString(this.title, TITLE_SIZE);
         }
-
-        if (this.counterName) {
-            this.bufferWriter.writeString(this.counterName, 17);
-            totalSize += 17;
+        if (sendClockName) {
+            this.bufferWriter.writeString(this.clockName!, CLOCK_NAME_SIZE);
         }
-
-        if (this.counterValue) {
-            this.bufferWriter.writeUint32LE(this.counterValue);
-            totalSize += 4;
+        if (sendClockValue) {
+            this.bufferWriter.writeUint32LE(this.clockValue!);
         }
-
-        if (this.iconFile) {
-            this.bufferWriter.writeString(this.iconFile, 25);
-            totalSize += 25;
+        if (sendCounterName) {
+            this.bufferWriter.writeString(this.counterName!, COUNTER_NAME_SIZE);
+        }
+        if (sendCounterValue) {
+            this.bufferWriter.writeUint32LE(this.counterValue!);
+        }
+        if (sendIconFile) {
+            this.bufferWriter.writeString(this.iconFile!, ICON_FILE_SIZE);
         }
 
         return this.bufferWriter.getBuffer(totalSize);

--- a/test/unit/core/interface/networking/packets/packets/out/QuestInfoPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/out/QuestInfoPacket.test.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import QuestInfoPacket from '@/core/interface/networking/packets/packet/out/QuestInfoPacket';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { QuestFlagEnum } from '@/core/enum/QuestSendFlagEnum';
+
+const BASIC_SIZE = 6; // header + size(2) + id(2) + flags
+const IS_BEGIN_SIZE = 1;
+const TITLE_SIZE = 31; // client reads char[30+1]
+const COUNTER_NAME_SIZE = 17; // client reads char[16+1]
+const INT_SIZE = 4;
+
+describe('QuestInfoPacket', () => {
+    it('should initialize with correct header', () => {
+        const packet = new QuestInfoPacket({ id: 1, flags: 0, wasStarted: 0, title: 'Hunt Quest' });
+        expect(packet.getHeader()).to.equal(PacketHeaderEnum.QUEST_INFO);
+        expect(packet.getName()).to.equal('QuestInfoPacket');
+    });
+
+    it('should declare a size equal to the bytes actually sent', () => {
+        const packet = new QuestInfoPacket({
+            id: 1,
+            flags: QuestFlagEnum.ISBEGIN | QuestFlagEnum.TITLE,
+            wasStarted: 1,
+            title: 'Hunt Quest',
+        });
+        const buffer = packet.pack();
+        const declaredSize = buffer.readUInt16LE(1);
+        expect(buffer).to.have.lengthOf(declaredSize);
+        expect(declaredSize).to.equal(BASIC_SIZE + IS_BEGIN_SIZE + TITLE_SIZE);
+    });
+
+    it('should only flag fields that are present in the payload', () => {
+        const packet = new QuestInfoPacket({
+            id: 2,
+            flags: 0,
+            wasStarted: 1,
+            title: 'Hunt Quest',
+            counterName: 'kills',
+            counterValue: 5,
+        });
+        const buffer = packet.pack();
+        const flags = buffer.readUInt8(5);
+
+        // ISBEGIN was not requested, so the byte must not be flagged nor written
+        expect(flags & QuestFlagEnum.ISBEGIN).to.equal(0);
+        expect(flags & QuestFlagEnum.TITLE).to.equal(QuestFlagEnum.TITLE);
+        expect(flags & QuestFlagEnum.COUNTER_NAME).to.equal(QuestFlagEnum.COUNTER_NAME);
+        expect(flags & QuestFlagEnum.COUNTER_VALUE).to.equal(QuestFlagEnum.COUNTER_VALUE);
+        expect(buffer).to.have.lengthOf(BASIC_SIZE + TITLE_SIZE + COUNTER_NAME_SIZE + INT_SIZE);
+    });
+
+    it('should write the title with the 31 bytes the client reads', () => {
+        const packet = new QuestInfoPacket({ id: 3, flags: 0, wasStarted: 0, title: 'Hunt Quest' });
+        const buffer = packet.pack();
+
+        const title = buffer.subarray(BASIC_SIZE, BASIC_SIZE + TITLE_SIZE);
+        expect(title.toString('ascii', 0, 10)).to.equal('Hunt Quest');
+        expect(title[TITLE_SIZE - 1]).to.equal(0);
+        expect(buffer).to.have.lengthOf(BASIC_SIZE + TITLE_SIZE);
+    });
+
+    it('should send a zero counter value instead of dropping the flagged field', () => {
+        const packet = new QuestInfoPacket({
+            id: 4,
+            flags: 0,
+            wasStarted: 1,
+            title: 'Hunt Quest',
+            counterValue: 0,
+        });
+        const buffer = packet.pack();
+        const flags = buffer.readUInt8(5);
+
+        expect(flags & QuestFlagEnum.COUNTER_VALUE).to.equal(QuestFlagEnum.COUNTER_VALUE);
+        expect(buffer).to.have.lengthOf(BASIC_SIZE + TITLE_SIZE + INT_SIZE);
+        expect(buffer.readUInt32LE(buffer.length - INT_SIZE)).to.equal(0);
+    });
+});


### PR DESCRIPTION
## Summary

Killing a HuntQuest target (or any flow that updates the quest letter) crashes the 40250 client with `Unknown packet header: 164, last: 81 72` — reproduced twice in-game, fixed and verified in-game.

## Root cause

The client's `RecvQuestInfoPacket` consumes each field of `TPacketGCQuestInfo` **strictly by its flag bit**, but the server wrote fields by **truthiness** while the flag byte was tracked separately in `AbstractQuest`. The two can disagree — the quest-letter update sent on every HuntQuest kill wrote the title without the `TITLE` flag set, so the client read the leftover bytes as packet headers. (In the crash signature, the stray header `72` is literally the `'H'` of "Hunt Quest".)

Three more latent mismatches in the same pack():
- the title was written with **32** bytes, but the client reads **31** (`char szTitle[30+1]`) — off-by-one desync even with correct flags
- the declared packet size was always 105 instead of the real size
- `clockValue`/`counterValue` of **0** were dropped by the truthiness check even when flagged — a counter reaching zero desyncs by 4 bytes

## Fix

`QuestInfoPacket.pack()` now derives every field flag from the payload it actually writes, so flags and payload can never disagree. `ISBEGIN` stays caller-controlled since it selects the client's begin/end vs update semantics. Field sizes mirror the client buffers exactly, the real size is declared, and value fields use an `undefined` check so 0 is sent.

## Verification

- 5 new unit tests for the packet layout (412 total, green)
- In-game: repeated HuntQuest kills with letter updates — no more crashes
