### PR TITLE
Security: frame TCP packets so no bytes are dropped or misread (fix #76)

### DIFF
--- a/src/core/interface/networking/packets/packet/Packet.ts
+++ b/src/core/interface/networking/packets/packet/Packet.ts
@@ -45,6 +45,12 @@ export default abstract class Packet {
         return this.size;
     }
 
+    /** On-wire bytes at the start of the buffer, or null when more are needed to tell. */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getFrameLength(buffer: Buffer): number | null {
+        return this.size;
+    }
+
     haveSubHeader() {
         return !!this.subHeader && this.subHeader > 0;
     }

--- a/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
+++ b/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
@@ -19,6 +19,11 @@ export default class EmpirePacket extends PacketBidirectional {
         return this.empireId;
     }
 
+    // The declared size (3) sizes the outgoing buffer; the client sends 2 bytes.
+    getFrameLength(): number | null {
+        return 2;
+    }
+
     pack() {
         this.bufferWriter.writeUint8(this.empireId).writeUint8(0);
         return this.bufferWriter.getBuffer();

--- a/src/core/interface/networking/packets/packet/in/characterMove/CharacterMovePacket.ts
+++ b/src/core/interface/networking/packets/packet/in/characterMove/CharacterMovePacket.ts
@@ -28,7 +28,7 @@ export default class CharacterMovePacket extends PacketIn {
         super({
             header: PacketHeaderEnum.CHARACTER_MOVE,
             name: 'CharacterMovePacket',
-            size: 17,
+            size: 16,
             validator: CharacterMovePacketValidator,
         });
         this.movementType = movementType;

--- a/src/core/interface/networking/packets/packet/in/chat/ChatInPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/chat/ChatInPacket.ts
@@ -10,7 +10,7 @@ export default class ChatInPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.CHAT_IN,
             name: 'ChatInPacket',
-            size: 5 + message?.length + 1,
+            size: 4 + (message?.length ?? 0) + 1,
             validator: ChatInPacketValidator,
         });
 
@@ -23,6 +23,11 @@ export default class ChatInPacket extends PacketIn {
     }
     getMessageType() {
         return this.messageType;
+    }
+
+    getFrameLength(buffer: Buffer): number | null {
+        if (buffer.byteLength < 3) return null;
+        return buffer.readUInt16LE(1);
     }
 
     unpack(buffer: Buffer) {

--- a/src/core/interface/networking/packets/packet/in/clientVersion/ClientVersionPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/clientVersion/ClientVersionPacket.ts
@@ -15,6 +15,11 @@ export default class ClientVersionPacket extends PacketIn {
         this.timeStamp = timeStamp;
     }
 
+    // The struct size varies by client build, so claim the whole read.
+    getFrameLength(buffer: Buffer): number | null {
+        return buffer.byteLength >= this.size ? buffer.byteLength : null;
+    }
+
     getClientName() {
         return this.clientName;
     }

--- a/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacket.ts
@@ -22,13 +22,18 @@ export default class CreateCharacterPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.CREATE_CHARACTER,
             name: 'CreateCharacterPacket',
-            size: 29,
+            size: 30,
             validator: CreateCharacterPacketValidator,
         });
         this.slot = slot;
         this.playerName = playerName;
         this.playerClass = playerClass;
         this.appearance = appearance;
+    }
+
+    // Newer builds append stat bytes after appearance, so claim the whole read.
+    getFrameLength(buffer: Buffer): number | null {
+        return buffer.byteLength >= this.size ? buffer.byteLength : null;
     }
 
     getSlot() {

--- a/src/core/interface/networking/packets/packet/in/enterGame/EnterGamePacket.ts
+++ b/src/core/interface/networking/packets/packet/in/enterGame/EnterGamePacket.ts
@@ -6,7 +6,7 @@ export default class EnterGamePacket extends PacketIn {
         super({
             header: PacketHeaderEnum.ENTER_GAME,
             name: 'EnterGamePacket',
-            size: 0,
+            size: 1,
         });
     }
 

--- a/src/core/interface/networking/packets/packet/in/itemDrop/ItemDropPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/itemDrop/ItemDropPacket.ts
@@ -12,7 +12,7 @@ export default class ItemDropPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.ITEM_DROP,
             name: 'ItemDropPacket',
-            size: 5,
+            size: 9,
             validator: ItemDropPacketValidator,
         });
         this.window = window;

--- a/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacket.ts
+++ b/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacket.ts
@@ -25,7 +25,7 @@ export default class ItemMovePacket extends PacketIn {
         super({
             header: PacketHeaderEnum.ITEM_MOVE,
             name: 'ItemMovePacket',
-            size: 9,
+            size: 8,
             validator: ItemMovePacketValidator,
         });
         this.fromWindow = fromWindow;

--- a/src/core/interface/networking/packets/packet/in/itemUse/ItemUsePacket.ts
+++ b/src/core/interface/networking/packets/packet/in/itemUse/ItemUsePacket.ts
@@ -10,7 +10,7 @@ export default class ItemUsePacket extends PacketIn {
         super({
             header: PacketHeaderEnum.ITEM_USE,
             name: 'ItemUsePacket',
-            size: 5,
+            size: 4,
             validator: ItemUsePacketValidator,
         });
         this.window = window;

--- a/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
@@ -11,12 +11,17 @@ export default class LoginRequestPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.LOGIN_REQUEST,
             name: 'LoginRequestPacket',
-            size: 66,
+            size: 52,
             validator: LoginRequestPacketValidator,
         });
         this.username = username;
         this.password = password;
         this.key = key;
+    }
+
+    // The struct size varies by client build, so claim the whole read.
+    getFrameLength(buffer: Buffer): number | null {
+        return buffer.byteLength >= this.size ? buffer.byteLength : null;
     }
 
     getUsername() {

--- a/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
@@ -50,6 +50,12 @@ export default class MyShopPacket extends PacketIn {
         return this.items;
     }
 
+    getFrameLength(buffer: Buffer): number | null {
+        if (buffer.byteLength < FIXED_SIZE) return null;
+        const count = Math.min(buffer.readUInt8(FIXED_SIZE - 1), PRIVATE_SHOP_MAX_ITEMS);
+        return FIXED_SIZE + count * ITEM_ENTRY_SIZE;
+    }
+
     unpack(buffer: Buffer): this {
         this.bufferReader.setBuffer(buffer);
 

--- a/src/core/interface/networking/packets/packet/in/quickSlotRemove/QuickSlotRemoveRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/quickSlotRemove/QuickSlotRemoveRequestPacket.ts
@@ -9,7 +9,7 @@ export default class QuickSlotRemoveRequestPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.QUICK_SLOT_REMOVE_REQUEST,
             name: 'QuickSlotRemoveRequestPacket',
-            size: 4,
+            size: 2,
             validator: QuickSlotRemoveRequestPacketValidator,
         });
         this.slot = slot;

--- a/src/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacket.ts
@@ -6,7 +6,7 @@ export default class ServerStatusRequestPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.SERVER_STATUS_REQUEST,
             name: 'ServerStatusRequestPacket',
-            size: 10,
+            size: 1,
         });
     }
 

--- a/src/core/interface/networking/packets/packet/in/shop/ShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/shop/ShopPacket.ts
@@ -3,8 +3,8 @@ import PacketIn from '../PacketIn';
 import ShopPacketValidator from './ShopPacketValidator';
 import { ShopSubHeaderCG } from '@/core/enum/ShopSubHeaderEnum';
 
-// CG_SHOP is variable-length; maximum is END(2), BUY(3), SELL(3), SELL2(4).
-// We allocate for the largest (4 bytes including header).
+// CG_SHOP is variable-length; the subheader decides the size:
+// END(2), BUY(4), SELL(3), SELL2(4). We allocate for the largest.
 export default class ShopPacket extends PacketIn {
     private shopSubHeader: ShopSubHeaderCG = ShopSubHeaderCG.END;
     private pos: number = 0;
@@ -29,6 +29,20 @@ export default class ShopPacket extends PacketIn {
 
     getCount(): number {
         return this.count;
+    }
+
+    getFrameLength(buffer: Buffer): number | null {
+        if (buffer.byteLength < 2) return null;
+
+        switch (buffer[1] as ShopSubHeaderCG) {
+            case ShopSubHeaderCG.BUY:
+            case ShopSubHeaderCG.SELL2:
+                return 4;
+            case ShopSubHeaderCG.SELL:
+                return 3;
+            default:
+                return 2;
+        }
     }
 
     unpack(buffer: Buffer): this {

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -5,9 +5,18 @@ import { PacketMapValue } from '@/core/interface/networking/packets/Packets';
 import { GameConfig } from '@/game/infra/config/GameConfig';
 import { ConnectionStateEnum } from '@/core/enum/ConnectionStateEnum';
 
+const MAX_PACKET_LENGTH = 1024;
+const MAX_RECEIVE_BUFFER = 16_384;
+
+type FrameState = {
+    buffer: Buffer;
+    draining: boolean;
+};
+
 export default abstract class Server {
     protected server!: SocketServer;
     protected readonly connections = new Map<string, Connection>();
+    private readonly frameStates = new Map<string, FrameState>();
     protected readonly logger: Logger;
     protected readonly config: GameConfig;
     protected readonly container: any;
@@ -61,8 +70,80 @@ export default abstract class Server {
         connection.startKeepalive();
 
         socket.on('close', this.onClose.bind(this, connection));
-        socket.on('data', this.onData.bind(this, connection));
+        socket.on('data', (chunk: Buffer) => {
+            this.handleData(connection, chunk).catch((err) => this.logger.error(err));
+        });
         socket.on('error', this.onError.bind(this, connection));
+    }
+
+    /**
+     * TCP has no message boundaries: a read can carry several packets, or part
+     * of one. The drain is serialized per connection so packets stay in
+     * arrival order even while a handler is still awaiting.
+     */
+    private async handleData(connection: Connection, chunk: Buffer) {
+        const connectionId = connection.getId();
+        const state = this.frameStates.get(connectionId) ?? { buffer: Buffer.alloc(0), draining: false };
+        this.frameStates.set(connectionId, state);
+        state.buffer = state.buffer.byteLength > 0 ? Buffer.concat([state.buffer, chunk]) : chunk;
+
+        if (state.buffer.byteLength > MAX_RECEIVE_BUFFER) {
+            this.logger.error(
+                `[IN][PACKET] Receive buffer overflow (${state.buffer.byteLength} bytes) from connection: ID: ${connectionId}, closing`,
+            );
+            this.frameStates.delete(connectionId);
+            connection.close();
+            return;
+        }
+
+        if (state.draining) return;
+
+        state.draining = true;
+        try {
+            while (state.buffer.byteLength > 0) {
+                const frame = this.extractFrame(connection, state);
+                if (!frame) break;
+                await this.onData(connection, frame);
+            }
+        } finally {
+            state.draining = false;
+        }
+    }
+
+    /**
+     * Cuts the next complete packet off the front of the buffer, or returns
+     * null while it holds only a partial one. An unknown header means framing
+     * is lost, so the buffered bytes are discarded.
+     */
+    private extractFrame(connection: Connection, state: FrameState): Buffer | null {
+        const header = state.buffer[0];
+        const packetBuilder = this.packets.get(header);
+
+        if (!packetBuilder) {
+            this.logger.info(
+                `[IN][PACKET] Unknown header packet: ${header}, discarding ${state.buffer.byteLength} buffered byte(s)`,
+            );
+            state.buffer = Buffer.alloc(0);
+            return null;
+        }
+
+        const frameLength = packetBuilder.createPacket({}).getFrameLength(state.buffer);
+        if (frameLength === null) return null;
+
+        if (frameLength < 1 || frameLength > MAX_PACKET_LENGTH) {
+            this.logger.error(
+                `[IN][PACKET] Invalid packet length ${frameLength} for header ${header} from connection: ID: ${connection.getId()}, closing`,
+            );
+            this.frameStates.delete(connection.getId());
+            connection.close();
+            return null;
+        }
+
+        if (state.buffer.byteLength < frameLength) return null;
+
+        const frame = state.buffer.subarray(0, frameLength);
+        state.buffer = state.buffer.subarray(frameLength);
+        return frame;
     }
 
     async onError(connection: Connection, err: Error) {
@@ -75,6 +156,7 @@ export default abstract class Server {
         this.logger.debug(`[IN][CLOSE SOCKET EVENT] Closing connection: ID: ${connection.getId()}`);
         connection.stopKeepalive();
         this.connections.delete(connection.getId());
+        this.frameStates.delete(connection.getId());
     }
 
     start(): Promise<void> {

--- a/test/integration/game/packetFraming.test.ts
+++ b/test/integration/game/packetFraming.test.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import { createConnection } from 'node:net';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { container } from '@/game/Container';
+
+/**
+ * Regression for issue #76: TCP has no message boundaries, so packets that
+ * coalesce into one read (or split across reads) must still all be processed.
+ * Before the fix only the first packet of a read was handled and the rest were
+ * silently discarded.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — TCP packet framing (issue #76)', function () {
+    this.timeout(30000);
+
+    const USER = 'framing_test';
+    const POTION_A = 27001;
+    const POTION_B = 27002;
+    const POTION_C = 27004;
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    const chatCommand = (message: string) => {
+        const size = 1 + 2 + 1 + message.length + 1;
+        const w = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
+        return w
+            .writeUint16LE(size)
+            .writeUint8(0)
+            .writeString(message, message.length + 1)
+            .getBuffer();
+    };
+
+    const totalOf = async (protoId: number) => {
+        const stacks = await session.dbItems(USER, protoId);
+        return stacks.reduce((sum, stack) => sum + stack.count, 0);
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('processes every packet when two commands coalesce into one TCP write', async () => {
+        session = await harness.login({ username: USER });
+
+        session.send(Buffer.concat([chatCommand(`/item ${POTION_A} 5`), chatCommand(`/item ${POTION_B} 5`)]));
+        await session.settle(800);
+
+        expect(await totalOf(POTION_A), 'first coalesced command landed').to.equal(5);
+        expect(await totalOf(POTION_B), 'second coalesced command landed').to.equal(5);
+    });
+
+    it('reassembles a packet split across two TCP writes', async () => {
+        const command = chatCommand(`/item ${POTION_C} 3`);
+
+        session.send(command.subarray(0, 3));
+        await session.settle(150);
+        session.send(command.subarray(3));
+        await session.settle(800);
+
+        expect(await totalOf(POTION_C), 'split command landed').to.equal(3);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+    });
+
+    it('drops the rest of a read after an unknown header but keeps the connection alive', async () => {
+        session.send(Buffer.concat([Buffer.from([0xee]), chatCommand(`/item ${POTION_B} 3`)]));
+        await session.settle(800);
+
+        expect(await totalOf(POTION_B), 'command behind the unknown header was discarded').to.equal(5);
+
+        session.send(chatCommand(`/item ${POTION_B} 3`));
+        await session.settle(800);
+        expect(await totalOf(POTION_B), 'connection still processes later packets').to.equal(8);
+    });
+
+    it('closes a connection whose packet claims an absurd length, without hurting the server', async () => {
+        const config = container.resolve<any>('config');
+
+        const kicked = await new Promise<boolean>((resolve) => {
+            const probe = createConnection({ host: config.SERVER_ADDRESS, port: Number(config.SERVER_PORT) });
+            const timer = setTimeout(() => {
+                probe.destroy();
+                resolve(false);
+            }, 5000);
+            const settle = (value: boolean) => {
+                clearTimeout(timer);
+                probe.destroy();
+                resolve(value);
+            };
+            // Drain whatever the server sends (handshake) so the OS does not hold
+            // the socket open waiting for us to read before surfacing the close.
+            probe.on('data', () => {});
+            probe.on('connect', () => {
+                probe.write(
+                    new BufferWriter(PacketHeaderEnum.CHAT_IN, 5).writeUint16LE(5000).writeUint8(0).getBuffer(),
+                );
+            });
+            probe.on('close', () => settle(true));
+            probe.on('end', () => settle(true));
+            probe.on('error', () => settle(true));
+        });
+
+        expect(kicked, 'lying connection was closed').to.equal(true);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped').to.deep.equal([]);
+    });
+});

--- a/test/unit/core/interface/networking/packets/packets/in/characterMove/CharacterMovePacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/characterMove/CharacterMovePacket.test.ts
@@ -19,7 +19,7 @@ describe('CharacterMovePacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(characterMovePacket.getHeader()).to.equal(PacketHeaderEnum.CHARACTER_MOVE);
         expect(characterMovePacket.getName()).to.equal('CharacterMovePacket');
-        expect(characterMovePacket.getSize()).to.equal(17);
+        expect(characterMovePacket.getSize()).to.equal(16);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/chat/ChatInPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/chat/ChatInPacket.test.ts
@@ -15,7 +15,7 @@ describe('ChatInPacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(chatInPacket.getHeader()).to.equal(PacketHeaderEnum.CHAT_IN);
         expect(chatInPacket.getName()).to.equal('ChatInPacket');
-        expect(chatInPacket.getSize()).to.equal(5 + 'Hello, world!'.length + 1);
+        expect(chatInPacket.getSize()).to.equal(4 + 'Hello, world!'.length + 1);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacket.test.ts
@@ -17,7 +17,7 @@ describe('CreateCharacterPacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(createCharacterPacket.getHeader()).to.equal(PacketHeaderEnum.CREATE_CHARACTER);
         expect(createCharacterPacket.getName()).to.equal('CreateCharacterPacket');
-        expect(createCharacterPacket.getSize()).to.equal(29);
+        expect(createCharacterPacket.getSize()).to.equal(30);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/enterGame/EnterGamePacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/enterGame/EnterGamePacket.test.ts
@@ -12,7 +12,7 @@ describe('EnterGamePacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(enterGamePacket.getHeader()).to.equal(PacketHeaderEnum.ENTER_GAME);
         expect(enterGamePacket.getName()).to.equal('EnterGamePacket');
-        expect(enterGamePacket.getSize()).to.equal(0);
+        expect(enterGamePacket.getSize()).to.equal(1);
     });
 
     it('should unpack correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
@@ -16,7 +16,7 @@ describe('LoginRequestPacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(loginRequestPacket.getHeader()).to.equal(PacketHeaderEnum.LOGIN_REQUEST);
         expect(loginRequestPacket.getName()).to.equal('LoginRequestPacket');
-        expect(loginRequestPacket.getSize()).to.equal(66);
+        expect(loginRequestPacket.getSize()).to.equal(52);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/server/Server.test.ts
+++ b/test/unit/core/interface/server/Server.test.ts
@@ -1,0 +1,200 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { EventEmitter } from 'node:events';
+import Server from '@/core/interface/server/Server';
+import Connection from '@/core/interface/networking/Connection';
+import { makePackets } from '@/core/interface/networking/packets/Packets';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import ShopPacket from '@/core/interface/networking/packets/packet/in/shop/ShopPacket';
+import MyShopPacket from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
+import EmpirePacket from '@/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket';
+import { ShopSubHeaderCG } from '@/core/enum/ShopSubHeaderEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+class TestConnection extends Connection {
+    onHandshakeSuccess(): void {}
+    send(): void {}
+}
+
+class FrameRecorder extends Server {
+    public readonly frames: Buffer[] = [];
+    public lastConnection!: TestConnection;
+    public onDataGate: Promise<void> | null = null;
+
+    async onData(_connection: Connection, frame: Buffer) {
+        this.frames.push(frame);
+        if (this.onDataGate) await this.onDataGate;
+    }
+
+    createConnection(socket: any) {
+        this.lastConnection = new TestConnection({ socket, logger });
+        return this.lastConnection;
+    }
+}
+
+const createFakeSocket = () => {
+    const socket: any = new EventEmitter();
+    socket.setNoDelay = () => {};
+    socket.destroy = sinon.spy();
+    return socket;
+};
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+const attackPacket = () =>
+    new BufferWriter(PacketHeaderEnum.ATTACK, 8)
+        .writeUint8(0)
+        .writeUint32LE(1234)
+        .writeUint8(0)
+        .writeUint8(0)
+        .getBuffer();
+
+const chatPacket = (message: string) => {
+    const size = 4 + message.length + 1;
+    return new BufferWriter(PacketHeaderEnum.CHAT_IN, size)
+        .writeUint16LE(size)
+        .writeUint8(0)
+        .writeString(message, message.length + 1)
+        .getBuffer();
+};
+
+describe('Server packet framing', () => {
+    let server: FrameRecorder;
+    let socket: any;
+
+    beforeEach(() => {
+        server = new FrameRecorder({ logger, config: {} as any, packets: makePackets() });
+        socket = createFakeSocket();
+        server.onListener(socket);
+    });
+
+    afterEach(() => {
+        server.lastConnection?.stopKeepalive();
+    });
+
+    it('should process every packet when several arrive in one read', async () => {
+        socket.emit('data', Buffer.concat([attackPacket(), chatPacket('hello'), attackPacket()]));
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(3);
+        expect(server.frames[0]).to.have.lengthOf(8);
+        expect(server.frames[1]).to.have.lengthOf(4 + 'hello'.length + 1);
+        expect(server.frames[2]).to.have.lengthOf(8);
+    });
+
+    it('should hold a partial packet until the rest of it arrives', async () => {
+        const packet = chatPacket('split across reads');
+        socket.emit('data', packet.subarray(0, 5));
+        await settle();
+        expect(server.frames).to.have.lengthOf(0);
+
+        socket.emit('data', packet.subarray(5));
+        await settle();
+        expect(server.frames).to.have.lengthOf(1);
+        expect(server.frames[0]).to.deep.equal(packet);
+        expect(socket.destroy.called).to.be.equal(false);
+    });
+
+    it('should discard the buffer on an unknown header without closing the connection', async () => {
+        socket.emit('data', Buffer.concat([attackPacket(), Buffer.from([0xee]), chatPacket('lost')]));
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(1);
+        expect(socket.destroy.called).to.be.equal(false);
+
+        socket.emit('data', attackPacket());
+        await settle();
+        expect(server.frames).to.have.lengthOf(2);
+    });
+
+    it('should close the connection when a packet claims an absurd length', async () => {
+        const lyingChat = new BufferWriter(PacketHeaderEnum.CHAT_IN, 5).writeUint16LE(5000).writeUint8(0).getBuffer();
+        socket.emit('data', lyingChat);
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(0);
+        expect(socket.destroy.called).to.be.equal(true);
+    });
+
+    it('should close the connection when the receive buffer overflows while a handler is busy', async () => {
+        let release!: () => void;
+        server.onDataGate = new Promise((resolve) => (release = resolve));
+
+        socket.emit('data', attackPacket());
+        await settle();
+        expect(server.frames).to.have.lengthOf(1);
+
+        socket.emit('data', Buffer.alloc(20_000, attackPacket()));
+        await settle();
+        expect(socket.destroy.called).to.be.equal(true);
+
+        release();
+        server.onDataGate = null;
+    });
+
+    it('should keep packets in arrival order while a handler is still awaiting', async () => {
+        let release!: () => void;
+        server.onDataGate = new Promise((resolve) => (release = resolve));
+
+        socket.emit('data', chatPacket('first'));
+        await settle();
+        socket.emit('data', Buffer.concat([chatPacket('second'), chatPacket('third')]));
+        await settle();
+        expect(server.frames).to.have.lengthOf(1);
+
+        server.onDataGate = null;
+        release();
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(3);
+        expect(server.frames.map((f) => f.subarray(4, f.length - 1).toString('ascii'))).to.deep.equal([
+            'first',
+            'second',
+            'third',
+        ]);
+    });
+
+    it('should let a login request claim the whole read once its parsed prefix is buffered', async () => {
+        const login = new BufferWriter(PacketHeaderEnum.LOGIN_REQUEST, 66)
+            .writeString('admin', 31)
+            .writeString('admin', 16)
+            .writeUint32LE(123)
+            .getBuffer();
+        socket.emit('data', login);
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(1);
+        expect(server.frames[0]).to.have.lengthOf(66);
+    });
+});
+
+describe('Variable-length frame sizes', () => {
+    it('should size a shop packet by its subheader', () => {
+        const frameFor = (subHeader: number) => new ShopPacket().getFrameLength(Buffer.from([0x32, subHeader]));
+
+        expect(frameFor(ShopSubHeaderCG.END)).to.be.equal(2);
+        expect(frameFor(ShopSubHeaderCG.BUY)).to.be.equal(4);
+        expect(frameFor(ShopSubHeaderCG.SELL)).to.be.equal(3);
+        expect(frameFor(ShopSubHeaderCG.SELL2)).to.be.equal(4);
+        expect(new ShopPacket().getFrameLength(Buffer.from([0x32]))).to.be.equal(null);
+    });
+
+    it('should frame an incoming empire packet at its 2-byte wire size, not the 3-byte send size', () => {
+        expect(new EmpirePacket({ empireId: 1 }).getFrameLength()).to.be.equal(2);
+    });
+
+    it('should size a private-shop packet by its item count', () => {
+        const withCount = (count: number) => {
+            const buffer = Buffer.alloc(35);
+            buffer[0] = 0x37;
+            buffer[34] = count;
+            return new MyShopPacket().getFrameLength(buffer);
+        };
+
+        expect(withCount(0)).to.be.equal(35);
+        expect(withCount(3)).to.be.equal(35 + 3 * 13);
+        expect(new MyShopPacket().getFrameLength(Buffer.alloc(10))).to.be.equal(null);
+    });
+});


### PR DESCRIPTION
## What

`GameServer.onData` (and `AuthServer.onData`) treated every socket read as exactly one packet — read `data[0]`, unpack, handle, return. TCP has no message boundaries, so:

- **Coalesced packets** (several in one read) → only the first was handled, the rest **silently discarded**. No log, no error, the client just never sees its action happen. This hits hardest exactly when the player acts fastest.
- **A split packet** (one packet across two reads) → handed to `unpack()` truncated, landing in the malformed-packet path that **closes the connection**.

I found this writing the flood test for #67: 30 chat packets back-to-back, one reached the handler.

## How

Buffer per connection and drain complete packets one at a time, keeping any partial tail for the next read. Each packet reports its own on-wire frame length via `getFrameLength(buffer)`:

- fixed-size packets → their declared `size`;
- **chat** → its length field; **shop** → the subheader; **private-shop** → the item count.

The drain is serialized per connection, so packets stay in arrival order even while a handler is still awaiting. A lying or runaway length (`> 1024`) or a receive buffer that overflows (`> 16 KB`) closes the connection instead of stalling or reading past the buffer. An unknown header discards the buffered bytes (same tolerance as before) without dropping the connection.

## Packet-size corrections

Consumption is now driven by each packet's declared size, which exposed sizes that were wrong but never mattered under one-read-one-packet:

- **item-drop** `5 → 9` (client sends the drop2 struct);
- **character-move** `17 → 16` (counted a padding byte); item-use `5 → 4`, item-move `9 → 8`, quick-slot-remove `4 → 2`, enter-game `0 → 1`, state-checker `10 → 1`;
- **empire** is sent as 3 bytes but received as 2, so it frames by its real incoming length;
- **login / create-character / client-version** have wire layouts that vary by client build, so they keep consuming the whole read — identical to the old behaviour, and safe because those are request/reply flows that never pipeline.

## Tests

- **Unit** (`Server.test.ts`): the framing loop — coalesced, split, unknown header, absurd length, buffer overflow, arrival order, and the variable-length sizers (chat/shop/private-shop/empire). No DB.
- **Integration** (`packetFraming.test.ts`): coalesced and split commands driven through the real in-process server, plus the malformed-length close.

The malicious-client harness now boots once and is shared across spec files, so a second integration file can run in the same process (the game container is a module-level singleton). This same generalization is in the open security stack (#71–#75); depending on merge order a trivial rebase on `test/support/AttackSession.ts` may be needed.

`npm run test:unit` 435 passing, `npm run test:integration` 7 passing.

Closes #76