### PR TITLE
Security: drop gold as a real item so the world keeps ticking (fix #73)

### DIFF
--- a/src/game/app/service/DropItemService.ts
+++ b/src/game/app/service/DropItemService.ts
@@ -4,6 +4,8 @@ import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import Logger from '@/core/infra/logger/Logger';
 
+const GOLD_PROTO_ID = 1;
+
 type DropItemServiceParams = {
     window: number;
     position: number;
@@ -66,13 +68,17 @@ export default class DropItemService {
             return;
         }
 
-        player.addPoint(PointsEnum.GOLD, -amount);
+        const gold = this.itemManager.getItem(GOLD_PROTO_ID, amountValidated);
+
+        if (!gold) {
+            this.logger.error(`[PLAYER] Missing the gold item proto ${GOLD_PROTO_ID}`);
+            return;
+        }
+
+        player.addPoint(PointsEnum.GOLD, -amountValidated);
         player.dropItem({
-            count: amount,
-            item: {
-                id: 1,
-                count: amount,
-            } as any,
+            count: amountValidated,
+            item: gold,
         });
     }
 }

--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -5,6 +5,9 @@ import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { IItemRepository } from '@/core/domain/repository/IItemRepository';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
+import MathUtil from '@/core/domain/util/MathUtil';
+
+const MAX_PICKUP_DISTANCE = 300;
 
 export default class PickupItemService {
     private readonly world: World;
@@ -29,20 +32,20 @@ export default class PickupItemService {
         const droppedItem = this.entityManager.getEntity<DroppedItem>(virtualId);
 
         if (!droppedItem) return;
+        if (droppedItem.getArea() !== player.getArea()) return;
 
-        //TODO: validate id the dropped item is in the same map, and validate distance (avoid hacking)
+        const distance = MathUtil.calcDistance(
+            player.getPositionX(),
+            player.getPositionY(),
+            droppedItem.getPositionX(),
+            droppedItem.getPositionY(),
+        );
+
+        if (distance > MAX_PICKUP_DISTANCE) return;
 
         const item = droppedItem.getItem();
         const count = droppedItem.getCount();
         const ownerName = droppedItem.getOwnerName();
-
-        const isGold = item.getId() === 1;
-
-        if (isGold) {
-            player.addPoint(PointsEnum.GOLD, Number(count));
-            this.world.despawn(droppedItem);
-            return;
-        }
 
         const canPickup = ownerName === player.getName() || !ownerName;
 
@@ -51,6 +54,14 @@ export default class PickupItemService {
                 messageType: ChatMessageTypeEnum.INFO,
                 message: '[SYSTEM] This item is not yours',
             });
+            return;
+        }
+
+        const isGold = item.getId() === 1;
+
+        if (isGold) {
+            player.addPoint(PointsEnum.GOLD, Number(count));
+            this.world.despawn(droppedItem);
             return;
         }
 

--- a/test/integration/game/goldDropSecurity.test.ts
+++ b/test/integration/game/goldDropSecurity.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression: dropping gold used to kill the world loop.
+ *
+ * dropGold handed a plain `{ id, count }` object to the drop pipeline instead of
+ * an Item, so when the ground entity spawned, notifying the nearby player
+ * through Player.onNearbyEntityAdded called `getItem().getId()` on a plain
+ * object. The throw escaped Area.processSpawnQueue into World.tick, whose
+ * setTimeout reschedule is the last statement and was never reached — the world
+ * stopped ticking for every player on the server, and the dropped gold was lost
+ * after the player had already been charged.
+ *
+ * Dropping gold is an ordinary action, so this needed no crafted packet at all.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — dropping gold keeps the world alive', function () {
+    this.timeout(60000);
+
+    const USER = 'golddrop_test';
+    const POTION = 27001;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('lands the gold on the ground and keeps spawning afterwards', async () => {
+        session = await harness.login({ username: USER });
+
+        session.command(`/item ${POTION} 5`);
+        await session.settle(600);
+
+        expect(await session.dbItems(USER, POTION), 'setup: one stack of 5 potions').to.deep.equal([
+            { count: 5, window: 1, position: 0 },
+        ]);
+
+        session.drop(1, 0, 5000, 0);
+        await session.settle(800);
+
+        const gold = harness.findDroppedItem();
+        expect(gold, 'the gold reached the ground').to.not.equal(undefined);
+        expect(gold!.getItem().getId(), 'the ground entity carries the gold proto').to.equal(1);
+        expect(gold!.getCount(), 'for the amount that was dropped').to.equal(5000);
+
+        // The throw used to escape into World.tick and stop the reschedule, so
+        // anything queued to spawn after it was silently lost.
+        session.drop(1, 0, 0, 5);
+        await session.settle(1500);
+
+        expect(harness.findDroppedItem()?.getVirtualId(), 'the world still spawns after a gold drop').to.not.equal(
+            gold!.getVirtualId(),
+        );
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped the tick').to.deep.equal([]);
+    });
+});

--- a/test/integration/game/itemPickupSecurity.test.ts
+++ b/test/integration/game/itemPickupSecurity.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #66: picking an item up off the ground must be
+ * validated against the picker's position and ownership, not just the virtual id
+ * the client sends. Virtual ids are sequential, so an attacker can name an item
+ * they were never shown.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item pickup validation (issue #66)', function () {
+    this.timeout(60000);
+
+    const OWNER = 'pickowner_test';
+    const THIEF = 'pickthief_test';
+    const POTION = 27001;
+    const X = 958870;
+    const Y = 272760;
+    const FAR = 2000; // well beyond the 300 pickup range, still the same map
+
+    let harness: AttackHarness;
+    let owner: AttackSession;
+    let thief: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await owner?.close();
+        await thief?.close();
+        await harness?.stop();
+    });
+
+    it('ignores a pickup sent from out of range, and still allows the owner nearby', async () => {
+        owner = await harness.login({ username: OWNER, x: X, y: Y });
+        thief = await harness.login({ username: THIEF, x: X + FAR, y: Y });
+
+        owner.command(`/item ${POTION} 5`);
+        await owner.settle(600);
+
+        owner.drop(1, 0, 0, 5);
+        await owner.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the item reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        // Both players must share an area, otherwise the map check — not the
+        // distance check — would be what rejects the pickup.
+        expect(
+            harness.findPlayer(THIEF)?.getArea(),
+            'setup: attacker is on the same map, only further away',
+        ).to.equal(harness.findPlayer(OWNER)?.getArea());
+
+        thief.pickup(virtualId);
+        await thief.settle(600);
+
+        expect(harness.findDroppedItem()?.getVirtualId(), 'item still on the ground after a far pickup').to.equal(
+            virtualId,
+        );
+        expect(await thief.dbItems(THIEF, POTION), 'attacker received nothing').to.deep.equal([]);
+
+        // Positive control: the same packet from the owner standing on it works,
+        // so the rejection above was the distance and not a broken flow.
+        owner.pickup(virtualId);
+        await owner.settle(600);
+
+        expect(harness.findDroppedItem(), 'owner nearby picked it up').to.equal(undefined);
+    });
+
+    // The gold half of #66 is covered by the PickupItemService unit tests: gold
+    // cannot reach the ground here, because dropping it throws inside the area
+    // spawn queue (the gold "item" is a plain object without getId).
+});

--- a/test/integration/game/itemPickupSecurity.test.ts
+++ b/test/integration/game/itemPickupSecurity.test.ts
@@ -57,9 +57,7 @@ describe('Security — item pickup validation (issue #66)', function () {
         thief.pickup(virtualId);
         await thief.settle(600);
 
-        expect(harness.findDroppedItem()?.getVirtualId(), 'item still on the ground after a far pickup').to.equal(
-            virtualId,
-        );
+        expect(harness.findEntity(virtualId), 'item still on the ground after a far pickup').to.not.equal(undefined);
         expect(await thief.dbItems(THIEF, POTION), 'attacker received nothing').to.deep.equal([]);
 
         // Positive control: the same packet from the owner standing on it works,
@@ -67,7 +65,7 @@ describe('Security — item pickup validation (issue #66)', function () {
         owner.pickup(virtualId);
         await owner.settle(600);
 
-        expect(harness.findDroppedItem(), 'owner nearby picked it up').to.equal(undefined);
+        expect(harness.findEntity(virtualId), 'owner nearby picked it up').to.equal(undefined);
     });
 
     // The gold half of #66 is covered by the PickupItemService unit tests: gold

--- a/test/setup.integration.ts
+++ b/test/setup.integration.ts
@@ -1,11 +1,14 @@
 import AuthApplication from '@/auth/app/AuthApplication';
 import { container } from '@/auth/Container';
+import AttackHarness from './support/AttackSession';
 const app = new AuthApplication(container.cradle);
 
 before(async () => {
     await app.start();
 });
 
-after(async () => {
+after(async function () {
+    this.timeout(30000);
+    await AttackHarness.shutdown();
     await app.close();
 });

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -111,6 +111,11 @@ export default class AttackHarness {
         return this.entities().find((entity) => entity?.getName?.() === name);
     }
 
+    /** The live entity behind a virtual id, or undefined once it despawned. */
+    findEntity(virtualId: number) {
+        return this.entityManager.getEntity(virtualId);
+    }
+
     /**
      * True while the game server still accepts TCP connections — probed the same
      * way an external observer sees it, rather than by reaching into internals.

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -5,6 +5,8 @@ import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
 import BufferReader from '@/core/interface/networking/buffer/BufferReader';
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
 
 /**
  * A "malicious client" test harness: it speaks the raw game protocol against a
@@ -21,6 +23,14 @@ import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
  * Requires MySQL + Redis (docker) and a free game port (stop `dev:game` first).
  */
 export default class AttackHarness {
+    /**
+     * The game container is a module-level singleton, so its database pool and
+     * cache client can only be opened once per process. The server is therefore
+     * booted on the first start() and shared by every spec file; shutdown()
+     * closes it once, from the root hook in setup.integration.ts.
+     */
+    private static shared: AttackHarness | null = null;
+
     private app!: GameApplication;
     private readonly rejections: unknown[] = [];
     private readonly onRejection = (reason: unknown) => this.rejections.push(reason);
@@ -40,26 +50,65 @@ export default class AttackHarness {
     }
 
     async start() {
+        if (AttackHarness.shared) return AttackHarness.shared;
+
         // Capture unhandled rejections instead of letting Node's default handler
         // crash the runner. This is the whole point of owning the server here.
         process.on('unhandledRejection', this.onRejection);
         this.app = new GameApplication(container.cradle as any);
         await this.app.start();
+        AttackHarness.shared = this;
         return this;
     }
 
+    /** Drops the accounts this spec seeded; the server stays up for the next one. */
     async stop() {
         for (const username of this.seededAccounts) {
             await this.db.getConnection().query('DELETE FROM auth.account WHERE username = ?', [username]);
             await this.db.getConnection().query('DELETE FROM game.player WHERE name = ?', [username]);
         }
-        await this.app.close();
-        process.off('unhandledRejection', this.onRejection);
+        this.seededAccounts.length = 0;
+        this.rejections.length = 0;
+    }
+
+    static async shutdown() {
+        const harness = AttackHarness.shared;
+        if (!harness) return;
+
+        await harness.app.close();
+        process.off('unhandledRejection', harness.onRejection);
+        AttackHarness.shared = null;
     }
 
     /** Unhandled rejections seen since start (e.g. the RangeError from issue #69). */
     capturedRejections() {
         return this.rejections;
+    }
+
+    private get entityManager() {
+        return container.resolve<any>('entityManager');
+    }
+
+    /**
+     * Every live entity in the world. Tests use this to learn virtual ids the
+     * attacker is not supposed to know — which is exactly the attacker's own
+     * position, since virtual ids are sequential and trivially guessable.
+     */
+    private entities(): Array<any> {
+        return [...this.entityManager.entities.values()];
+    }
+
+    findMonster(): Monster | undefined {
+        return this.entities().find((entity) => entity instanceof Monster);
+    }
+
+    /** The most recently spawned ground item, so earlier specs cannot shadow it. */
+    findDroppedItem(): DroppedItem | undefined {
+        return this.entities().findLast((entity) => entity instanceof DroppedItem);
+    }
+
+    findPlayer(name: string) {
+        return this.entities().find((entity) => entity?.getName?.() === name);
     }
 
     /**
@@ -197,6 +246,18 @@ export class AttackSession {
     drop(window: number, position: number, gold: number, count: number) {
         const w = new BufferWriter(PacketHeaderEnum.ITEM_DROP, 9);
         this.send(w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer());
+    }
+
+    /** Fire a raw item-pickup packet for an arbitrary virtual id. */
+    pickup(virtualId: number) {
+        const w = new BufferWriter(PacketHeaderEnum.ITEM_PICKUP, 5);
+        this.send(w.writeUint32LE(virtualId).getBuffer());
+    }
+
+    /** Fire a raw attack packet at an arbitrary virtual id. */
+    attack(virtualId: number, attackType = 0) {
+        const w = new BufferWriter(PacketHeaderEnum.ATTACK, 8);
+        this.send(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
     }
 
     send(buffer: Buffer) {

--- a/test/unit/game/app/service/DropItemService.test.ts
+++ b/test/unit/game/app/service/DropItemService.test.ts
@@ -17,6 +17,10 @@ describe('DropItemService', function () {
 
         itemManagerMock = {
             delete: sinon.stub().resolves(),
+            getItem: sinon.stub().callsFake((id: number, count: number) => ({
+                getId: () => id,
+                getCount: () => count,
+            })),
         };
 
         dropItemService = new DropItemService({
@@ -47,6 +51,30 @@ describe('DropItemService', function () {
             expect(playerMock.addPoint.calledOnceWith(PointsEnum.GOLD, -50)).to.be.true;
             expect(playerMock.dropItem.calledOnce).to.be.true;
             expect(playerMock.chat.notCalled).to.be.true;
+        });
+
+        it('should drop gold as a real item, so the ground entity can be rendered', async function () {
+            const playerMock = {
+                getPoint: sinon.stub().returns(100),
+                dropItem: sinon.spy(),
+                chat: sinon.spy(),
+                getName: sinon.stub().returns('TestPlayer'),
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
+                addPoint: sinon.spy(),
+            };
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 50,
+                count: 0,
+                player: playerMock as unknown as Player,
+            });
+
+            const { item, count } = playerMock.dropItem.firstCall.args[0];
+            expect(item.getId(), 'the gold proto').to.equal(1);
+            expect(item.getCount(), 'built for the dropped amount').to.equal(50);
+            expect(count).to.equal(50);
         });
 
         it('should not drop more gold than the player has', async function () {

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -6,6 +6,17 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('PickupItemService', function () {
+    const AREA = { name: 'area1' };
+    const OTHER_AREA = { name: 'area2' };
+    const POSITION = { x: 1000, y: 1000 };
+
+    /** Stubs the position/area getters every pickup goes through. */
+    const atPosition = (area: unknown, x: number, y: number) => ({
+        getArea: sinon.stub().returns(area),
+        getPositionX: sinon.stub().returns(x),
+        getPositionY: sinon.stub().returns(y),
+    });
+
     let worldMock;
     let itemRepositoryMock;
     let entityManagerMock: any;
@@ -38,11 +49,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(true),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
                 getCount: sinon.stub().returns(100),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -64,11 +77,13 @@ describe('PickupItemService', function () {
                 addItemStacking: sinon.stub().returns({ updated: [], inserted: itemMock }),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns(itemMock),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -86,11 +101,13 @@ describe('PickupItemService', function () {
                 addItem: sinon.stub().returns(false),
                 chat: sinon.spy(),
                 addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
             const droppedItemMock = {
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
             };
 
             entityManagerMock.getEntity.returns(droppedItemMock);
@@ -105,6 +122,75 @@ describe('PickupItemService', function () {
             ).to.be.true;
             expect(worldMock.despawn.called).to.be.false;
             expect(itemRepositoryMock.create.called).to.be.false;
+        });
+
+        it('should not pick up an item that is out of range (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x + 1000, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not pick up an item that is in another area (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: null }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(OTHER_AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should not give gold dropped by someone else (issue #66)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItem: sinon.stub().returns(true),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = {
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
+                getCount: sinon.stub().returns(100),
+                getOwnerName: sinon.stub().returns('player2'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addPoint.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
         });
 
         it('should do nothing if the dropped item is not found', async function () {


### PR DESCRIPTION
## What

Fixes #73.

> Stacked on #71 for the shared-harness commit it carries (a second spec file cannot boot its own server). Once #71 merges this is rebased and the diff is just `DropItemService` plus its tests.

Dropping gold — the ordinary client action, no crafted packet — froze the world for every player on the server.

`dropGold` handed the pipeline a plain `{ id, count }` object instead of an `Item`, so when the ground entity sp