### PR TITLE
Security: validate distance and ownership on item pickup (fix #66)

### DIFF
--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -5,6 +5,9 @@ import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { IItemRepository } from '@/core/domain/repository/IItemRepository';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
+import MathUtil from '@/core/domain/util/MathUtil';
+
+const MAX_PICKUP_DISTANCE = 300;
 
 export default class PickupItemService {
     private readonly world: World;
@@ -29,20 +32,20 @@ export default class PickupItemService {
         const droppedItem = this.entityManager.getEntity<DroppedItem>(virtualId);
 
         if (!droppedItem) return;
+        if (droppedItem.getArea() !== player.getArea()) return;
 
-        //TODO: validate id the dropped item is in the same map, and validate distance (avoid hacking)
+        const distance = MathUtil.calcDistance(
+            player.getPositionX(),
+            player.getPositionY(),
+            droppedItem.getPositionX(),
+            droppedItem.getPositionY(),
+        );
+
+        if (distance > MAX_PICKUP_DISTANCE) return;
 
         const item = droppedItem.getItem();
         const count = droppedItem.getCount();
         const ownerName = droppedItem.getOwnerName();
-
-        const isGold = item.getId() === 1;
-
-        if (isGold) {
-            player.addPoint(PointsEnum.GOLD, Number(count));
-            this.world.despawn(droppedItem);
-            return;
-        }
 
         const canPickup = ownerName === player.getName() || !ownerName;
 
@@ -51,6 +54,14 @@ export default class PickupItemService {
                 messageType: ChatMessageTypeEnum.INFO,
                 message: '[SYSTEM] This item is not yours',
             });
+            return;
+        }
+
+        const isGold = item.getId() === 1;
+
+        if (isGold) {
+            player.addPoint(PointsEnum.GOLD, Number(count));
+            this.world.despawn(droppedItem);
             return;
         }
 

--- a/test/integration/game/itemPickupSecurity.test.ts
+++ b/test/integration/game/itemPickupSecurity.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #66: picking an item up off the ground must be
+ * validated against the picker's position and ownership, not just the virtual id
+ * the client sends. Virtual ids are sequential, so an attacker can name an item
+ * they were never shown.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item pickup validation (issue #66)', function () {
+    this.timeout(60000);
+
+    const OWNER = 'pickowner_test';
+    const THIEF = 'pickthief_test';
+    const POTION = 27001;
+    const X = 958870;
+    const Y = 272760;
+    const FAR = 2000; // well beyond the 300 pickup range, still the same map
+
+    let harness: AttackHarness;
+    let owner: AttackSession;
+    let thief: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await owner?.close();
+        await thief?.close();
+        await harness?.stop();
+    });
+
+    it('ignores a pickup sent from out of range, and still allows the owner nearby', async () => {
+        owner = await harness.login({ username: OWNER, x: X, y: Y });
+        thief = await harness.login({ username: THIEF, x: X + FAR, y: Y });
+
+        owner.command(`/item ${POTION} 5`);
+        await owner.settle(600);
+
+        owner.drop(1, 0, 0, 5);
+        await owner.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the item reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        // Both players must share an area, otherwise the map check — not the
+        // distance check — would be what rejects the pickup.
+        expect(
+            harness.findPlayer(THIEF)?.getArea(),
+            'setup: attacker is on the same map, only further away',
+        ).to.equal(harness.findPlayer(OWNER)?.getArea());
+
+        thief.pickup(virtualId);
+        await thief.settle(600);
+
+        expect(harness.findDroppedItem()?.getVirtualId(), 'item still on the ground after a far pickup').to.equal(
+            virtualId,
+        );
+        expect(await thief.dbItems(THIEF, POTION), 'attacker received nothing').to.deep.equal([]);
+
+        // Positive control: the same packet from the owner standing on it works,
+        // so the rejection above was the distance and not a broken flow.
+        owner.pickup(virtualId);
+        await owner.settle(600);
+
+        expect(harness.findDroppedItem(), 'owner nearby picked it up').to.equal(undefined);
+    });
+
+    // The gold half of #66 is covered by the PickupItemService unit tests: gold
+    // cannot reach the ground here, because dropping it throws inside the area
+    // spawn queue (the gold "item" is a plain object without getId).
+});

--- a/test/setup.integration.ts
+++ b/test/setup.integration.ts
@@ -1,11 +1,14 @@
 import AuthApplication from '@/auth/app/AuthApplication';
 import { container } from '@/auth/Container';
+import AttackHarness from './support/AttackSession';
 const app = new AuthApplication(container.cradle);
 
 before(async () => {
     await app.start();
 });
 
-after(async () => {
+after(async function () {
+    this.timeout(30000);
+    await AttackHarness.shutdown();
     await app.close();
 });

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -5,6 +5,8 @@ import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
 import BufferReader from '@/core/interface/networking/buffer/BufferReader';
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
 
 /**
  * A "malicious client" test harness: it speaks the raw game protocol against a
@@ -21,6 +23,14 @@ import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
  * Requires MySQL + Redis (docker) and a free game port (stop `dev:game` first).
  */
 export default class AttackHarness {
+    /**
+     * The game container is a module-level singleton, so its database pool and
+     * cache client can only be opened once per process. The server is therefore
+     * booted on the first start() and shared by every spec file; shutdown()
+     * closes it once, from the root hook in setup.integration.ts.
+     */
+    private static shared: AttackHarness | null = null;
+
     private app!: GameApplication;
     private readonly rejections: unknown[] = [];
     private readonly onRejection = (reason: unknown) => this.rejections.push(reason);
@@ -40,26 +50,65 @@ export default class AttackHarness {
     }
 
     async start() {
+        if (AttackHarness.shared) return AttackHarness.shared;
+
         // Capture unhandled rejections instead of letting Node's default handler
         // crash the runner. This is the whole point of owning the server here.
         process.on('unhandledRejection', this.onRejection);
         this.app = new GameApplication(container.cradle as any);
         await this.app.start();
+        AttackHarness.shared = this;
         return this;
     }
 
+    /** Drops the accounts this spec seeded; the server stays up for the next one. */
     async stop() {
         for (const username of this.seededAccounts) {
             await this.db.getConnection().query('DELETE FROM auth.account WHERE username = ?', [username]);
             await this.db.getConnection().query('DELETE FROM game.player WHERE name = ?', [username]);
         }
-        await this.app.close();
-        process.off('unhandledRejection', this.onRejection);
+        this.seededAccounts.length = 0;
+        this.rejections.length = 0;
+    }
+
+    static async shutdown() {
+        const harness = AttackHarness.shared;
+        if (!harness) return;
+
+        await harness.app.close();
+        process.off('unhandledRejection', harness.onRejection);
+        AttackHarness.shared = null;
     }
 
     /** Unhandled rejections seen since start (e.g. the RangeError from issue #69). */
     capturedRejections() {
         return this.rejections;
+    }
+
+    private get entityManager() {
+        return container.resolve<any>('entityManager');
+    }
+
+    /**
+     * Every live entity in the world. Tests use this to learn virtual ids the
+     * attacker is not supposed to know — which is exactly the attacker's own
+     * position, since virtual ids are sequential and trivially guessable.
+     */
+    private entities(): Array<any> {
+        return [...this.entityManager.entities.values()];
+    }
+
+    findMonster(): Monster | undefined {
+        return this.entities().find((entity) => entity instanceof Monster);
+    }
+
+    /** The most recently spawned ground item, so earlier specs cannot shadow it. */
+    findDroppedItem(): DroppedItem | undefined {
+        return this.entities().findLast((entity) => entity instanceof DroppedItem);
+    }
+
+    findPlayer(name: string) {
+        return this.entities().find((entity) => entity?.getName?.() === name);
     }
 
     /**
@@ -197,6 +246,18 @@ export class AttackSession {
     drop(window: number, position: number, gold: number, count: number) {
         const w = new BufferWriter(PacketHeaderEnum.ITEM_DROP, 9);
         this.send(w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer());
+    }
+
+    /** Fire a raw item-pickup packet for an arbitrary virtual id. */
+    pickup(virtualId: number) {
+        const w = new BufferWriter(PacketHeaderEnum.ITEM_PICKUP, 5);
+        this.send(w.writeUint32LE(virtualId).getBuffer());
+    }
+
+    /** Fire a raw attack packet at an arbitrary virtual id. */
+    attack(virtualId: number, attackType = 0) {
+        const w = new BufferWriter(PacketHeaderEnum.ATTACK, 8);
+        this.send(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
     }
 
     send(buffer: Buffer) {

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -6,6 +6,17 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('PickupItemService', function () {
+    const AREA = { name: 'area1' };
+    const OTHER_AREA = { name: 'area2' };
+    const POSITION = { x: 1000, y: 1000 };
+
+    /** Stubs the position/area getters every pickup goes through. */
+    const atPosition = (area: unknown, x: number, y: number) => ({
+        getArea: sinon.stub().returns(area),
+        getPositionX: sinon.stub().returns(x),
+        getPositionY: sinon.stub().returns(y),
+    });
+
     let worldMock;
     let itemRepositoryMock;
     let entityManagerMock: any;
@@ -38,11 +49,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(true),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
                 getCount: sinon.stub().returns(100),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -64,11 +77,13 @@ describe('PickupItemService', function () {
                 addItemStacking: sinon.stub().returns({ updated: [], inserted: itemMock }),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns(itemMock),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -86,11 +101,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(false),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -105,6 +122,75 @@ describe('PickupItemService', function () {
             ).to.be.true;
             expect(worldMock.despawn.called).to.be.false;
             expect(itemRepositoryMock.create.called).to.be.false;
+        });
+
+        it('should not pick up an item that is out of range (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x + 1000, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not pick up an item that is in another area (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(OTHER_AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not give gold dropped by someone else (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItem: sinon.stub().returns(true),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
+                getCount: sinon.stub().returns(100),
+                getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addPoint.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
         });
 
         it('should do nothing if the dropped item is not found', async function () {


### PR DESCRIPTION
## What

Fixes #66. Follows #70, reusing the harness it introduced.

`PickupItemService` resolved the ground item straight from the virtual id the client sent, with no position check at all — the `//TODO: validate id the dropped item is in the same map, and validate distance` this replaces. Virtual ids are sequential, so a crafted packet can name an item on the other side of the map and take it without ever having seen it.

Gold went further: the gold branch returned before the ownership check, so a bystander could take a drop belonging to someone else.

## Fix

Validate the way the original does (`CItem::DistanceValid`, char_item.cpp `PickupItem`): the item must be in the picker's area and within 300 units. The ownership check now runs before the gold branch, so it covers every ground item.

### One test-infra commit rides along

The harness merged in #70 boots a game server per spec file. That works with one spec, but the game container is a module-level singleton — its DB pool and Redis client can only open once per process — so the second spec file fails with `EADDRINUSE`, then `Socket already opened` / `Pool is closed`. The first commit here boots once and shares, and closes it from the root hook.

## Test

Unit tests cover out-of-range, wrong-area, and gold-owned-by-someone-else. An integration test drives it end to end: an attacker 2000 units away sends the pickup packet for an item they were never shown and the item stays on the ground; the owner standing on it then picks it up, so the rejection is the distance and not a broken flow.

`npm run test:unit` (428) and `npm run test:integration` (4) are green.