### PR TITLE
Security: reject item-drop counts above the stack (fix #69)

### DIFF
--- a/src/game/app/service/DropItemService.ts
+++ b/src/game/app/service/DropItemService.ts
@@ -32,6 +32,8 @@ export default class DropItemService {
         if (!item) return;
         if (player.isItemLockedInPrivateShop(item)) return;
 
+        if (!Number.isInteger(count) || count <= 0 || count > item.getCount()) return;
+
         if (count === item.getCount()) {
             player.getInventory().removeItem(position, item.getSize());
             player.sendItemRemoved({

--- a/test/integration/game/itemDropSecurity.test.ts
+++ b/test/integration/game/itemDropSecurity.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #69: a single item-drop packet with a count
+ * larger than the stack must not be able to crash the whole game server.
+ *
+ * This drives real, potentially-malformed packets through an in-process game
+ * server — the same technique used to originally confirm the exploit — and is a
+ * template for the other security issues (#64-#68).
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item drop count validation (issue #69)', function () {
+    this.timeout(30000);
+
+    const USER = 'dropx_test';
+    const POTION = 27001;
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('rejects a drop whose count exceeds the stack, without crashing the server', async () => {
+        session = await harness.login({ username: USER });
+
+        // Give ourselves a stack of 5 potions (lands at window 1, position 0).
+        session.command(`/item ${POTION} 5`);
+        await session.settle(600);
+        const before = await session.dbItems(USER, POTION);
+        expect(before, 'setup: one stack of 5 potions').to.deep.equal([{ count: 5, window: 1, position: 0 }]);
+
+        session.flush();
+
+        // The exploit: drop 200 out of a stack of 5.
+        session.drop(1, 0, 0, 200);
+        await session.settle(800);
+
+        // 1) The server must still be up.
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+
+        // 2) No unhandled rejection (the RangeError -> process.exit chain).
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped a packet handler').to.deep.equal([]);
+
+        // 3) The stack must be untouched (or validly reduced) — never negative,
+        //    never duplicated onto the ground.
+        const after = await session.dbItems(USER, POTION);
+        expect(after, 'stack unchanged after a rejected drop').to.deep.equal([{ count: 5, window: 1, position: 0 }]);
+    });
+});

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -1,0 +1,234 @@
+import { createConnection, Socket } from 'node:net';
+import GameApplication from '@/game/app/GameApplication';
+import { container } from '@/game/Container';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import BufferReader from '@/core/interface/networking/buffer/BufferReader';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
+
+/**
+ * A "malicious client" test harness: it speaks the raw game protocol against a
+ * real, in-process game server and can send arbitrary — including malformed —
+ * packets, then observe how the server reacted (responses, persisted state, and
+ * whether it stayed alive).
+ *
+ * It deliberately boots GameApplication directly rather than through main.ts, so
+ * the process-level `unhandledRejection -> process.exit` handler is NOT
+ * installed — otherwise a single DoS reproduction would tear down the whole test
+ * runner. Instead the harness installs its own listener and exposes the captured
+ * rejections for assertions.
+ *
+ * Requires MySQL + Redis (docker) and a free game port (stop `dev:game` first).
+ */
+export default class AttackHarness {
+    private app!: GameApplication;
+    private readonly rejections: unknown[] = [];
+    private readonly onRejection = (reason: unknown) => this.rejections.push(reason);
+    private readonly seededAccounts: Array<string> = [];
+
+    private get db() {
+        return container.resolve<any>('databaseManager');
+    }
+    private get cache() {
+        return container.resolve<any>('cacheProvider');
+    }
+    private get host() {
+        return container.resolve<any>('config').SERVER_ADDRESS as string;
+    }
+    private get port() {
+        return Number(container.resolve<any>('config').SERVER_PORT);
+    }
+
+    async start() {
+        // Capture unhandled rejections instead of letting Node's default handler
+        // crash the runner. This is the whole point of owning the server here.
+        process.on('unhandledRejection', this.onRejection);
+        this.app = new GameApplication(container.cradle as any);
+        await this.app.start();
+        return this;
+    }
+
+    async stop() {
+        for (const username of this.seededAccounts) {
+            await this.db.getConnection().query('DELETE FROM auth.account WHERE username = ?', [username]);
+            await this.db.getConnection().query('DELETE FROM game.player WHERE name = ?', [username]);
+        }
+        await this.app.close();
+        process.off('unhandledRejection', this.onRejection);
+    }
+
+    /** Unhandled rejections seen since start (e.g. the RangeError from issue #69). */
+    capturedRejections() {
+        return this.rejections;
+    }
+
+    /**
+     * True while the game server still accepts TCP connections — probed the same
+     * way an external observer sees it, rather than by reaching into internals.
+     * This is exactly the signal that flipped to false when issue #69 crashed the
+     * real server (port 13001 stopped listening).
+     */
+    isServerAlive(): Promise<boolean> {
+        return new Promise((resolve) => {
+            const probe = createConnection({ host: this.host, port: this.port });
+            probe.on('connect', () => {
+                probe.destroy();
+                resolve(true);
+            });
+            probe.on('error', () => resolve(false));
+        });
+    }
+
+    /**
+     * Seed an account + level-99 character, inject a valid session token into the
+     * cache (bypassing the auth server), then connect and walk the enter-game
+     * handshake. Returns a session bound to that character.
+     */
+    async login({ username = 'attacker', x = 958870, y = 272760 } = {}) {
+        const hash = '$2b$05$KXeREc2TNuUR6IcgzUiX4.WA/0i3Yd3WpUHMtAcQi1ojWRdeQ9ExS'; // 'admin'
+        await this.db.getConnection().query('DELETE FROM auth.account WHERE username = ?', [username]);
+        const [res] = await this.db
+            .getConnection()
+            .query(
+                `INSERT INTO auth.account (deleteCode, email, password, accountStatusId, username) VALUES (?,?,?,?,?)`,
+                ['1234567', `${username}@test.com`, hash, 1, username],
+            );
+        const accountId = res.insertId;
+        await this.db.getConnection().query('DELETE FROM game.player WHERE name = ?', [username]);
+        await this.db.getConnection().query(
+            `INSERT INTO game.player (accountId, empire, playerClass, skillGroup, playTime, level, experience,
+                gold, st, ht, dx, iq, positionX, positionY, health, mana, stamina, bodyPart, hairPart, name,
+                givenStatusPoints, availableStatusPoints, slot)
+             VALUES (?, 2, 4, 0, 9105, 99, 0, 12038002, 17, 107, 12, 6, ?, ?, 15950, 5570, 1000, 0, 0, ?, 396, 192, 0)`,
+            [accountId, x, y, username],
+        );
+        this.seededAccounts.push(username);
+
+        // The auth server would have written this; we inject it directly.
+        const key = 0x0badf00d;
+        await this.cache.set(
+            CacheKeyGenerator.createTokenKey(String(key)),
+            JSON.stringify({ username, accountId }),
+            300,
+        );
+
+        const session = new AttackSession(this.host, this.port, this.db);
+        await session.enterGame(username, key);
+        return session;
+    }
+}
+
+/** One connected, in-game client used to fire packets and inspect the result. */
+export class AttackSession {
+    private client!: Socket;
+    private buffer: Buffer = Buffer.from([]);
+
+    constructor(
+        private readonly host: string,
+        private readonly port: number,
+        private readonly db: any,
+    ) {}
+
+    private connect(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.client = createConnection({ host: this.host, port: this.port }, () => resolve());
+            this.client.on('data', (d) => (this.buffer = Buffer.concat([this.buffer, d])));
+            this.client.on('error', reject);
+        });
+    }
+
+    private next(length: number): Promise<Buffer> {
+        return new Promise((resolve) => {
+            const tick = () => {
+                if (this.buffer.length >= length) {
+                    const out = this.buffer.subarray(0, length);
+                    this.buffer = this.buffer.subarray(length);
+                    return resolve(out);
+                }
+                setTimeout(tick, 20);
+            };
+            tick();
+        });
+    }
+
+    async enterGame(username: string, token: number) {
+        await this.connect();
+
+        await this.next(2); // HANDSHAKE state
+        const hs = await this.next(13);
+        const r = new BufferReader();
+        r.setBuffer(hs);
+        const id = r.readUInt32LE();
+        const time = r.readUInt32LE();
+        const delta = r.readUInt32LE();
+        const reply = new BufferWriter(PacketHeaderEnum.HANDSHAKE, 13);
+        this.send(reply.writeUint32LE(id).writeUint32LE(time).writeUint32LE(delta).getBuffer());
+
+        await this.next(2); // LOGIN state
+        const auth = new BufferWriter(PacketHeaderEnum.TOKEN, 52);
+        auth.writeString(username, 31)
+            .writeUint32LE(token)
+            .writeUint32LE(0)
+            .writeUint32LE(0)
+            .writeUint32LE(0)
+            .writeUint32LE(0);
+        this.send(auth.getBuffer());
+
+        await this.next(3); // empire
+        await this.next(331); // player list
+        const select = new BufferWriter(PacketHeaderEnum.SELECT_CHARACTER, 2);
+        this.send(select.writeUint8(0).getBuffer());
+
+        await this.next(2); // LOADING state
+        await this.next(46); // character detail
+        this.send(new BufferWriter(PacketHeaderEnum.ENTER_GAME, 1).getBuffer());
+        await this.settle(600);
+        this.flush();
+    }
+
+    /** Fire a raw command through the chat channel (e.g. "/item 27001 5"). */
+    command(message: string) {
+        const size = 1 + 2 + 1 + message.length + 1;
+        const w = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
+        this.send(w.writeUint16LE(size).writeUint8(0).writeString(message, message.length + 1).getBuffer());
+    }
+
+    /** Fire a raw item-drop packet (window u8, position u16, gold u32, count u8). */
+    drop(window: number, position: number, gold: number, count: number) {
+        const w = new BufferWriter(PacketHeaderEnum.ITEM_DROP, 9);
+        this.send(w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer());
+    }
+
+    send(buffer: Buffer) {
+        this.client.write(buffer);
+    }
+
+    /** Wait for the server to finish processing what we just sent. */
+    settle(ms = 300) {
+        return new Promise((r) => setTimeout(r, ms));
+    }
+
+    flush() {
+        this.buffer = Buffer.from([]);
+    }
+
+    received() {
+        return this.buffer;
+    }
+
+    /** The persisted stacks of a given proto for this session's character. */
+    async dbItems(username: string, protoId: number) {
+        const [rows] = await this.db
+            .getConnection()
+            .query(
+                `SELECT i.count, i.window, i.position FROM game.item i
+                 JOIN game.player p ON p.id = i.ownerId WHERE p.name = ? AND i.protoId = ?`,
+                [username, protoId],
+            );
+        return rows as Array<{ count: number; window: number; position: number }>;
+    }
+
+    async close() {
+        return new Promise<void>((resolve) => this.client.end(() => resolve()));
+    }
+}


### PR DESCRIPTION
## What

Fixes #69 — a single crafted item-drop packet can crash the whole game server (remote DoS).

`DropItemService.execute` trusted the client-supplied `count`. Dropping more than the stack holds (e.g. 200 out of a stack of 5) ran `setCount(stack - count)` into a negative value, and the drop chain then threw a `RangeError` that propagated as an `unhandledRejection`, tripping the process-level `process.exit` handler — the whole server goes down for every connected player.

## Fix

Reject non-positive counts and counts greater than the stack before the item is mutated:

```ts
if (!Number.isInteger(count) || count <= 0 || count > item.getCount()) return;
```

## Test

Adds an in-process "malicious-client" harness (`test/support/AttackSession.ts`) that boots `GameApplication` directly and speaks the raw protocol over a socket, so it can send arbitrary or malformed packets and observe how the server reacts. It deliberately skips `main.ts` so the `unhandledRejection -> process.exit` handler is not