### PR TITLE
fix: reading a quest letter no longer dismisses it

### DIFF
--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -34,6 +34,11 @@ export abstract class AbstractQuest {
     // reaches select()/nextPage() (several awaits in), leaving a window where a
     // second click could start a concurrent run. This flag closes that window.
     private running: boolean = false;
+    // Player interacted with an open quest window during the current run
+    // (answered a select, turned a page, closed the window). Mirrors the
+    // original engine's m_bShouldSendDone: only then is a bare trailing
+    // [DONE] sent, so the client releases that window.
+    private shouldSendDone: boolean = false;
     private readonly questFlags: BitFlag = new BitFlag();
 
     private readonly player: Player;
@@ -105,7 +110,8 @@ export abstract class AbstractQuest {
                     } catch (err) {
                         console.error('[QUEST] condition error', err);
                     } finally {
-                        this.done();
+                        this.rearmLetter(context.eventType, callbackResult);
+                        this.autoDone();
                         this.endRunning(callbackResult);
                     }
                 } catch (err) {
@@ -117,6 +123,47 @@ export abstract class AbstractQuest {
 
     private getCurrentTasksByEvent(event: QuestEventEnum) {
         return this.currentState?.tasks.filter((routine) => routine.when === event) ?? [];
+    }
+
+    /**
+     * Trailing [DONE] policy, mirroring the original engine (SendScript in
+     * questmanager.cpp): send it when there is accumulated text to show, or
+     * when the player interacted with an open quest window during this run
+     * (answer, next page, close) and the client needs a bare [DONE] to release
+     * it. In any other case send nothing — a bare [DONE] ends the client-side
+     * quest script, which is what used to take quest letters down (issue #58).
+     */
+    private autoDone() {
+        const playerInteracted = this.shouldSendDone;
+        this.shouldSendDone = false;
+
+        if (this.src.length < 1 && !playerInteracted) return;
+
+        this.done();
+    }
+
+    /**
+     * The client destroys a letter the moment it is clicked (the click and the
+     * BUTTON packet are one action), so a BUTTON run that leaves the quest in
+     * the same state must re-send the [QUESTBUTTON] or the letter is gone for
+     * good (issue #58). Matches the resend_letter idiom of the original quest
+     * scripts: the button rides in the same script as the reply text. When the
+     * run changes state, endRunning dispatches the new state's LETTER event
+     * and that letter replaces this one.
+     */
+    private rearmLetter(eventType: QuestEventEnum, result?: TaskResult) {
+        if (eventType !== QuestEventEnum.BUTTON) return;
+        if (result && result.nextState && result.nextState !== this.currentState?.name) return;
+
+        const letterTitle = this.currentState?.letterTitle;
+        if (!letterTitle || !this.currentState?.wasStarted) return;
+
+        if (this.src.length > 0) {
+            this.src = this.button(letterTitle) + this.src;
+            return;
+        }
+
+        this.letter(letterTitle);
     }
 
     public async setState(name: string) {
@@ -170,6 +217,7 @@ export abstract class AbstractQuest {
 
     protected letter(title: string) {
         const src = this.button(title);
+        if (this.currentState) this.currentState.letterTitle = title;
         this.skin = QuestSkinEnum.NO_WINDOW;
         this.setStart();
         this.setTitle(this.currentState?.title || this.name);
@@ -180,6 +228,7 @@ export abstract class AbstractQuest {
     protected clearLetter() {
         if (!this.currentState) return;
         this.currentState.wasStarted = false;
+        this.currentState.letterTitle = undefined;
         this.questFlags.set(QuestFlagEnum.ISBEGIN);
     }
 
@@ -207,10 +256,12 @@ export abstract class AbstractQuest {
     }
 
     public unselect(answer: number) {
+        this.shouldSendDone = true;
         this.currentChoicePromise.resolve(answer);
     }
 
     public unpause() {
+        this.shouldSendDone = true;
         this.nextPagePromise.resolve();
     }
 
@@ -221,11 +272,13 @@ export abstract class AbstractQuest {
      */
     public cancel() {
         if (this.status === QuestStatusEnum.SELECT) {
+            this.shouldSendDone = true;
             this.currentChoicePromise.resolve(CLOSE_WINDOW_ANSWER);
             return;
         }
 
         if (this.status === QuestStatusEnum.PAUSE) {
+            this.shouldSendDone = true;
             this.nextPagePromise.resolve();
         }
     }
@@ -336,6 +389,7 @@ export abstract class AbstractQuest {
         this.questFlags.reset();
         if (!this.currentState) return;
         this.currentState.wasStarted = false;
+        this.currentState.letterTitle = undefined;
         this.currentState.title = undefined;
         this.currentState.clockName = undefined;
         this.currentState.clockValue = undefined;

--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -34,10 +34,6 @@ export abstract class AbstractQuest {
     // reaches select()/nextPage() (several awaits in), leaving a window where a
     // second click could start a concurrent run. This flag closes that window.
     private running: boolean = false;
-    // Player interacted with an open quest window during the current run
-    // (answered a select, turned a page, closed the window). Mirrors the
-    // original engine's m_bShouldSendDone: only then is a bare trailing
-    // [DONE] sent, so the client releases that window.
     private shouldSendDone: boolean = false;
     private readonly questFlags: BitFlag = new BitFlag();
 
@@ -125,14 +121,6 @@ export abstract class AbstractQuest {
         return this.currentState?.tasks.filter((routine) => routine.when === event) ?? [];
     }
 
-    /**
-     * Trailing [DONE] policy, mirroring the original engine (SendScript in
-     * questmanager.cpp): send it when there is accumulated text to show, or
-     * when the player interacted with an open quest window during this run
-     * (answer, next page, close) and the client needs a bare [DONE] to release
-     * it. In any other case send nothing — a bare [DONE] ends the client-side
-     * quest script, which is what used to take quest letters down (issue #58).
-     */
     private autoDone() {
         const playerInteracted = this.shouldSendDone;
         this.shouldSendDone = false;
@@ -142,15 +130,6 @@ export abstract class AbstractQuest {
         this.done();
     }
 
-    /**
-     * The client destroys a letter the moment it is clicked (the click and the
-     * BUTTON packet are one action), so a BUTTON run that leaves the quest in
-     * the same state must re-send the [QUESTBUTTON] or the letter is gone for
-     * good (issue #58). Matches the resend_letter idiom of the original quest
-     * scripts: the button rides in the same script as the reply text. When the
-     * run changes state, endRunning dispatches the new state's LETTER event
-     * and that letter replaces this one.
-     */
     private rearmLetter(eventType: QuestEventEnum, result?: TaskResult) {
         if (eventType !== QuestEventEnum.BUTTON) return;
         if (result && result.nextState && result.nextState !== this.currentState?.name) return;

--- a/src/core/domain/quests/decorators/QuestDecorator.ts
+++ b/src/core/domain/quests/decorators/QuestDecorator.ts
@@ -122,6 +122,7 @@ export type State = {
     readonly name: string;
     readonly tasks: ReadonlyArray<QuestTask>;
     wasStarted?: boolean;
+    letterTitle?: string;
     title?: string;
     clockName?: string;
     clockValue?: number;

--- a/test/unit/core/domain/quests/AbstractQuest.test.ts
+++ b/test/unit/core/domain/quests/AbstractQuest.test.ts
@@ -110,14 +110,11 @@ describe('AbstractQuest', () => {
                 return (this as any).nextState('DONE_STATE');
             }
 
-            public async countingTask() {
-                // Counts a kill; produces no script output.
-            }
+            public async countingTask() {}
 
             public async abortableSelectTask() {
                 (this as any).text('Pick one');
                 await (this as any).select(['A', 'B']);
-                // No trailing text: mirrors quests that open a shop or bail out.
             }
         }
 

--- a/test/unit/core/domain/quests/AbstractQuest.test.ts
+++ b/test/unit/core/domain/quests/AbstractQuest.test.ts
@@ -24,10 +24,13 @@ class TestQuest extends AbstractQuest {
 
 const createPlayer = () => {
     let currentQuest: any = null;
+    const scripts: Array<{ skin: number; src: string }> = [];
     return {
         setCurrentQuest: (q: any) => (currentQuest = q),
         getCurrentQuest: () => currentQuest,
-        sendQuestScript: () => {},
+        sendQuestScript: (skin: number, src: string) => scripts.push({ skin, src }),
+        sendQuestInfoPacket: () => {},
+        scripts,
     };
 };
 
@@ -83,6 +86,146 @@ describe('AbstractQuest', () => {
                 await tick();
                 expect(quest.isRunning()).to.be.equal(false);
             }
+        });
+    });
+
+    describe('letter lifecycle and trailing [DONE] (issue #58)', () => {
+        class LetterQuest extends AbstractQuest {
+            constructor(player: any) {
+                super({ player } as any);
+                (this as any).id = 7;
+                (this as any).name = 'LetterQuest';
+            }
+
+            public async letterTask() {
+                (this as any).letter('Hunt Quest');
+            }
+
+            public async describeTask() {
+                (this as any).text('Kill 10 boars');
+            }
+
+            public async describeAndAdvanceTask() {
+                (this as any).text('All done!');
+                return (this as any).nextState('DONE_STATE');
+            }
+
+            public async countingTask() {
+                // Counts a kill; produces no script output.
+            }
+
+            public async abortableSelectTask() {
+                (this as any).text('Pick one');
+                await (this as any).select(['A', 'B']);
+                // No trailing text: mirrors quests that open a shop or bail out.
+            }
+        }
+
+        const buildLetterQuest = () => {
+            const player = createPlayer();
+            const quest = new LetterQuest(player);
+            quest.addState({
+                name: 'HUNT',
+                tasks: [
+                    { when: QuestEventEnum.LETTER, callback: () => quest.letterTask() },
+                    { when: QuestEventEnum.BUTTON, callback: () => quest.describeTask() },
+                    { when: QuestEventEnum.KILL, callback: () => quest.countingTask() },
+                ] as any,
+            });
+            quest.addState({
+                name: 'FINISH',
+                tasks: [
+                    { when: QuestEventEnum.LETTER, callback: () => quest.letterTask() },
+                    { when: QuestEventEnum.BUTTON, callback: () => quest.describeAndAdvanceTask() },
+                ] as any,
+            });
+            quest.addState({ name: 'DONE_STATE', tasks: [] as any });
+            (quest as any).currentState = (quest as any).states.get('HUNT');
+            return { quest, player };
+        };
+
+        it('should not send a bare [DONE] after showing a letter', async () => {
+            const { quest, player } = buildLetterQuest();
+
+            await quest.runState({ eventType: QuestEventEnum.LETTER } as any);
+
+            expect(player.scripts).to.have.lengthOf(1);
+            expect(player.scripts[0].src).to.include('[QUESTBUTTON');
+            expect(player.scripts[0].src).to.not.include('[DONE]');
+        });
+
+        it('should re-arm the letter in the same script as the BUTTON reply', async () => {
+            const { quest, player } = buildLetterQuest();
+            await quest.runState({ eventType: QuestEventEnum.LETTER } as any);
+            player.scripts.length = 0;
+
+            await quest.runState({ eventType: QuestEventEnum.BUTTON } as any);
+
+            expect(player.scripts).to.have.lengthOf(1);
+            const { src } = player.scripts[0];
+            expect(src).to.include('[QUESTBUTTON');
+            expect(src).to.include('Kill 10 boars');
+            expect(src).to.include('[DONE]');
+            expect(src.indexOf('[QUESTBUTTON')).to.be.lessThan(src.indexOf('Kill 10 boars'));
+        });
+
+        it('should not re-arm the letter when the BUTTON task changes state', async () => {
+            const { quest, player } = buildLetterQuest();
+            (quest as any).currentState = (quest as any).states.get('FINISH');
+            await quest.runState({ eventType: QuestEventEnum.LETTER } as any);
+            player.scripts.length = 0;
+
+            await quest.runState({ eventType: QuestEventEnum.BUTTON } as any);
+
+            expect(player.scripts).to.have.lengthOf(1);
+            expect(player.scripts[0].src).to.include('All done!');
+            expect(player.scripts[0].src).to.not.include('[QUESTBUTTON');
+        });
+
+        it('should send nothing for a task with no output and no interaction', async () => {
+            const { quest, player } = buildLetterQuest();
+
+            await quest.runState({ eventType: QuestEventEnum.KILL } as any);
+
+            expect(player.scripts).to.have.lengthOf(0);
+        });
+
+        it('should still send the bare [DONE] that releases an answered window', async () => {
+            const player = createPlayer();
+            const quest = new LetterQuest(player);
+            quest.addState({
+                name: 'START',
+                tasks: [{ when: QuestEventEnum.CLICK, callback: () => quest.abortableSelectTask() }] as any,
+            });
+            (quest as any).currentState = (quest as any).states.get('START');
+
+            quest.run({ eventType: QuestEventEnum.CLICK } as any);
+            await tick();
+            quest.unselect(0);
+            await tick();
+            await tick();
+
+            const last = player.scripts[player.scripts.length - 1];
+            expect(last.src).to.be.equal('[DONE]');
+        });
+
+        it('should re-send the letter when a letter select is closed without an answer', async () => {
+            const { quest, player } = buildLetterQuest();
+            (quest as any).currentState.tasks = [
+                { when: QuestEventEnum.LETTER, callback: () => quest.letterTask() },
+                { when: QuestEventEnum.BUTTON, callback: () => quest.abortableSelectTask() },
+            ];
+            await quest.runState({ eventType: QuestEventEnum.LETTER } as any);
+            player.scripts.length = 0;
+
+            quest.run({ eventType: QuestEventEnum.BUTTON } as any);
+            await tick();
+            quest.cancel();
+            await tick();
+            await tick();
+
+            const rearmed = player.scripts.some((s) => s.src.includes('[QUESTBUTTON'));
+            expect(rearmed).to.be.equal(true);
         });
     });
 });


### PR DESCRIPTION
Closes #58.

## Problem

`AbstractQuest.runState()` appended `[DONE]` to the quest script after **every** task callback. A bare `[DONE]` ends the client-side quest script, so:

- Reading a letter (`BUTTON`) took it down for good — the client destroys the letter button the moment it is clicked (`interfacemodule.py`, `__OnClickQuestButton`), and nothing ever re-sent it.
- Silent tasks (kill counters, letter dispatch, state entry) spammed bare `[DONE]` script packets that could close whatever quest window was open.

## Fix (mirrors the original engine)

Two changes in `AbstractQuest`, both taken from how the original quest engine behaves:

1. **Trailing `[DONE]` policy** (`SendScript()` in `questmanager.cpp`): the auto-`[DONE]` is only sent when there is accumulated text to show, or when the player interacted with an open quest window during the run (answered a select, turned a page, closed the window — tracked like the original's `m_bShouldSendDone`) and the client needs the bare `[DONE]` to release it. In any other case nothing is sent.
2. **Letter re-arm** (the `resend_letter` idiom from the original quest scripts): a `BUTTON` run that leaves the quest in the same state re-sends the `[QUESTBUTTON]` in the same script as the reply text, so the letter survives being read. A state change skips this — the new state's `LETTER` event produces the replacement letter.

## Verified in game

- Hunt Quest letter can be read and re-read any number of times; the icon stays on screen.
- Completing the hunt still pops the reward window and hands over to the next tier's letter.
- Saleswoman shop dialog still closes cleanly and opens the shop (the path that relies on the bare `[DONE]` after an answered select).

## Tests

6 new unit tests covering the letter lifecycle and the `[DONE]` policy; full suite 421 passing.