### PR TITLE
fix: inventory page 2+ items collapse onto page 1 after relog

### DIFF
--- a/src/core/domain/entities/game/inventory/Inventory.ts
+++ b/src/core/domain/entities/game/inventory/Inventory.ts
@@ -80,11 +80,13 @@ export default class Inventory {
         const page = this.calcPage(position);
         const pagePosition = this.calcPagePosition(page, position);
         if (this.pages[page].addItemAt(item, pagePosition)) {
-            item.setPosition(pagePosition);
+            // Keep the absolute position on the item: pagePosition is relative
+            // to its page, and storing it would fold every page-2+ item back
+            // onto page 1 (visible after a relog, when the inventory is
+            // rebuilt from the database through this method).
+            item.setPosition(position);
             item.setOwnerId(this.ownerId);
-            item.setWindow(
-                this.isEquipmentPosition(pagePosition) ? WindowTypeEnum.EQUIPMENT : WindowTypeEnum.INVENTORY,
-            );
+            item.setWindow(this.isEquipmentPosition(position) ? WindowTypeEnum.EQUIPMENT : WindowTypeEnum.INVENTORY);
             this.items.set(item.getDbId()!, item);
         }
     }

--- a/test/unit/core/domain/inventory/Inventory.test.ts
+++ b/test/unit/core/domain/inventory/Inventory.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import BitFlag from '@/core/util/BitFlag';
+import Item from '@/core/domain/entities/game/item/Item';
+import Inventory from '@/core/domain/entities/game/inventory/Inventory';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
+import { ItemUseSubTypeEnum } from '@/core/enum/ItemUseSubTypeEnum';
+import { GameConfig } from '@/game/infra/config/GameConfig';
+
+const PAGE_SIZE = 45; // 5 x 9
+
+function createItem(id: number, dbId: number) {
+    return new Item({
+        id,
+        name: `item-${id}`,
+        type: ItemTypeEnum.ITEM_USE,
+        subType: ItemUseSubTypeEnum.USE_POTION,
+        size: 1,
+        antiFlags: new BitFlag(),
+        flags: new BitFlag(),
+        wearFlags: new BitFlag(),
+        immuneFlags: new BitFlag(),
+        gold: 0,
+        shopPrice: 100,
+        refineId: 0,
+        refineSet: 0,
+        magicPercent: 0,
+        limits: [],
+        applies: [],
+        values: [],
+        specular: 0,
+        socket: 0,
+        addon: 0,
+        count: 1,
+        socket0: 0,
+        socket1: 0,
+        socket2: 0,
+        attributeType0: 0,
+        attributeValue0: 0,
+        attributeType1: 0,
+        attributeValue1: 0,
+        attributeType2: 0,
+        attributeValue2: 0,
+        attributeType3: 0,
+        attributeValue3: 0,
+        attributeType4: 0,
+        attributeValue4: 0,
+        attributeType5: 0,
+        attributeValue5: 0,
+        attributeType6: 0,
+        attributeValue6: 0,
+        dbId,
+    });
+}
+
+function createInventory() {
+    return new Inventory({ config: { INVENTORY_PAGES: 2 } as GameConfig, ownerId: 1 });
+}
+
+describe('Inventory', () => {
+    it('should keep the absolute position when placing an item on the first page', () => {
+        const inventory = createInventory();
+        const item = createItem(27003, 1);
+
+        inventory.addItemAt(item, 10);
+
+        expect(item.getPosition()).to.equal(10);
+        expect(inventory.getItem(10)).to.equal(item);
+    });
+
+    it('should keep the absolute position when placing an item on the second page', () => {
+        const inventory = createInventory();
+        const item = createItem(27003, 1);
+
+        const secondPagePosition = PAGE_SIZE + 25;
+        inventory.addItemAt(item, secondPagePosition);
+
+        expect(item.getPosition()).to.equal(secondPagePosition);
+        expect(inventory.getItem(secondPagePosition)).to.equal(item);
+    });
+
+    it('should not collide first-page items with reloaded second-page items', () => {
+        const inventory = createInventory();
+        const firstPageItem = createItem(27003, 1);
+        const secondPageItem = createItem(27004, 2);
+
+        // Same page-relative slot on both pages, as when the inventory is
+        // rebuilt from the database on login.
+        inventory.addItemAt(firstPageItem, 25);
+        inventory.addItemAt(secondPageItem, PAGE_SIZE + 25);
+
+        expect(inventory.getItem(25)).to.equal(firstPageItem);
+        expect(inventory.getItem(PAGE_SIZE + 25)).to.equal(secondPageItem);
+        expect(firstPageItem.getPosition()).to.equal(25);
+        expect(secondPageItem.getPosition()).to.equal(PAGE_SIZE + 25);
+    });
+});


### PR DESCRIPTION
## Summary

Found while play-testing: fill inventory page 1, buy more stacks (they correctly land on page 2), relog — page 2 comes back **empty**. The database still holds every item at the right position; they are lost visually and, worse, the in-memory items now carry wrong positions.

## Root cause

`Inventory.addItemAt` places the item on the right page but then calls `item.setPosition(pagePosition)` — the **page-relative** slot — instead of the absolute position (`addItem` gets this right). On login the inventory is rebuilt from the database through this method, so every page-2 item ends up claiming a page-1 position: `sendInventory` sends it on top of the page-1 item in the same slot, and any later save/move acting on the stale position hits the wrong slot (position corruption / item-loss potential).

Dormant until now because it only triggers once page 1 is full.

## Fix

Store the absolute position (mirroring `addItem`), and pass it to the window check as well. Unit tests cover first-page placement, second-page placement, and the reload collision scenario.

## Verification

- 3 new unit tests (410 total, green)
- In-game: refilled page 1 + page 2, relogged — every stack now reappears on page 2
