### PR TITLE
feat: render the level-up effect on the client

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -1,5 +1,28 @@
 # Packet Documentation
 
+### AffectAddPacket
+
+**Type:** Out
+
+**Header:** 0x7E
+
+**Size:** 22 bytes
+
+**Description:** Used to send an effect.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| type | `int` | 4 | Apply type number. See in AffectTypeEnum |
+| apply | `byte` | 1 | Describe which point is affected by this affect. See in PointEnum |
+| flag | `int` | 4 | The bit flag of applies. See in AffectBitsTypeEnum |
+| duration | `int` | 4 | The duration in seconds of an affect |
+| manaCost | `int` | 4 | The mana cost of an affect |
+
+---
+
 ### ChannelPacket
 
 **Type:** Out
@@ -124,19 +147,20 @@
 
 **Header:** 0x11
 
-**Size:** 22 bytes
+**Size:** 17 bytes
 
-**Description:** Is used to send and update of a point (attribute) to the client (used to notify all nearby players of an update of a character). See all points in PointsEnum.
+**Description:** Is used to send an update of a single point (attribute) of a character to the client. The client plays the level-up effect when it receives a POINT_LEVEL change for any vid. See all points in PointsEnum.
 
 **Fields:**
 
 | Name        | Type       | Size (bytes)   | Description               |
 |-------------|------------|----------------|---------------------------|
 | header | `byte` | 1 | Packet header. |
+| padding | `byte[3]` | 3 | The client declares the header as a 4-byte int, so 3 padding bytes follow the header byte. |
 | vid | `int` | 4 | Character identification in game. |
 | type | `byte` | 1 | Number which indicates the point type (See in PointsEnum). |
-| amount | `long` | 8 | Number which indicates the quantity of that point (default is 0). |
-| value | `long` | 8 | Number which indicates the value of that point. |
+| amount | `int` | 4 | Signed quantity delta of that point (default is 0). |
+| value | `int` | 4 | Signed new value of that point. |
 
 ---
 
@@ -217,6 +241,88 @@
 | virtualId | `number` | 4 | virtualId of the affected entity |
 | damageFlags | `byte` | 1 | indicates the flags of damage like: critical, pierced etc //TODO |
 | damage | `number` | 4 | the damage number |
+
+---
+
+### FlyPacket
+
+**Type:** Out
+
+**Header:** 0x46
+
+**Size:** 10 bytes
+
+**Description:** Used to send fly particle from entity to another.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| type | `byte` | 4 | type of fly. See in FlyEnum. |
+| fromVirtualId | `number` | 4 | wich entity the fly starts |
+| toVirtualId | `number` | 4 | wich entity the fly ends |
+
+---
+
+### InternalPongPacket
+
+**Type:** Out
+
+**Header:** 253
+
+**Size:** 5 bytes
+
+**Description:** Used to internal pong.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| time | `int` | 4 | The time sent by client |
+
+---
+
+### SpecialEffectPacket
+
+**Type:** Out
+
+**Header:** 0x72
+
+**Size:** 6 bytes
+
+**Description:** Used to send an special effect.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| type | `byte` | 1 | Describe the special effect. See in SpecialEffectTypeEnum |
+| virtual | `int` | 4 | Virtual id of the player to be effected |
+
+---
+
+### SyncPositionPacket
+
+**Type:** Out
+
+**Header:** 0x05
+
+**Size:** 15 bytes
+
+**Description:** Forces the client to snap an entity (including the player's own
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| size | `number` | 2 | Total packet size in bytes |
+| virtualId | `number` | 4 | virtualId of the entity to snap |
+| positionX | `number` | 4 | Server-side X position |
+| positionY | `number` | 4 | Server-side Y position |
 
 ---
 

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -339,6 +339,31 @@ export default class Player extends Character {
 
     levelUp() {
         this.questManager.onLevelUp(this);
+        this.broadcastLevelUp();
+    }
+
+    /**
+     * The client plays the level-up visual effect when it receives a
+     * POINT_LEVEL point-change for a vid (original: PointChange POINT_LEVEL
+     * packets go to the character and everyone around).
+     */
+    private broadcastLevelUp() {
+        const level = this.getLevel();
+
+        this.connection?.send(
+            new CharacterPointChangePacket({
+                vid: this.virtualId,
+                type: PointsEnum.LEVEL,
+                amount: 0,
+                value: level,
+            }),
+        );
+
+        for (const entity of this.nearbyEntities.values()) {
+            if (entity instanceof Player) {
+                entity.otherEntityLevelUp({ virtualId: this.virtualId, level });
+            }
+        }
     }
 
     async onSpawn(): Promise<void> {

--- a/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
@@ -991,6 +991,9 @@ export class PlayerPoints extends Points {
         this.iq = this.config.jobs[className].common.iq;
 
         this.calcPointsAndResetValues();
+        // Original behaviour: PointChange(POINT_LEVEL) fires the quest hook and
+        // the level-up effect no matter how the level changed (/lvl included).
+        this.player.levelUp();
     }
 
     private calcAttack() {

--- a/src/core/interface/networking/buffer/BufferWriter.ts
+++ b/src/core/interface/networking/buffer/BufferWriter.ts
@@ -37,6 +37,12 @@ export default class BufferWriter {
         return this;
     }
 
+    writeInt32LE(value: number): this {
+        this.buffer.writeInt32LE(value, this.lastPos);
+        this.lastPos += 4;
+        return this;
+    }
+
     writeUint64LE(value: number | bigint): this {
         this.buffer.writeBigUInt64LE(BigInt(value), this.lastPos);
         this.lastPos += 8;

--- a/src/core/interface/networking/packets/packet/out/CharacterPointChangePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharacterPointChangePacket.ts
@@ -6,14 +6,15 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  * @type Out
  * @name CharacterPointChangePacket
  * @header 0x11
- * @size 22
- * @description Is used to send and update of a point (attribute) to the client (used to notify all nearby players of an update of a character). See all points in PointsEnum.
+ * @size 17
+ * @description Is used to send an update of a single point (attribute) of a character to the client. The client plays the level-up effect when it receives a POINT_LEVEL change for any vid. See all points in PointsEnum.
  * @fields
  *   - {byte} header 1 Packet header.
+ *   - {byte[3]} padding 3 The client declares the header as a 4-byte int, so 3 padding bytes follow the header byte.
  *   - {int} vid 4 Character identification in game.
  *   - {byte} type 1 Number which indicates the point type (See in PointsEnum).
- *   - {long} amount 8 Number which indicates the quantity of that point (default is 0).
- *   - {long} value 8 Number which indicates the value of that point.
+ *   - {int} amount 4 Signed quantity delta of that point (default is 0).
+ *   - {int} value 4 Signed new value of that point.
  */
 
 export default class CharacterPointChangePacket extends PacketOut {
@@ -26,7 +27,7 @@ export default class CharacterPointChangePacket extends PacketOut {
         super({
             header: PacketHeaderEnum.CHARACTER_POINT_CHANGE,
             name: 'CharacterPointChangePacket',
-            size: 22,
+            size: 17,
         });
         this.vid = vid;
         this.type = type;
@@ -35,10 +36,15 @@ export default class CharacterPointChangePacket extends PacketOut {
     }
 
     pack() {
+        // The client struct starts with `int header` inside its pack(1) region,
+        // so the header byte is followed by 3 padding bytes before the payload.
+        this.bufferWriter.writeUint8(0);
+        this.bufferWriter.writeUint8(0);
+        this.bufferWriter.writeUint8(0);
         this.bufferWriter.writeUint32LE(this.vid);
         this.bufferWriter.writeUint8(this.type);
-        this.bufferWriter.writeUint64LE(this.amount);
-        this.bufferWriter.writeUint64LE(this.value);
+        this.bufferWriter.writeInt32LE(this.amount);
+        this.bufferWriter.writeInt32LE(this.value);
         return this.bufferWriter.getBuffer();
     }
 }


### PR DESCRIPTION
Closes #45.

## Approach

The client already plays `EFFECT_LEVELUP` on its own when it receives a **POINT_LEVEL point-change** for a vid — `ShowPointEffect` fires for any vid, before the is-main-character check (`PythonNetworkStreamPhaseGame.cpp:1491` → `PythonCharacterManager.cpp:242`). So no dedicated effect packet is needed; the canonical trigger is `CharacterPointChangePacket`, which existed in the codebase but had zero callers and a wrong layout.

(For the record: `SpecialEffectPacket` types 14/15 — `LEVELUP_*_FOR_GERMANY` — are a separate German-locale mechanism using different effect slots, not the classic level-up visual.)

## Changes

- **Fix `CharacterPointChangePacket` layout** against the client struct: `packet_point_change` declares the header as a 4-byte `int` inside the `#pragma pack(1)` region and `long` is 32-bit there — so the wire format is header byte + 3 padding bytes, uint32 vid, uint8 type, int32 amount, int32 value = **17 bytes**, not 22. (Same class of bug as the skill-level packet found on the horse branch: the client silently skips zero bytes between packets, so wrong sizes can hide.)
- **`Player.levelUp()` now broadcasts** the point-change to the player and everyone nearby, wiring up the previously dead `otherEntityLevelUp`.
- **GM `/lvl` path fires `levelUp()` too** (`PlayerPoints.setLevel`), matching the original where `PointChange(POINT_LEVEL)` triggers the quest hook and the effect regardless of how the level changed.
- `docs/packets.md` regenerated (separate commit — also catches up packets added earlier without a doc regen).

## Verification

- Verified in game: the level-up pillar effect renders on `/lvl` and on natural level-up via exp.
- `npm run test:unit` green (415), `tsc` clean.
<img width="395" height="514" alt="image" src="https://github.com/user-attachments/assets/02bd4518-dd61-4b15-922e-fad649299126" />
