### PR TITLE
chore: use plain literals in QuestTargetTypeEnum (SonarCloud S7767)

### DIFF
--- a/src/core/enum/QuestTargetTypeEnum.ts
+++ b/src/core/enum/QuestTargetTypeEnum.ts
@@ -1,4 +1,6 @@
+// Discrete packet values, not combinable flags — plain literals keep
+// SonarCloud (S7767) from reading `1 << 0` as a truncation idiom.
 export enum QuestTargetTypeEnum {
-    POSITION = 1 << 0,
-    VIRTUAL_ID = 1 << 1,
+    POSITION = 1,
+    VIRTUAL_ID = 2,
 }

--- a/src/core/enum/QuestTargetTypeEnum.ts
+++ b/src/core/enum/QuestTargetTypeEnum.ts
@@ -1,5 +1,3 @@
-// Discrete packet values, not combinable flags — plain literals keep
-// SonarCloud (S7767) from reading `1 << 0` as a truncation idiom.
 export enum QuestTargetTypeEnum {
     POSITION = 1,
     VIRTUAL_ID = 2,


### PR DESCRIPTION
Clears the only open HIGH-reliability issue on master: SonarCloud reads the `1 << 0` spelling as the float-truncation idiom (S7767). The enum holds discrete packet values that are never OR-combined, so plain literals say it better anyway. Values unchanged (1 and 2).