### PR TITLE
fix: explain why an item cannot be equipped + enforce level limits

### DIFF
--- a/src/core/domain/entities/game/item/Item.ts
+++ b/src/core/domain/entities/game/item/Item.ts
@@ -579,12 +579,15 @@ export default class Item {
             immuneFlags: immuneFlagsBitFlag,
             wearFlags: wearFlagsBitFlag,
             limits: [
+                // items.json uses both bare ("LEVEL") and prefixed ("LIMIT_NONE")
+                // names; splitting on the prefix turned every bare "LEVEL" into
+                // NONE, so no item enforced its level limit.
                 new ItemLimit({
-                    type: itemLimitMapper[`${proto.limit_type0.split('LIMIT_')[1]}`] || ItemLimitTypeEnum.NONE,
+                    type: itemLimitMapper[proto.limit_type0.replace('LIMIT_', '')] || ItemLimitTypeEnum.NONE,
                     value: Number(proto.limit_value0),
                 }),
                 new ItemLimit({
-                    type: itemLimitMapper[`${proto.limit_type1.split('LIMIT_')[1]}`] || ItemLimitTypeEnum.NONE,
+                    type: itemLimitMapper[proto.limit_type1.replace('LIMIT_', '')] || ItemLimitTypeEnum.NONE,
                     value: Number(proto.limit_value1),
                 }),
             ],

--- a/src/core/domain/entities/game/item/Item.ts
+++ b/src/core/domain/entities/game/item/Item.ts
@@ -579,9 +579,6 @@ export default class Item {
             immuneFlags: immuneFlagsBitFlag,
             wearFlags: wearFlagsBitFlag,
             limits: [
-                // items.json uses both bare ("LEVEL") and prefixed ("LIMIT_NONE")
-                // names; splitting on the prefix turned every bare "LEVEL" into
-                // NONE, so no item enforced its level limit.
                 new ItemLimit({
                     type: itemLimitMapper[proto.limit_type0.replace('LIMIT_', '')] || ItemLimitTypeEnum.NONE,
                     value: Number(proto.limit_value0),

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1374,6 +1374,31 @@ export default class Player extends Character {
         );
     }
 
+    /**
+     * Why this player cannot equip the item right now, or undefined when the
+     * item is not equipment at all (no wear flags) or nothing is blocking it.
+     * Mirrors the original's CanEquipNow chat feedback (char_item.cpp), which
+     * answers the level limit; class/gender are covered too so a refusal is
+     * never silent (issue #57).
+     */
+    getEquipFailureReason(item: Item): string | undefined {
+        if (item.getWearFlags().getFlag() < 1) return undefined;
+
+        if (this.getLevel() < item.getLevelLimit()) {
+            return `Your level is too low to equip this item. Required level: ${item.getLevelLimit()}.`;
+        }
+
+        if (item.getAntiFlags().is(this.antiFlagClass)) {
+            return 'Your class cannot use this item.';
+        }
+
+        if (item.getAntiFlags().is(this.antiFlagGender)) {
+            return 'This item cannot be equipped by your gender.';
+        }
+
+        return undefined;
+    }
+
     moveItem({
         fromWindow,
         fromPosition,
@@ -1394,7 +1419,11 @@ export default class Player extends Character {
         if (!this.getInventory().haveAvailablePosition(toPosition, item.getSize())) return;
 
         if (this.getInventory().isEquipmentPosition(toPosition)) {
-            if (!this.isWearable(item)) return;
+            if (!this.isWearable(item)) {
+                const reason = this.getEquipFailureReason(item);
+                if (reason) this.chat({ messageType: ChatMessageTypeEnum.INFO, message: reason });
+                return;
+            }
             if (!this.getInventory().isValidSlot(item, toPosition)) return;
         }
 

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1374,13 +1374,6 @@ export default class Player extends Character {
         );
     }
 
-    /**
-     * Why this player cannot equip the item right now, or undefined when the
-     * item is not equipment at all (no wear flags) or nothing is blocking it.
-     * Mirrors the original's CanEquipNow chat feedback (char_item.cpp), which
-     * answers the level limit; class/gender are covered too so a refusal is
-     * never silent (issue #57).
-     */
     getEquipFailureReason(item: Item): string | undefined {
         if (item.getWearFlags().getFlag() < 1) return undefined;
 

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -41,9 +41,6 @@ export default class UseItemService {
         if (player.isWearable(item)) {
             await this.useWearableItem(player, item, position, window);
         } else {
-            // Equipment the player cannot wear yet must say why instead of
-            // falling through to the non-wearable routing, which has no case
-            // for weapons/armor and used to refuse silently (issue #57).
             const equipFailureReason = player.getEquipFailureReason(item);
             if (equipFailureReason) {
                 player.chat({

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -41,6 +41,18 @@ export default class UseItemService {
         if (player.isWearable(item)) {
             await this.useWearableItem(player, item, position, window);
         } else {
+            // Equipment the player cannot wear yet must say why instead of
+            // falling through to the non-wearable routing, which has no case
+            // for weapons/armor and used to refuse silently (issue #57).
+            const equipFailureReason = player.getEquipFailureReason(item);
+            if (equipFailureReason) {
+                player.chat({
+                    messageType: ChatMessageTypeEnum.INFO,
+                    message: equipFailureReason,
+                });
+                return;
+            }
+
             await this.useNonWearableItem(player, item);
         }
     }

--- a/test/unit/core/domain/entities/game/item/Item.test.ts
+++ b/test/unit/core/domain/entities/game/item/Item.test.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import Item from '@/core/domain/entities/game/item/Item';
+import { ItemLimitTypeEnum } from '@/core/enum/ItemLimitTypeEnum';
+
+const baseProto = {
+    vnum: '479',
+    name: 'Dragon Tooth Blade +9',
+    item_type: 'ITEM_WEAPON',
+    sub_type: 'WEAPON_SWORD',
+    size: '2',
+    anti_flag: 'ANTI_MUSA | ANTI_ASSASSIN | ANTI_MUDANG | ANTI_SELL',
+    flag: 'ITEM_TUNABLE',
+    item_wear: 'WEAR_WEAPON',
+    immune: 'NONE',
+    gold: '120000',
+    shop_buy_price: '515000',
+    refine: '0',
+    refineset: '0',
+    magic_pct: '0',
+    limit_type0: 'LEVEL',
+    limit_value0: '105',
+    limit_type1: 'LIMIT_NONE',
+    limit_value1: '0',
+    addon_type0: 'APPLY_ATT_SPEED',
+    addon_value0: '15',
+    addon_type1: 'APPLY_ATTBONUS_HUMAN',
+    addon_value1: '15',
+    addon_type2: 'APPLY_ATTBONUS_MONSTER',
+    addon_value2: '5',
+    value0: '0',
+    value1: '149',
+    value2: '211',
+    value3: '116',
+    value4: '164',
+    value5: '250',
+    specular: '100',
+    socket: '3',
+    attu_addon: '0',
+};
+
+describe('Item', () => {
+    describe('create (proto parsing)', () => {
+        it('should parse a bare LEVEL limit type (items.json does not prefix it)', () => {
+            const item = Item.create(baseProto as any, 1);
+
+            expect(item.getLevelLimit()).to.be.equal(105);
+        });
+
+        it('should parse the prefixed LIMIT_NONE limit type as no limit', () => {
+            const item = Item.create(
+                { ...baseProto, limit_type0: 'LIMIT_NONE', limit_value0: '0' } as any,
+                1,
+            );
+
+            expect(item.getLevelLimit()).to.be.equal(0);
+            expect(item.getLimits().every((limit) => limit.type === ItemLimitTypeEnum.NONE)).to.be.equal(true);
+        });
+    });
+});

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -25,6 +25,7 @@ describe('UseItemService', () => {
             sendItemAdded: sinon.stub(),
             chat: sinon.stub(),
             isWearable: sinon.stub(),
+            getEquipFailureReason: sinon.stub(),
         };
     });
 
@@ -167,5 +168,36 @@ describe('UseItemService', () => {
         expect(inventoryStub.addItemAt.calledWith(mockItem, 4)).to.be.true;
         expect(playerStub.sendItemRemoved.calledWith({ window: WindowTypeEnum.EQUIPMENT, position: 4 })).to.be.true;
         expect(playerStub.sendItemRemoved.calledWith({ window: WindowTypeEnum.INVENTORY, position: 2 })).to.be.true;
+    });
+
+    it('should explain why equipment the player cannot wear was refused (issue #57)', async () => {
+        const mockItem = { getType: sinon.stub() };
+        playerStub.getItem.returns(mockItem);
+        playerStub.isWearable.returns(false);
+        playerStub.getEquipFailureReason.returns('Your level is too low to equip this item. Required level: 105.');
+
+        await service.execute(playerStub, 1, 2);
+
+        expect(
+            playerStub.chat.calledOnceWith({
+                messageType: ChatMessageTypeEnum.INFO,
+                message: 'Your level is too low to equip this item. Required level: 105.',
+            }),
+        ).to.be.true;
+        // Refusal ends the flow: nothing is routed to the non-wearable handlers.
+        expect(mockItem.getType.notCalled).to.be.true;
+        expect(playerStub.getInventory.notCalled).to.be.true;
+    });
+
+    it('should still route non-equipment items to the non-wearable handlers without chatting', async () => {
+        const mockItem = { getType: sinon.stub().returns(0), getSubType: sinon.stub().returns(0) };
+        playerStub.getItem.returns(mockItem);
+        playerStub.isWearable.returns(false);
+        playerStub.getEquipFailureReason.returns(undefined);
+
+        await service.execute(playerStub, 1, 2);
+
+        expect(playerStub.chat.notCalled).to.be.true;
+        expect(mockItem.getType.called).to.be.true;
     });
 });

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -184,7 +184,6 @@ describe('UseItemService', () => {
                 message: 'Your level is too low to equip this item. Required level: 105.',
             }),
         ).to.be.true;
-        // Refusal ends the flow: nothing is routed to the non-wearable handlers.
         expect(mockItem.getType.notCalled).to.be.true;
         expect(playerStub.getInventory.notCalled).to.be.true;
     });


### PR DESCRIPTION
Closes #57.

## What

Two fixes, found in that order while verifying in game:

1. **Silent refusal (#57):** right-clicking equipment the player cannot wear routed to the non-wearable item handlers, which have no case for weapons/armor, so nothing happened at all. Dragging the item onto an equipment slot was equally silent. New `Player.getEquipFailureReason` mirrors the original's `CanEquipNow` chat feedback (`char_item.cpp`): the level limit answers with the required level, and class/gender anti-flags are covered too so no refusal path stays silent. Both the use-item path and the drag-to-slot path now send the reason as an INFO chat message.

2. **Level limits were never parsed:** `items.json` writes the level limit type as bare `"LEVEL"` while other limit types carry the `LIMIT_` prefix (`"LIMIT_NONE"`). The parser split on `"LIMIT_"`, so every one of the **2958 level-limited protos** fell back to `NONE` — `getLevelLimit()` returned 0 and any item could be equipped at any level. Found because the new level message never fired in game: with the limit parsed as 0, a Sura at level 62 passed every `isWearable` check for a level-105 Sura blade. Fixed by stripping the optional prefix instead.

## Verified in game (level 62 Sura, Dragon Tooth Blade +9, level 105)

- Right-click: `Your level is too low to equip this item. Required level: 105.` in chat, item stays unequipped.
- Drag onto the weapon slot: same message.
- A level-appropriate weapon still equips normally; non-equipment items (potions etc.) still route to their handlers with no spurious chat.

## Tests

4 new unit tests (refusal message + non-wearable routing in `UseItemService`, bare/prefixed limit parsing in `Item.create`); suite at 419 passing.