### PR TITLE
Security: enforce the real melee attack range (fix #68)

### DIFF
--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
@@ -1,4 +1,5 @@
 import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
 import Logger from '@/core/infra/logger/Logger';
 import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
 import { ItemSubTypeEnum } from '@/core/enum/ItemSubTypeEnum';
@@ -30,7 +31,8 @@ const weaponResistanceMapper: { [key in ItemWeaponSubTypeEnum]: MobResistEnum } 
     [ItemWeaponSubTypeEnum.WEAPON_ARROW]: MobResistEnum.BOW,
 };
 
-const MAX_DISTANCE = 500; //TODO: this should be calculated by player weapon, hackers can use this fixed value to attack with 500 of range for daggers, sword, bell, fan etc
+const MAX_DISTANCE = 300;
+const MOB_ATTACK_RANGE_TOLERANCE = 1.15;
 
 export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy<Monster> {
     private readonly logger: Logger;
@@ -167,7 +169,12 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
             victim.getPositionY(),
         );
 
-        if (distance > MAX_DISTANCE) {
+        const maxDistance =
+            victim.getBattleType() === BattleTypeEnum.MELEE
+                ? Math.max(MAX_DISTANCE, victim.getAttackRange() * MOB_ATTACK_RANGE_TOLERANCE)
+                : MAX_DISTANCE;
+
+        if (distance > maxDistance) {
             this.logger.info(`[PlayerBattle] Very far from the victim.`);
             return;
         }

--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -5,6 +5,9 @@ import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { IItemRepository } from '@/core/domain/repository/IItemRepository';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
+import MathUtil from '@/core/domain/util/MathUtil';
+
+const MAX_PICKUP_DISTANCE = 300;
 
 export default class PickupItemService {
     private readonly world: World;
@@ -29,20 +32,20 @@ export default class PickupItemService {
         const droppedItem = this.entityManager.getEntity<DroppedItem>(virtualId);
 
         if (!droppedItem) return;
+        if (droppedItem.getArea() !== player.getArea()) return;
 
-        //TODO: validate id the dropped item is in the same map, and validate distance (avoid hacking)
+        const distance = MathUtil.calcDistance(
+            player.getPositionX(),
+            player.getPositionY(),
+            droppedItem.getPositionX(),
+            droppedItem.getPositionY(),
+        );
+
+        if (distance > MAX_PICKUP_DISTANCE) return;
 
         const item = droppedItem.getItem();
         const count = droppedItem.getCount();
         const ownerName = droppedItem.getOwnerName();
-
-        const isGold = item.getId() === 1;
-
-        if (isGold) {
-            player.addPoint(PointsEnum.GOLD, Number(count));
-            this.world.despawn(droppedItem);
-            return;
-        }
 
         const canPickup = ownerName === player.getName() || !ownerName;
 
@@ -51,6 +54,14 @@ export default class PickupItemService {
                 messageType: ChatMessageTypeEnum.INFO,
                 message: '[SYSTEM] This item is not yours',
             });
+            return;
+        }
+
+        const isGold = item.getId() === 1;
+
+        if (isGold) {
+            player.addPoint(PointsEnum.GOLD, Number(count));
+            this.world.despawn(droppedItem);
             return;
         }
 

--- a/test/integration/game/attackRangeSecurity.test.ts
+++ b/test/integration/game/attackRangeSecurity.test.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #68: the melee attack range must be enforced
+ * server side. The victim is resolved from a global virtual id lookup, so an
+ * attacker can name a monster anywhere in the world and hit it from off screen
+ * if the range check is too permissive.
+ *
+ * A landed hit is asserted through the damage message the server sends back to
+ * the attacker rather than through the monster's health, which regenerates on a
+ * timer and would race the assertion.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — melee attack range (issue #68)', function () {
+    this.timeout(60000);
+
+    const SNIPER = 'sniper_test';
+    const BRAWLER = 'brawler_test';
+    const DAMAGE_MESSAGE = 'your damage is';
+    const OUT_OF_RANGE = 1500;
+
+    let harness: AttackHarness;
+    let sniper: AttackSession;
+    let brawler: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await sniper?.close();
+        await brawler?.close();
+        await harness?.stop();
+    });
+
+    it('ignores a melee attack from out of range, and still lands one up close', async () => {
+        // Mobs reach the world through the area spawn queue, so it takes a few
+        // ticks before there is a live one to hit.
+        let monster = harness.findMonster();
+        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            monster = harness.findMonster();
+        }
+
+        expect(monster, 'setup: the world spawned a monster to attack').to.not.equal(undefined);
+        expect(monster!.getPoint(PointsEnum.HEALTH), 'setup: the monster is alive').to.be.greaterThan(0);
+
+        const virtualId = monster!.getVirtualId();
+
+        sniper = await harness.login({
+            username: SNIPER,
+            x: monster!.getPositionX() + OUT_OF_RANGE,
+            y: monster!.getPositionY(),
+        });
+
+        sniper.flush();
+        sniper.attack(virtualId);
+        await sniper.settle(600);
+
+        expect(sniper.received().includes(DAMAGE_MESSAGE), 'no damage dealt from out of range').to.equal(false);
+
+        // Positive control: the same packet from a character standing on the
+        // monster does land, so the rejection above was the range check.
+        brawler = await harness.login({
+            username: BRAWLER,
+            x: monster!.getPositionX(),
+            y: monster!.getPositionY(),
+        });
+
+        brawler.flush();
+        brawler.attack(virtualId);
+        await brawler.settle(600);
+
+        expect(brawler.received().includes(DAMAGE_MESSAGE), 'damage dealt from melee range').to.equal(true);
+    });
+});

--- a/test/integration/game/itemPickupSecurity.test.ts
+++ b/test/integration/game/itemPickupSecurity.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #66: picking an item up off the ground must be
+ * validated against the picker's position and ownership, not just the virtual id
+ * the client sends. Virtual ids are sequential, so an attacker can name an item
+ * they were never shown.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item pickup validation (issue #66)', function () {
+    this.timeout(60000);
+
+    const OWNER = 'pickowner_test';
+    const THIEF = 'pickthief_test';
+    const POTION = 27001;
+    const X = 958870;
+    const Y = 272760;
+    const FAR = 2000; // well beyond the 300 pickup range, still the same map
+
+    let harness: AttackHarness;
+    let owner: AttackSession;
+    let thief: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await owner?.close();
+        await thief?.close();
+        await harness?.stop();
+    });
+
+    it('ignores a pickup sent from out of range, and still allows the owner nearby', async () => {
+        owner = await harness.login({ username: OWNER, x: X, y: Y });
+        thief = await harness.login({ username: THIEF, x: X + FAR, y: Y });
+
+        owner.command(`/item ${POTION} 5`);
+        await owner.settle(600);
+
+        owner.drop(1, 0, 0, 5);
+        await owner.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the item reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        // Both players must share an area, otherwise the map check — not the
+        // distance check — would be what rejects the pickup.
+        expect(
+            harness.findPlayer(THIEF)?.getArea(),
+            'setup: attacker is on the same map, only further away',
+        ).to.equal(harness.findPlayer(OWNER)?.getArea());
+
+        thief.pickup(virtualId);
+        await thief.settle(600);
+
+        expect(harness.findDroppedItem()?.getVirtualId(), 'item still on the ground after a far pickup').to.equal(
+            virtualId,
+        );
+        expect(await thief.dbItems(THIEF, POTION), 'attacker received nothing').to.deep.equal([]);
+
+        // Positive control: the same packet from the owner standing on it works,
+        // so the rejection above was the distance and not a broken flow.
+        owner.pickup(virtualId);
+        await owner.settle(600);
+
+        expect(harness.findDroppedItem(), 'owner nearby picked it up').to.equal(undefined);
+    });
+
+    // The gold half of #66 is covered by the PickupItemService unit tests: gold
+    // cannot reach the ground here, because dropping it throws inside the area
+    // spawn queue (the gold "item" is a plain object without getId).
+});

--- a/test/setup.integration.ts
+++ b/test/setup.integration.ts
@@ -1,11 +1,14 @@
 import AuthApplication from '@/auth/app/AuthApplication';
 import { container } from '@/auth/Container';
+import AttackHarness from './support/AttackSession';
 const app = new AuthApplication(container.cradle);
 
 before(async () => {
     await app.start();
 });
 
-after(async () => {
+after(async function () {
+    this.timeout(30000);
+    await AttackHarness.shutdown();
     await app.close();
 });

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -5,6 +5,8 @@ import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
 import BufferReader from '@/core/interface/networking/buffer/BufferReader';
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
 
 /**
  * A "malicious client" test harness: it speaks the raw game protocol against a
@@ -21,6 +23,14 @@ import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
  * Requires MySQL + Redis (docker) and a free game port (stop `dev:game` first).
  */
 export default class AttackHarness {
+    /**
+     * The game container is a module-level singleton, so its database pool and
+     * cache client can only be opened once per process. The server is therefore
+     * booted on the first start() and shared by every spec file; shutdown()
+     * closes it once, from the root hook in setup.integration.ts.
+     */
+    private static shared: AttackHarness | null = null;
+
     private app!: GameApplication;
     private readonly rejections: unknown[] = [];
     private readonly onRejection = (reason: unknown) => this.rejections.push(reason);
@@ -40,26 +50,65 @@ export default class AttackHarness {
     }
 
     async start() {
+        if (AttackHarness.shared) return AttackHarness.shared;
+
         // Capture unhandled rejections instead of letting Node's default handler
         // crash the runner. This is the whole point of owning the server here.
         process.on('unhandledRejection', this.onRejection);
         this.app = new GameApplication(container.cradle as any);
         await this.app.start();
+        AttackHarness.shared = this;
         return this;
     }
 
+    /** Drops the accounts this spec seeded; the server stays up for the next one. */
     async stop() {
         for (const username of this.seededAccounts) {
             await this.db.getConnection().query('DELETE FROM auth.account WHERE username = ?', [username]);
             await this.db.getConnection().query('DELETE FROM game.player WHERE name = ?', [username]);
         }
-        await this.app.close();
-        process.off('unhandledRejection', this.onRejection);
+        this.seededAccounts.length = 0;
+        this.rejections.length = 0;
+    }
+
+    static async shutdown() {
+        const harness = AttackHarness.shared;
+        if (!harness) return;
+
+        await harness.app.close();
+        process.off('unhandledRejection', harness.onRejection);
+        AttackHarness.shared = null;
     }
 
     /** Unhandled rejections seen since start (e.g. the RangeError from issue #69). */
     capturedRejections() {
         return this.rejections;
+    }
+
+    private get entityManager() {
+        return container.resolve<any>('entityManager');
+    }
+
+    /**
+     * Every live entity in the world. Tests use this to learn virtual ids the
+     * attacker is not supposed to know — which is exactly the attacker's own
+     * position, since virtual ids are sequential and trivially guessable.
+     */
+    private entities(): Array<any> {
+        return [...this.entityManager.entities.values()];
+    }
+
+    findMonster(): Monster | undefined {
+        return this.entities().find((entity) => entity instanceof Monster);
+    }
+
+    /** The most recently spawned ground item, so earlier specs cannot shadow it. */
+    findDroppedItem(): DroppedItem | undefined {
+        return this.entities().findLast((entity) => entity instanceof DroppedItem);
+    }
+
+    findPlayer(name: string) {
+        return this.entities().find((entity) => entity?.getName?.() === name);
     }
 
     /**
@@ -197,6 +246,18 @@ export class AttackSession {
     drop(window: number, position: number, gold: number, count: number) {
         const w = new BufferWriter(PacketHeaderEnum.ITEM_DROP, 9);
         this.send(w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer());
+    }
+
+    /** Fire a raw item-pickup packet for an arbitrary virtual id. */
+    pickup(virtualId: number) {
+        const w = new BufferWriter(PacketHeaderEnum.ITEM_PICKUP, 5);
+        this.send(w.writeUint32LE(virtualId).getBuffer());
+    }
+
+    /** Fire a raw attack packet at an arbitrary virtual id. */
+    attack(virtualId: number, attackType = 0) {
+        const w = new BufferWriter(PacketHeaderEnum.ATTACK, 8);
+        this.send(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
     }
 
     send(buffer: Buffer) {

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -6,6 +6,17 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('PickupItemService', function () {
+    const AREA = { name: 'area1' };
+    const OTHER_AREA = { name: 'area2' };
+    const POSITION = { x: 1000, y: 1000 };
+
+    /** Stubs the position/area getters every pickup goes through. */
+    const atPosition = (area: unknown, x: number, y: number) => ({
+        getArea: sinon.stub().returns(area),
+        getPositionX: sinon.stub().returns(x),
+        getPositionY: sinon.stub().returns(y),
+    });
+
     let worldMock;
     let itemRepositoryMock;
     let entityManagerMock: any;
@@ -38,11 +49,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(true),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
                 getCount: sinon.stub().returns(100),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -64,11 +77,13 @@ describe('PickupItemService', function () {
                 addItemStacking: sinon.stub().returns({ updated: [], inserted: itemMock }),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns(itemMock),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -86,11 +101,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(false),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -105,6 +122,75 @@ describe('PickupItemService', function () {
             ).to.be.true;
             expect(worldMock.despawn.called).to.be.false;
             expect(itemRepositoryMock.create.called).to.be.false;
+        });
+
+        it('should not pick up an item that is out of range (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x + 1000, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not pick up an item that is in another area (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(OTHER_AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not give gold dropped by someone else (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItem: sinon.stub().returns(true),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
+                getCount: sinon.stub().returns(100),
+                getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addPoint.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
         });
 
         it('should do nothing if the dropped item is not found', async function () {


### PR DESCRIPTION
## What

Fixes #68.

> Builds on the #66 branch for the shared-harness commit. Once that merges this is rebased and the diff is just the two files below.

The victim is resolved from a global virtual id lookup, so the range check is the only thing stopping a player from hitting a monster anywhere in the world. It allowed 500 units for every weapon.

## A correction to the issue

The issue (and the TODO in the code) says the range should come from the weapon. It cannot, and the original does not do that: `item_proto` has no range or distance field at all — I checked every column in `items.json`.

What `battle_melee_attack` (battle.cpp) actually does for a PC is:

```cpp
int max = 300;
if (false == victim->IsPC() && BATTLE_TYPE_MELEE == victim->GetMobBattleType())
    max = MAX(300, (int)(victim->GetMobAttackRange() * 1.15f));
```

So it is a flat 300 for the player, raised to the *victim's* attack range when the victim is a melee mob — so a player can trade blows with something that outreaches them. This PR follows that. Happy to reword the issue if you prefer.

(`battle_distance_valid`, the 170 one, is declared in battle.h but never called anywhere — dead code, not the rule.)

## Test

An integration test picks a spawned monster, attacks from 1500 units away and asserts no hit, then attacks from on top of it and asserts a hit. The landed hit is asserted through the damage message the server sends back, not the monster's health, which regenerates on a timer and would race the assertion.

`npm run test:unit` (428) and `npm run test:integration` (5) are green.