### PR TITLE
Security: bound movement by speed, not just per-packet distance (fix #65)

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -17,6 +17,8 @@ import { QuestManager } from '../../quests/QuestManager';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import GlobalEventTimerManager from '../../manager/GlobalEventTimeManager';
 
+const SPEED_REFERENCE_DISTANCE = 10_000;
+
 export default abstract class Character extends GameEntity {
     protected id: number;
     protected classId: number = 0;
@@ -250,6 +252,25 @@ export default abstract class Character extends GameEntity {
 
     getMovementSpeed() {
         return this.getPoint(PointsEnum.MOVE_SPEED);
+    }
+
+    /** Null when the class has no run animation, the case gotoInternal() also gives no duration. */
+    getMoveDistancePerMs(): number | null {
+        const animation = this.animationManager.getAnimation(
+            String(this.classId),
+            AnimationTypeEnum.RUN,
+            AnimationSubTypeEnum.GENERAL,
+        );
+
+        if (!animation) return null;
+
+        const duration = AnimationUtil.calcAnimationDuration(
+            animation,
+            this.getPoint(PointsEnum.MOVE_SPEED),
+            SPEED_REFERENCE_DISTANCE,
+        );
+
+        return duration > 0 ? SPEED_REFERENCE_DISTANCE / duration : null;
     }
 
     getAttackSpeed() {

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -104,6 +104,11 @@ const MIN_ATTACK_INTERVAL_MS = 80;
 // client never sends a longer segment. Kept generous here.
 const MAX_MOVE_DISTANCE = 2500;
 
+// The cap above has no time component: many small hops sent fast pass it.
+// Tolerance absorbs latency and the packet bunching that follows a lag spike.
+const MOVE_WINDOW_MS = 1_000;
+const MOVE_DISTANCE_TOLERANCE = 2;
+
 // Chat flood limit. The original scores banned words per IP instead of capping
 // the rate, which needs a banword list we do not have, so this is a plain
 // rolling window: wide enough that nobody types through it, narrow enough to
@@ -148,6 +153,7 @@ export default class Player extends Character {
     private lastAttackVictimVid: number = 0;
     /** Last client-reported position accepted by the anti-teleport check. */
     private lastReportedPosition: { x: number; y: number } | null = null;
+    private recentMoves: Array<{ time: number; distance: number }> = [];
 
     //chat
     private chatTimes: Array<number> = [];
@@ -586,11 +592,28 @@ export default class Player extends Character {
         return true;
     }
 
+    private isMoveRateAllowed(distance: number, now: number): boolean {
+        const distancePerMs = this.getMoveDistancePerMs();
+
+        if (distancePerMs === null) return true;
+
+        this.recentMoves = this.recentMoves.filter((move) => now - move.time < MOVE_WINDOW_MS);
+
+        const accumulated = this.recentMoves.reduce((total, move) => total + move.distance, 0);
+        const budget = distancePerMs * MOVE_WINDOW_MS * MOVE_DISTANCE_TOLERANCE;
+
+        if (accumulated + distance > budget) return false;
+
+        this.recentMoves.push({ time: now, distance });
+        return true;
+    }
+
     /**
-     * Rejects move packets that jump farther than a single step allows
-     * (teleport hack). A legitimate client segments long walks, so a request
-     * beyond the cap is either a hack or a desync — in both cases we snap the
-     * client back to the server's authoritative position and drop the move.
+     * Rejects move packets that jump farther than a single step allows, or
+     * that arrive faster than the character can walk (teleport hack). A
+     * legitimate client segments long walks, so a request beyond either bound
+     * is either a hack or a desync — in both cases we snap the client back to
+     * the server's authoritative position and drop the move.
      * Returns true when the requested destination is acceptable.
      */
     isMoveAllowed(x: number, y: number): boolean {
@@ -599,12 +622,16 @@ export default class Player extends Character {
         // fast client, which would trip the cap on honest moves. The server
         // position is the fallback anchor (first move after login or a
         // teleport), so a crafted jump is still capped from a trusted point.
-        const anchors = [this.lastReportedPosition, { x: this.getPositionX(), y: this.getPositionY() }];
-        const allowed = anchors.some(
+        const serverPosition = { x: this.getPositionX(), y: this.getPositionY() };
+        const anchors = [this.lastReportedPosition, serverPosition];
+        const withinCap = anchors.some(
             (anchor) => anchor && MathUtil.calcDistance(anchor.x, anchor.y, x, y) <= MAX_MOVE_DISTANCE,
         );
 
-        if (allowed) {
+        const anchor = this.lastReportedPosition ?? serverPosition;
+        const distance = MathUtil.calcDistance(anchor.x, anchor.y, x, y);
+
+        if (withinCap && this.isMoveRateAllowed(distance, performance.now())) {
             this.lastReportedPosition = { x, y };
             return true;
         }
@@ -848,6 +875,7 @@ export default class Player extends Character {
 
         // The anti-teleport anchor is stale after a server-initiated warp.
         this.lastReportedPosition = null;
+        this.recentMoves = [];
 
         this.connection?.send(
             new TeleportPacket({

--- a/test/integration/game/moveSpeedSecurity.test.ts
+++ b/test/integration/game/moveSpeedSecurity.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #65: the per-packet distance cap has no time
+ * component, so a teleport hack walks through it with many small, individually
+ * legal hops. This reproduces the public multihack's shape — 180-unit hops
+ * every ~34ms, alternating the movement type between WAIT and MOVE — and
+ * asserts the character cannot outrun its own movement speed.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — movement speed validation (issue #65)', function () {
+    this.timeout(30000);
+
+    const USER = 'speedx_test';
+    const START_X = 958870;
+    const START_Y = 272760;
+
+    const HOP_DISTANCE = 180;
+    const HOP_INTERVAL_MS = 34;
+    const HOP_COUNT = 30;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('stops a hop-by-hop teleport from outrunning the character movement speed', async () => {
+        session = await harness.login({ username: USER, x: START_X, y: START_Y });
+
+        const player = harness.findPlayer(USER);
+        expect(player, 'setup: the character is in the world').to.not.equal(undefined);
+
+        expect(HOP_DISTANCE, 'setup: each hop clears the per-packet cap').to.be.lessThan(2500);
+
+        for (let hop = 1; hop <= HOP_COUNT; hop++) {
+            session.move(START_X + hop * HOP_DISTANCE, START_Y, hop % 2);
+            await session.settle(HOP_INTERVAL_MS);
+        }
+        await session.settle(600);
+
+        const claimed = HOP_COUNT * HOP_DISTANCE;
+        const travelled = player.getPositionX() - START_X;
+        const elapsed = HOP_COUNT * HOP_INTERVAL_MS;
+
+        const distancePerMs = player.getMoveDistancePerMs();
+        expect(distancePerMs, 'setup: the class has a run animation to bound').to.be.a('number');
+        const entitled = distancePerMs * (elapsed + 600) * 2;
+
+        expect(travelled, 'the hack did not reach where it claimed to be').to.be.lessThan(claimed);
+        expect(travelled, 'movement stayed within what the speed allows').to.be.at.most(entitled);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped').to.deep.equal([]);
+    });
+
+    it('lets a legitimate client walk at its own pace without being throttled', async () => {
+        const player = harness.findPlayer(USER);
+        const originX = player.getPositionX();
+        const originY = player.getPositionY();
+
+        // A real client reports its own position every ~300ms while moving.
+        const distancePerMs = player.getMoveDistancePerMs();
+        const stepInterval = 300;
+        const step = Math.floor(distancePerMs * stepInterval);
+
+        for (let i = 1; i <= 5; i++) {
+            session.move(originX + i * step, originY, 1);
+            await session.settle(stepInterval);
+        }
+        await session.settle(600);
+
+        const travelled = player.getPositionX() - originX;
+
+        expect(travelled, 'an honest walker kept moving').to.be.greaterThan(step);
+    });
+});

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -265,6 +265,21 @@ export class AttackSession {
         this.send(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
     }
 
+    /** Fire a raw character-move packet (the client reports where it now is). */
+    move(x: number, y: number, movementType = 1, time = 0) {
+        const w = new BufferWriter(PacketHeaderEnum.CHARACTER_MOVE, 16);
+        this.send(
+            w
+                .writeUint8(movementType)
+                .writeUint8(0)
+                .writeUint8(0)
+                .writeUint32LE(x)
+                .writeUint32LE(y)
+                .writeUint32LE(time)
+                .getBuffer(),
+        );
+    }
+
     send(buffer: Buffer) {
         this.client.write(buffer);
     }

--- a/test/unit/core/domain/entities/game/CharacterMoveSpeed.test.ts
+++ b/test/unit/core/domain/entities/game/CharacterMoveSpeed.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import Character from '@/core/domain/entities/game/Character';
+import Animation from '@/core/domain/Animation';
+import AnimationUtil from '@/core/domain/util/AnimationUtil';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+
+class TestCharacter extends Character {
+    private readonly testPoints = new Map<PointsEnum, number>();
+
+    addPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, (this.testPoints.get(point) ?? 0) + value);
+    }
+    setPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, value);
+    }
+    getPoint(point: PointsEnum): number {
+        return this.testPoints.get(point) ?? 0;
+    }
+    getHealthPercentage(): number {
+        return 100;
+    }
+    getAttack(): number {
+        return 0;
+    }
+    getDefense(): number {
+        return 0;
+    }
+    onSpawn(): void {}
+    onDespawn(): void {}
+}
+
+// A player run animation: 450 map units per second at movement speed 100.
+const RUN_ANIMATION = new Animation({ duration: 1, accX: 0, accY: -450, accZ: 0 });
+
+const createCharacter = ({ moveSpeed, animation }: { moveSpeed: number; animation?: Animation }) => {
+    const character = new TestCharacter(
+        {
+            id: 1,
+            classId: 1,
+            virtualId: 1,
+            entityType: EntityTypeEnum.PLAYER,
+            positionX: 0,
+            positionY: 0,
+            name: 'test',
+            empire: 1,
+        },
+        {
+            animationManager: { getAnimation: () => animation } as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+        },
+    );
+    character.setPoint(PointsEnum.MOVE_SPEED, moveSpeed);
+    return character;
+};
+
+describe('Character.getMoveDistancePerMs', () => {
+    it('should report the animation speed at movement speed 100', () => {
+        const character = createCharacter({ moveSpeed: 100, animation: RUN_ANIMATION });
+
+        expect(character.getMoveDistancePerMs()).to.be.closeTo(0.45, 1e-9);
+    });
+
+    it('should agree with the duration the movement engine assigns a step', () => {
+        const character = createCharacter({ moveSpeed: 150, animation: RUN_ANIMATION });
+        const distance = 1234;
+
+        const duration = AnimationUtil.calcAnimationDuration(RUN_ANIMATION, 150, distance);
+
+        expect(character.getMoveDistancePerMs()).to.be.closeTo(distance / duration, 1e-9);
+    });
+
+    it('should scale with movement speed', () => {
+        const base = createCharacter({ moveSpeed: 100, animation: RUN_ANIMATION }).getMoveDistancePerMs()!;
+        const faster = createCharacter({ moveSpeed: 200, animation: RUN_ANIMATION }).getMoveDistancePerMs()!;
+        const slower = createCharacter({ moveSpeed: 50, animation: RUN_ANIMATION }).getMoveDistancePerMs()!;
+
+        expect(faster).to.be.greaterThan(base);
+        expect(slower).to.be.lessThan(base);
+    });
+
+    it('should return null when the class has no run animation', () => {
+        const character = createCharacter({ moveSpeed: 150 });
+
+        expect(character.getMoveDistancePerMs()).to.be.equal(null);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerMoveRate.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerMoveRate.test.ts
@@ -1,0 +1,161 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Animation from '@/core/domain/Animation';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import Logger from '@/core/infra/logger/Logger';
+
+const logger: Logger = { info: () => {}, error: () => {}, debug: () => {} };
+
+// A player run animation: 450 map units per second at movement speed 100.
+const RUN_ANIMATION = new Animation({ duration: 1, accX: 0, accY: -450, accZ: 0 });
+const MOVE_SPEED = 100;
+
+const MOVE_WINDOW_MS = 1_000;
+const MOVE_DISTANCE_TOLERANCE = 2;
+
+const START_X = 100_000;
+const START_Y = 100_000;
+
+const createPlayer = ({ animation }: { animation?: Animation } = { animation: RUN_ANIMATION }) => {
+    const config: any = {
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: 100,
+                    initialMp: 50,
+                    initialStamina: 30,
+                    hpPerLvl: 10,
+                    hpPerHtPoint: 2,
+                    mpPerLvl: 5,
+                    mpPerIqPoint: 1,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: START_X,
+            positionY: START_Y,
+            health: 100,
+            mana: 50,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'mover',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => animation } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+            mobManager: {} as any,
+        },
+    );
+
+    // The factory only stores the base speed; the live point is filled in by
+    // Player.init() on login, which needs far more of the world than this test.
+    player.addPoint(PointsEnum.MOVE_SPEED, MOVE_SPEED);
+    return player;
+};
+
+describe('Player anti-teleport rate check', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers({ now: 1_000_000, toFake: ['performance'] });
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+    it('should reject the hop-by-hop teleport that clears the per-packet cap', () => {
+        const player = createPlayer();
+        const budget = player.getMoveDistancePerMs()! * MOVE_WINDOW_MS * MOVE_DISTANCE_TOLERANCE;
+        let accepted = 0;
+
+        // The multihack's shape: 180-unit hops every 34ms, each well under the cap.
+        for (let hop = 1; hop <= 30; hop++) {
+            if (player.isMoveAllowed(START_X + hop * 180, START_Y)) accepted++;
+            clock.tick(34);
+        }
+
+        const claimed = 30 * 180;
+        expect(accepted * 180, 'the hack could not travel the distance it claimed').to.be.lessThan(claimed);
+        expect(accepted * 180, 'accepted distance stayed within the speed budget').to.be.at.most(budget);
+    });
+
+    it('should accept an honest client reporting its position while it walks', () => {
+        const player = createPlayer();
+        const stepInterval = 300;
+        const step = player.getMoveDistancePerMs()! * stepInterval;
+
+        for (let i = 1; i <= 20; i++) {
+            const allowed = player.isMoveAllowed(START_X + i * step, START_Y);
+            expect(allowed, `honest step ${i} was accepted`).to.be.equal(true);
+            clock.tick(stepInterval);
+        }
+    });
+
+    it('should let a blocked client move again once the window drains', () => {
+        const player = createPlayer();
+        const step = player.getMoveDistancePerMs()! * 100;
+        let x = START_X;
+
+        // Burn the window's budget without advancing time.
+        while (player.isMoveAllowed((x += step), START_Y)) {
+            expect(x - START_X, 'the burst was bounded').to.be.lessThan(100_000);
+        }
+
+        clock.tick(MOVE_WINDOW_MS);
+
+        // A rejected client is snapped back to the server position, so it
+        // resumes from there rather than from where it claimed to be.
+        expect(player.isMoveAllowed(START_X + step, START_Y), 'budget recovered after the window').to.be.equal(true);
+    });
+
+    it('should still reject a single jump beyond the per-packet cap', () => {
+        const player = createPlayer();
+
+        expect(player.isMoveAllowed(START_X + 5_000, START_Y)).to.be.equal(false);
+    });
+
+    it('should not bound movement when the class has no run animation', () => {
+        const player = createPlayer({ animation: undefined });
+
+        for (let hop = 1; hop <= 30; hop++) {
+            expect(player.isMoveAllowed(START_X + hop * 180, START_Y)).to.be.equal(true);
+            clock.tick(34);
+        }
+    });
+});


### PR DESCRIPTION
## What

The per-packet cap in `Player.isMoveAllowed` (`MAX_MOVE_DISTANCE = 2500`) has no time component, so the public multihacks walk straight through it: they split the path into **~180 unit hops — 7% of the cap — and send one every ~34ms**, alternating the movement type between `WAIT` and `MOVE` so the sequence looks like ordinary walking. Every hop is individually legal and the character crosses the map at roughly **5000 units/second**.

**`WAIT` is what makes this bite rather than merely desync.** `Character.waitInternal` assigns the reported position to the character *directly*, with no interpolation:

```ts
protected waitInternal(x: number, y: number) {
    this.positionX = this.startPositionX = this.targetPositionX = x;
```

So the server itself relocates the player — this is a server-authoritative teleport, not just a client-side desync. `MOVE` alone would only have advanced the interpolated position at the correct speed, which is exactly why the hack alternates the two.

## How

Keep the per-packet cap (it still catches the naive single jump) and sum the accepted distance over a **one second sliding window**, bounded by what the character's movement speed allows there.

The speed comes from a new `Character.getMoveDistancePerMs()`, which inverts the **same animation math the movement engine already uses** to time a step (`AnimationUtil.calcAnimationDuration`, the one `gotoInternal` calls). That means speed buffs — and anything else that moves `MOVE_SPEED` — are honoured for free, with no second source of truth for speed. When a class has no run animation it returns `null` and the rate check stands down, matching the engine, which gives such a step no duration either.

Two details worth flagging:
- A **rejected move is not recorded**, so a throttled client keeps its budget for the moves it is actually entitled to.
- A **server-initiated warp clears the window**, since the player legitimately covered that distance.

The tolerance (2×) is deliberately generous, in the spirit of the existing anti-speedhack constants: an honest client reports its own position every ~300ms while moving (`PythonPlayerEventHandler::OnMoving`), which lands at **half** the budget, while the hacks run an **order of magnitude above** it.

## On the original

Worth noting for reviewers: the original's own `SPEEDHACK` check in `input_main.cpp` is a *clock-drift* check (client-reported time vs server time) and it only logs — the disconnect is commented out. Its real movement guard is the distance test (`fDist > 25` on foot, `> 40` riding), which is the cap we already had. So bounding the rate is a deliberate step beyond the original, which is what the issue asked for.

## Tests

- **Unit** — `PlayerMoveRate.test.ts` drives the window with fake timers: the hack shape, an honest walker, budget recovery after the window drains, the per-packet cap still firing, and the no-animation fallback. `CharacterMoveSpeed.test.ts` pins the speed math against `calcAnimationDuration`.
- **Integration** — `moveSpeedSecurity.test.ts` reproduces the hack against the real in-process server and asserts the character cannot outrun its own speed, plus an honest-walker case that must not be throttled.

**I verified the integration spec fails without the fix** — the character reaches exactly where the hack claimed to be — and that the honest-walker case passes either way, so the test is proving the vulnerability rather than the implementation.

`npm run test:unit` 443 passing, `npm run test:integration` 8 passing.

Branched off `master`, independent of #77.

Closes #65