### PR TITLE
docs: sync README, guide and quests docs with the current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Open Metin2 - Server Emulator
 
-![GitHub repo size](https://img.shields.io/github/repo-size/willianmarquess/mt2-server-javascript?style=for-the-badge)
-![GitHub language count](https://img.shields.io/github/languages/count/willianmarquess/mt2-server-javascript?style=for-the-badge)
-![GitHub forks](https://img.shields.io/github/forks/willianmarquess/mt2-server-javascript?style=for-the-badge)
+![GitHub repo size](https://img.shields.io/github/repo-size/willianmarquess/open-mt2?style=for-the-badge)
+![GitHub language count](https://img.shields.io/github/languages/count/willianmarquess/open-mt2?style=for-the-badge)
+![GitHub forks](https://img.shields.io/github/forks/willianmarquess/open-mt2?style=for-the-badge)
 
 ![CI Pipeline](https://github.com/willianmarquess/open-mt2/actions/workflows/flow.yml/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=willianmarquess_open-mt2&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=willianmarquess_open-mt2)
@@ -27,8 +27,8 @@ Metin2 are copyrighted by [Webzen](http://webzen.com/ "Webzen").
 | Server Status |      |       | ✅    |
 | Login |      |       | ✅    |
 | Logout    |      |       | ✅    |
-| Return to Select    | X    |       |      |
-| Delete Character    | X    |       |      |
+| Return to Select    |      |       | ✅    |
+| Delete Character    |      |       | ✅    |
 | Protocol Encryption   | X    |       |      |
 | Create character  |      |       | ✅    |
 | Enter Game    |      |       | ✅   |
@@ -64,7 +64,8 @@ Metin2 are copyrighted by [Webzen](http://webzen.com/ "Webzen").
 | Drop System   |      | X     |      |
 | Affect System   |      | X     |      |
 | Quest System   |      |  X    |      |
-| Skills System   | X    |       |      |
+| Skills System   |      | X     |      |
+| Private Shop System   |      |       | ✅    |
 | Chat System   | X    |       |      |
 | Level System   |      |       | ✅    |
 | Graceful shutdown   |      |       | ✅    |
@@ -108,8 +109,8 @@ In this implementation we are using custom commands, described bellow:
     - Description: create an item passing vnum and you can pass the quantity.
     - Example: /item <vnum> <quantity>
 - **/list**
-    - Description: list resources <areas, players>.
-    - Example: /list <areas, players>
+    - Description: list resources <areas, players, privileges>.
+    - Example: /list <areas, players, privileges>
 - **/lvl**
     - Description: set level to other player or to yourself.
     - Example: /lvl <number> <targetName>
@@ -129,15 +130,33 @@ In this implementation we are using custom commands, described bellow:
     - Description: transform your character into a mob appearance by vnum. Pass 0 to revert to original appearance.
     - Example: /polymorph <vnum>
     - Usage: /polymorph 101 (transforms into mob with vnum 101)
+- **/close_shop**
+    - Description: close the player private shop.
+    - Example: /close_shop
+- **/logout**
+    - Description: logout the account.
+    - Example: /logout
+- **/quit**
+    - Description: quit the client.
+    - Example: /quit
+- **/restart_here**
+    - Description: restart at the same coordinates (after death).
+    - Example: /restart_here
+- **/restart_town**
+    - Description: restart at the town (after death).
+    - Example: /restart_town
+- **/phase_select**
+    - Description: back to the character select screen.
+    - Example: /phase_select
 
 
 ## Auth Flow
 The image bellow show how the client interacts with auth server.
-![](https://github.com/willianmarquess/mt2-server-javascript/blob/master/docs/images/mt2-auth-server.drawio.png)
+![](https://github.com/willianmarquess/open-mt2/blob/master/docs/images/mt2-auth-server.drawio.png)
 
 ## Game Flow (work in progress)
 The image bellow show how the client interacts with game server.
-![](https://github.com/willianmarquess/mt2-server-javascript/blob/master/docs/images/mt2-game-server.drawio.png)
+![](https://github.com/willianmarquess/open-mt2/blob/master/docs/images/mt2-game-server.drawio.png)
 
 ## License
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -23,7 +23,7 @@ ps: If you changed the ports in the .env, put the relative values ​​here
 
 - Install dependencies
 ```bash
-npm run install
+npm install
 ```
 - Setup .env file (you can use .env.example as example)
 - Execute this command on terminal:
@@ -42,6 +42,7 @@ npm run dev:auth
 ```bash
 npm run dev:game
 ```
+ps: `npm run dev:auth:debug` / `npm run dev:game:debug` run the same servers with `LOG_LEVEL=debug` — useful when investigating, since many rejection paths only log at debug level.
 - Open mt2 client and use these values for login and password:
 ```bash
 login: admin

--- a/docs/quests.md
+++ b/docs/quests.md
@@ -10,12 +10,17 @@ This document explains how quests are implemented on the server and how to creat
 
 ### Examples
 
-- Example quests: [src/core/domain/quests/quests/WelcomeQuest.ts](src/core/domain/quests/quests/WelcomeQuest.ts) and [src/core/domain/quests/quests/HuntQuest.ts](src/core/domain/quests/quests/HuntQuest.ts).
+- Example quests: [src/core/domain/quests/quests/WelcomeQuest.ts](src/core/domain/quests/quests/WelcomeQuest.ts) and [src/core/domain/quests/quests/HuntQuest.ts](src/core/domain/quests/quests/HuntQuest.ts). For `CLICK`-driven NPC interaction see [ShopQuest.ts](src/core/domain/quests/quests/ShopQuest.ts), and for a state-machine-heavy example see [SkillQuest.ts](src/core/domain/quests/quests/SkillQuest.ts).
 
 ### Decorators and signatures (usage)
 
 - `@Quest(questName: string, initialStateName: string)` — marks a class as a quest and sets the initial state name.
-- `@Task({ state: string, when: QuestEventEnum, with?: (ctx) => boolean | Promise<boolean> })` — marks a method to run when the given event happens while the quest is in the specified state. Optional `with` is a condition that can short-circuit execution.
+- `@Task({ state: string, when: QuestEventEnum, target?: number | number[], with?: (ctx) => boolean | Promise<boolean> })` — marks a method to run when the given event happens while the quest is in the specified state. Optional `with` is a condition that can short-circuit execution.
+- `target` applies to `CLICK` and `KILL` tasks: the mob/NPC vnum (or a list of vnums) the event must match. Example from `ShopQuest`:
+
+```ts
+@Task({ state: ShopQuestState.START, when: QuestEventEnum.CLICK, target: [ShopIdEnum.GOODS, ShopIdEnum.POTIONS] })
+```
 
 Typical method signature for task handlers:
 
@@ -25,12 +30,18 @@ public async startOnLogin({ player }: LoginExecutionContext) { ... }
 public async huntOnKill({ victim }: KillExecutionContext) { ... }
 ```
 
-### Execution contexts
+### Events and execution contexts
 
-- `LoginExecutionContext` — available when the trigger is player login (gives access to `player`).
-- `KillExecutionContext` — contains `victim` (the killed monster) and `player` where appropriate.
-- `EnterExecutionContext` — used when entering a state.
-- These contexts are passed to the task callback by the quest runner.
+Available events (`QuestEventEnum`): `LOGIN`, `LOGOUT`, `CLICK`, `KILL`, `LEVELUP`, `ENTER_STATE`, `LEAVE_STATE`, `LETTER`, `INFO`, `BUTTON`.
+
+Each event has a matching context type passed to the task callback:
+
+- `LoginExecutionContext` / `LogoutExecutionContext` — trigger is player login/logout (gives access to `player`).
+- `ClickExecutionContext` — the player clicked an NPC matching `target`; contains `npc` (an `NpcQuest` facade with `getId()`, `getVirtualId()`, `getLevel()`, `openShop()`).
+- `KillExecutionContext` — contains `victim` (the killed monster).
+- `LevelUpExecutionContext` — the player leveled up.
+- `EnterExecutionContext` / `LeaveExecutionContext` — used when entering/leaving a state.
+- `LetterExecutionContext`, `InfoExecutionContext`, `ButtonExecutionContext` — quest-letter UI interactions (see `HuntQuest` for usage).
 
 ### Quest lifecycle
 


### PR DESCRIPTION
Small docs-only sync — the hand-written docs had drifted behind the code:

## README
- Roadmap corrected against the code: **Return to Select** and **Delete Character** are implemented (moved to Done), **Skills System** moved to Doing (#38), and a **Private Shop System** row added (it was fully implemented but absent from the table).
- Commands section: added the six undocumented commands (`/close_shop`, `/logout`, `/quit`, `/restart_here`, `/restart_town`, `/phase_select`) and updated `/list` to mention privileges — the section now matches all 17 registered commands.
- Badges and flow-image links updated from the old `mt2-server-javascript` repo name to `open-mt2`.

## docs/guide.md
- `npm run install` → `npm install` (the script doesn't exist).
- Note about the `:debug` script variants, since many rejection paths only log at debug level.

## docs/quests.md
- Documented the `target` option of `@Task` (`number | number[]`, with the multi-target ShopQuest example) — it was missing entirely.
- Completed the event list (`LOGIN/LOGOUT/CLICK/KILL/LEVELUP/ENTER_STATE/LEAVE_STATE/LETTER/INFO/BUTTON`) and the per-event execution contexts, including `ClickExecutionContext` and the `NpcQuest` facade.
- Linked ShopQuest/SkillQuest as modern examples alongside WelcomeQuest/HuntQuest.

No code changes. (Horse commands intentionally left out — they'll come with #33 to avoid conflicts.)