### PR TITLE
Fix: account for the client sequence byte when framing packets (regression from #77)

### DIFF
--- a/src/auth/interface/server/AuthServer.ts
+++ b/src/auth/interface/server/AuthServer.ts
@@ -3,6 +3,8 @@ import AuthConnection from '@/auth/interface/networking/AuthConnection';
 import { Socket } from 'node:net';
 
 export default class AuthServer extends Server {
+    protected readonly unknownHeaderLogLevel = 'debug' as const;
+
     async onData(connection: AuthConnection, data: Buffer) {
         this.container.containerInstance.createScope();
         this.logger.debug(`[IN][DATA SOCKET EVENT] Data received from ID: ${connection.getId()}`);

--- a/src/core/interface/networking/packets/packet/Packet.ts
+++ b/src/core/interface/networking/packets/packet/Packet.ts
@@ -1,10 +1,15 @@
 import PacketValidator from '@/core/interface/networking/packets/PacketValidator';
 
+// The client trails one sequence byte after most packets it sends; the original
+// opts out per header, which is what `sequenced` mirrors.
+const SEQUENCE_BYTE_LENGTH = 1;
+
 export default abstract class Packet {
     protected header: number;
     protected subHeader?: number;
     protected size: number;
     protected name: string;
+    protected sequenced: boolean;
     protected validator?: PacketValidator<this>;
 
     constructor({
@@ -12,18 +17,21 @@ export default abstract class Packet {
         subHeader = 0,
         size,
         name,
+        sequenced = true,
         validator = undefined,
     }: {
         header: number;
         subHeader?: number;
         size: number;
         name: string;
+        sequenced?: boolean;
         validator?: new (packet: any) => PacketValidator<any>;
     }) {
         this.header = header;
         this.subHeader = subHeader;
         this.size = size;
         this.name = name;
+        this.sequenced = sequenced;
         if (validator) {
             this.validator = this.createValidator(validator);
         }
@@ -45,10 +53,14 @@ export default abstract class Packet {
         return this.size;
     }
 
+    getSequenceLength() {
+        return this.sequenced ? SEQUENCE_BYTE_LENGTH : 0;
+    }
+
     /** On-wire bytes at the start of the buffer, or null when more are needed to tell. */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getFrameLength(buffer: Buffer): number | null {
-        return this.size;
+        return this.size + this.getSequenceLength();
     }
 
     haveSubHeader() {

--- a/src/core/interface/networking/packets/packet/bidirectional/PacketBidirectional.ts
+++ b/src/core/interface/networking/packets/packet/bidirectional/PacketBidirectional.ts
@@ -12,15 +12,17 @@ export default abstract class PacketBidirectional extends Packet {
         subHeader = 0,
         size,
         name,
+        sequenced = true,
         validator,
     }: {
         header: number;
         subHeader?: number;
         size: number;
         name: string;
+        sequenced?: boolean;
         validator?: new (packet: any) => PacketValidator<any>;
     }) {
-        super({ header, subHeader, size, name, validator });
+        super({ header, subHeader, size, name, sequenced, validator });
         this.bufferWriter = new BufferWriter(this.header, this.size);
         this.bufferReader = new BufferReader();
     }

--- a/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
+++ b/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
@@ -19,9 +19,9 @@ export default class EmpirePacket extends PacketBidirectional {
         return this.empireId;
     }
 
-    // The declared size (3) sizes the outgoing buffer; the client sends 2 bytes.
+    // The declared size (3) sizes the outgoing buffer; inbound is header + empire.
     getFrameLength(): number | null {
-        return 2;
+        return 2 + this.getSequenceLength();
     }
 
     pack() {

--- a/src/core/interface/networking/packets/packet/bidirectional/handshake/HandshakePacket.ts
+++ b/src/core/interface/networking/packets/packet/bidirectional/handshake/HandshakePacket.ts
@@ -12,6 +12,7 @@ export default class HandshakePacket extends PacketBidirectional {
             header: PacketHeaderEnum.HANDSHAKE,
             name: 'HandshakePacket',
             size: 13,
+            sequenced: false,
             validator: HandshakePacketValidator,
         });
         this.id = id;

--- a/src/core/interface/networking/packets/packet/in/chat/ChatInPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/chat/ChatInPacket.ts
@@ -27,7 +27,7 @@ export default class ChatInPacket extends PacketIn {
 
     getFrameLength(buffer: Buffer): number | null {
         if (buffer.byteLength < 3) return null;
-        return buffer.readUInt16LE(1);
+        return buffer.readUInt16LE(1) + this.getSequenceLength();
     }
 
     unpack(buffer: Buffer) {

--- a/src/core/interface/networking/packets/packet/in/clientVersion/ClientVersionPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/clientVersion/ClientVersionPacket.ts
@@ -15,11 +15,6 @@ export default class ClientVersionPacket extends PacketIn {
         this.timeStamp = timeStamp;
     }
 
-    // The struct size varies by client build, so claim the whole read.
-    getFrameLength(buffer: Buffer): number | null {
-        return buffer.byteLength >= this.size ? buffer.byteLength : null;
-    }
-
     getClientName() {
         return this.clientName;
     }

--- a/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacket.ts
@@ -22,18 +22,13 @@ export default class CreateCharacterPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.CREATE_CHARACTER,
             name: 'CreateCharacterPacket',
-            size: 30,
+            size: 34,
             validator: CreateCharacterPacketValidator,
         });
         this.slot = slot;
         this.playerName = playerName;
         this.playerClass = playerClass;
         this.appearance = appearance;
-    }
-
-    // Newer builds append stat bytes after appearance, so claim the whole read.
-    getFrameLength(buffer: Buffer): number | null {
-        return buffer.byteLength >= this.size ? buffer.byteLength : null;
     }
 
     getSlot() {

--- a/src/core/interface/networking/packets/packet/in/internalPing/InternalPingPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/internalPing/InternalPingPacket.ts
@@ -10,6 +10,7 @@ export default class InternalPingPacket extends PacketIn {
             header: PacketHeaderEnum.INTERNAL_PING,
             name: 'InternalPing',
             size: 5,
+            sequenced: false,
             validator: InternalPingPacketValidator,
         });
         this.time = time;

--- a/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
@@ -11,17 +11,12 @@ export default class LoginRequestPacket extends PacketIn {
         super({
             header: PacketHeaderEnum.LOGIN_REQUEST,
             name: 'LoginRequestPacket',
-            size: 52,
+            size: 65,
             validator: LoginRequestPacketValidator,
         });
         this.username = username;
         this.password = password;
         this.key = key;
-    }
-
-    // The struct size varies by client build, so claim the whole read.
-    getFrameLength(buffer: Buffer): number | null {
-        return buffer.byteLength >= this.size ? buffer.byteLength : null;
     }
 
     getUsername() {

--- a/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
@@ -53,7 +53,7 @@ export default class MyShopPacket extends PacketIn {
     getFrameLength(buffer: Buffer): number | null {
         if (buffer.byteLength < FIXED_SIZE) return null;
         const count = Math.min(buffer.readUInt8(FIXED_SIZE - 1), PRIVATE_SHOP_MAX_ITEMS);
-        return FIXED_SIZE + count * ITEM_ENTRY_SIZE;
+        return FIXED_SIZE + count * ITEM_ENTRY_SIZE + this.getSequenceLength();
     }
 
     unpack(buffer: Buffer): this {

--- a/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/myshop/MyShopPacket.ts
@@ -52,7 +52,7 @@ export default class MyShopPacket extends PacketIn {
 
     getFrameLength(buffer: Buffer): number | null {
         if (buffer.byteLength < FIXED_SIZE) return null;
-        const count = Math.min(buffer.readUInt8(FIXED_SIZE - 1), PRIVATE_SHOP_MAX_ITEMS);
+        const count = buffer.readUInt8(FIXED_SIZE - 1);
         return FIXED_SIZE + count * ITEM_ENTRY_SIZE + this.getSequenceLength();
     }
 

--- a/src/core/interface/networking/packets/packet/in/pong/PongPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/pong/PongPacket.ts
@@ -11,6 +11,7 @@ export default class PongPacket extends PacketIn {
             header: PacketHeaderEnum.PONG,
             name: 'PongPacket',
             size: 1,
+            sequenced: false,
         });
     }
 

--- a/src/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacket.ts
@@ -7,6 +7,7 @@ export default class ServerStatusRequestPacket extends PacketIn {
             header: PacketHeaderEnum.SERVER_STATUS_REQUEST,
             name: 'ServerStatusRequestPacket',
             size: 1,
+            sequenced: false,
         });
     }
 

--- a/src/core/interface/networking/packets/packet/in/shop/ShopPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/shop/ShopPacket.ts
@@ -3,8 +3,13 @@ import PacketIn from '../PacketIn';
 import ShopPacketValidator from './ShopPacketValidator';
 import { ShopSubHeaderCG } from '@/core/enum/ShopSubHeaderEnum';
 
-// CG_SHOP is variable-length; the subheader decides the size:
-// END(2), BUY(4), SELL(3), SELL2(4). We allocate for the largest.
+const SHOP_BODY_SIZE_DEFAULT = 2;
+const SHOP_BODY_SIZE: Partial<Record<ShopSubHeaderCG, number>> = {
+    [ShopSubHeaderCG.BUY]: 4,
+    [ShopSubHeaderCG.SELL]: 3,
+    [ShopSubHeaderCG.SELL2]: 4,
+};
+
 export default class ShopPacket extends PacketIn {
     private shopSubHeader: ShopSubHeaderCG = ShopSubHeaderCG.END;
     private pos: number = 0;
@@ -34,15 +39,9 @@ export default class ShopPacket extends PacketIn {
     getFrameLength(buffer: Buffer): number | null {
         if (buffer.byteLength < 2) return null;
 
-        switch (buffer[1] as ShopSubHeaderCG) {
-            case ShopSubHeaderCG.BUY:
-            case ShopSubHeaderCG.SELL2:
-                return 4;
-            case ShopSubHeaderCG.SELL:
-                return 3;
-            default:
-                return 2;
-        }
+        const body = SHOP_BODY_SIZE[buffer[1] as ShopSubHeaderCG] ?? SHOP_BODY_SIZE_DEFAULT;
+
+        return body + this.getSequenceLength();
     }
 
     unpack(buffer: Buffer): this {

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -22,6 +22,8 @@ export default abstract class Server {
     protected readonly container: any;
     protected readonly packets: Map<number, PacketMapValue<any>>;
     protected isShuttingDown = false;
+    /** Headers a server does not implement are routine on auth, notable in game. */
+    protected readonly unknownHeaderLogLevel: 'info' | 'debug' = 'info';
 
     constructor(container: { logger: Logger; config: GameConfig; packets: Map<number, PacketMapValue<any>> }) {
         this.logger = container.logger;
@@ -112,7 +114,7 @@ export default abstract class Server {
         const packetBuilder = this.packets.get(header);
 
         if (!packetBuilder) {
-            this.logger.info(
+            this.logger[this.unknownHeaderLogLevel](
                 `[IN][PACKET] Unknown header packet: ${header}, discarding ${state.buffer.byteLength} buffered byte(s)`,
             );
             state.buffer = Buffer.alloc(0);

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -76,11 +76,7 @@ export default abstract class Server {
         socket.on('error', this.onError.bind(this, connection));
     }
 
-    /**
-     * TCP has no message boundaries: a read can carry several packets, or part
-     * of one. The drain is serialized per connection so packets stay in
-     * arrival order even while a handler is still awaiting.
-     */
+    /** Serialized per connection so packets stay in arrival order across awaits. */
     private async handleData(connection: Connection, chunk: Buffer) {
         const connectionId = connection.getId();
         const state = this.frameStates.get(connectionId) ?? { buffer: Buffer.alloc(0), draining: false };
@@ -110,11 +106,7 @@ export default abstract class Server {
         }
     }
 
-    /**
-     * Cuts the next complete packet off the front of the buffer, or returns
-     * null while it holds only a partial one. An unknown header means framing
-     * is lost, so the buffered bytes are discarded.
-     */
+    /** Next complete packet, or null while the buffer holds only a partial one. */
     private extractFrame(connection: Connection, state: FrameState): Buffer | null {
         const header = state.buffer[0];
         const packetBuilder = this.packets.get(header);

--- a/test/integration/game/packetFraming.test.ts
+++ b/test/integration/game/packetFraming.test.ts
@@ -23,14 +23,20 @@ describe('Security — TCP packet framing (issue #76)', function () {
     let harness: AttackHarness;
     let session: AttackSession;
 
+    // Built by hand rather than via session.command() so the tests can control
+    // exactly how the bytes are split across TCP writes. The trailing byte is
+    // the sequence byte the real client appends after every packet.
     const chatCommand = (message: string) => {
         const size = 1 + 2 + 1 + message.length + 1;
         const w = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
-        return w
-            .writeUint16LE(size)
-            .writeUint8(0)
-            .writeString(message, message.length + 1)
-            .getBuffer();
+        return Buffer.concat([
+            w
+                .writeUint16LE(size)
+                .writeUint8(0)
+                .writeString(message, message.length + 1)
+                .getBuffer(),
+            Buffer.of(0),
+        ]);
     };
 
     const totalOf = async (protoId: number) => {

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -226,16 +226,16 @@ export class AttackSession {
             .writeUint32LE(0)
             .writeUint32LE(0)
             .writeUint32LE(0);
-        this.send(auth.getBuffer());
+        this.sendSequenced(auth.getBuffer());
 
         await this.next(3); // empire
         await this.next(331); // player list
         const select = new BufferWriter(PacketHeaderEnum.SELECT_CHARACTER, 2);
-        this.send(select.writeUint8(0).getBuffer());
+        this.sendSequenced(select.writeUint8(0).getBuffer());
 
         await this.next(2); // LOADING state
         await this.next(46); // character detail
-        this.send(new BufferWriter(PacketHeaderEnum.ENTER_GAME, 1).getBuffer());
+        this.sendSequenced(new BufferWriter(PacketHeaderEnum.ENTER_GAME, 1).getBuffer());
         await this.settle(600);
         this.flush();
     }
@@ -244,25 +244,33 @@ export class AttackSession {
     command(message: string) {
         const size = 1 + 2 + 1 + message.length + 1;
         const w = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
-        this.send(w.writeUint16LE(size).writeUint8(0).writeString(message, message.length + 1).getBuffer());
+        this.sendSequenced(
+            w
+                .writeUint16LE(size)
+                .writeUint8(0)
+                .writeString(message, message.length + 1)
+                .getBuffer(),
+        );
     }
 
     /** Fire a raw item-drop packet (window u8, position u16, gold u32, count u8). */
     drop(window: number, position: number, gold: number, count: number) {
         const w = new BufferWriter(PacketHeaderEnum.ITEM_DROP, 9);
-        this.send(w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer());
+        this.sendSequenced(
+            w.writeUint8(window).writeUint16LE(position).writeUint32LE(gold).writeUint8(count).getBuffer(),
+        );
     }
 
     /** Fire a raw item-pickup packet for an arbitrary virtual id. */
     pickup(virtualId: number) {
         const w = new BufferWriter(PacketHeaderEnum.ITEM_PICKUP, 5);
-        this.send(w.writeUint32LE(virtualId).getBuffer());
+        this.sendSequenced(w.writeUint32LE(virtualId).getBuffer());
     }
 
     /** Fire a raw attack packet at an arbitrary virtual id. */
     attack(virtualId: number, attackType = 0) {
         const w = new BufferWriter(PacketHeaderEnum.ATTACK, 8);
-        this.send(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
+        this.sendSequenced(w.writeUint8(attackType).writeUint32LE(virtualId).writeUint8(0).writeUint8(0).getBuffer());
     }
 
     /** Fire a raw character-move packet (the client reports where it now is). */
@@ -284,6 +292,14 @@ export class AttackSession {
         this.client.write(buffer);
     }
 
+    /**
+     * Send a packet the way the real client does: with a trailing sequence byte.
+     * The server only needs to skip it, so the value is irrelevant here.
+     */
+    sendSequenced(buffer: Buffer) {
+        this.send(Buffer.concat([buffer, Buffer.of(0)]));
+    }
+
     /** Wait for the server to finish processing what we just sent. */
     settle(ms = 300) {
         return new Promise((r) => setTimeout(r, ms));
@@ -299,13 +315,11 @@ export class AttackSession {
 
     /** The persisted stacks of a given proto for this session's character. */
     async dbItems(username: string, protoId: number) {
-        const [rows] = await this.db
-            .getConnection()
-            .query(
-                `SELECT i.count, i.window, i.position FROM game.item i
+        const [rows] = await this.db.getConnection().query(
+            `SELECT i.count, i.window, i.position FROM game.item i
                  JOIN game.player p ON p.id = i.ownerId WHERE p.name = ? AND i.protoId = ?`,
-                [username, protoId],
-            );
+            [username, protoId],
+        );
         return rows as Array<{ count: number; window: number; position: number }>;
     }
 

--- a/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacket.test.ts
@@ -17,7 +17,7 @@ describe('CreateCharacterPacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(createCharacterPacket.getHeader()).to.equal(PacketHeaderEnum.CREATE_CHARACTER);
         expect(createCharacterPacket.getName()).to.equal('CreateCharacterPacket');
-        expect(createCharacterPacket.getSize()).to.equal(30);
+        expect(createCharacterPacket.getSize()).to.equal(34);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
@@ -16,7 +16,7 @@ describe('LoginRequestPacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(loginRequestPacket.getHeader()).to.equal(PacketHeaderEnum.LOGIN_REQUEST);
         expect(loginRequestPacket.getName()).to.equal('LoginRequestPacket');
-        expect(loginRequestPacket.getSize()).to.equal(52);
+        expect(loginRequestPacket.getSize()).to.equal(65);
     });
 
     it('should initialize properties correctly', function () {

--- a/test/unit/core/interface/networking/packets/packets/in/myshop/MyShopPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/myshop/MyShopPacket.test.ts
@@ -1,0 +1,50 @@
+import MyShopPacket, { ITEM_ENTRY_SIZE } from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
+import { PRIVATE_SHOP_MAX_ITEMS } from '@/core/domain/shop/PrivateShop';
+import { expect } from 'chai';
+
+const FIXED_SIZE = 35;
+const COUNT_OFFSET = FIXED_SIZE - 1;
+const SEQUENCE_BYTE = 1;
+
+const shopHeader = (count: number) => {
+    const buffer = Buffer.alloc(FIXED_SIZE);
+    buffer.writeUInt8(count, COUNT_OFFSET);
+    return buffer;
+};
+
+describe('MyShopPacket', function () {
+    let myShopPacket: MyShopPacket;
+
+    beforeEach(function () {
+        myShopPacket = new MyShopPacket();
+    });
+
+    it('should ask for more bytes while the fixed part is incomplete', function () {
+        expect(myShopPacket.getFrameLength(Buffer.alloc(FIXED_SIZE - 1))).to.equal(null);
+    });
+
+    it('should frame a shop with no items', function () {
+        expect(myShopPacket.getFrameLength(shopHeader(0))).to.equal(FIXED_SIZE + SEQUENCE_BYTE);
+    });
+
+    it('should frame a full shop', function () {
+        expect(myShopPacket.getFrameLength(shopHeader(PRIVATE_SHOP_MAX_ITEMS))).to.equal(
+            FIXED_SIZE + PRIVATE_SHOP_MAX_ITEMS * ITEM_ENTRY_SIZE + SEQUENCE_BYTE,
+        );
+    });
+
+    // Framing must follow the bytes on the wire, not the item cap: a length
+    // clamped to PRIVATE_SHOP_MAX_ITEMS leaves the declared surplus in the
+    // buffer, where the drain loop reads it as further packets.
+    it('should frame on the declared count even when it exceeds the item cap', function () {
+        const declared = PRIVATE_SHOP_MAX_ITEMS * 2;
+
+        expect(myShopPacket.getFrameLength(shopHeader(declared))).to.equal(
+            FIXED_SIZE + declared * ITEM_ENTRY_SIZE + SEQUENCE_BYTE,
+        );
+    });
+
+    it('should report a length above the server limit for an absurd count', function () {
+        expect(myShopPacket.getFrameLength(shopHeader(255))).to.be.greaterThan(1024);
+    });
+});

--- a/test/unit/core/interface/server/Server.test.ts
+++ b/test/unit/core/interface/server/Server.test.ts
@@ -43,21 +43,28 @@ const createFakeSocket = () => {
 
 const settle = () => new Promise((resolve) => setImmediate(resolve));
 
+/** Packets carry a trailing sequence byte on the wire, as the client sends them. */
+const sequenced = (packet: Buffer) => Buffer.concat([packet, Buffer.of(0)]);
+
 const attackPacket = () =>
-    new BufferWriter(PacketHeaderEnum.ATTACK, 8)
-        .writeUint8(0)
-        .writeUint32LE(1234)
-        .writeUint8(0)
-        .writeUint8(0)
-        .getBuffer();
+    sequenced(
+        new BufferWriter(PacketHeaderEnum.ATTACK, 8)
+            .writeUint8(0)
+            .writeUint32LE(1234)
+            .writeUint8(0)
+            .writeUint8(0)
+            .getBuffer(),
+    );
 
 const chatPacket = (message: string) => {
     const size = 4 + message.length + 1;
-    return new BufferWriter(PacketHeaderEnum.CHAT_IN, size)
-        .writeUint16LE(size)
-        .writeUint8(0)
-        .writeString(message, message.length + 1)
-        .getBuffer();
+    return sequenced(
+        new BufferWriter(PacketHeaderEnum.CHAT_IN, size)
+            .writeUint16LE(size)
+            .writeUint8(0)
+            .writeString(message, message.length + 1)
+            .getBuffer(),
+    );
 };
 
 describe('Server packet framing', () => {
@@ -79,9 +86,9 @@ describe('Server packet framing', () => {
         await settle();
 
         expect(server.frames).to.have.lengthOf(3);
-        expect(server.frames[0]).to.have.lengthOf(8);
-        expect(server.frames[1]).to.have.lengthOf(4 + 'hello'.length + 1);
-        expect(server.frames[2]).to.have.lengthOf(8);
+        expect(server.frames[0]).to.have.lengthOf(9);
+        expect(server.frames[1]).to.have.lengthOf(4 + 'hello'.length + 2);
+        expect(server.frames[2]).to.have.lengthOf(9);
     });
 
     it('should hold a partial packet until the rest of it arrives', async () => {
@@ -110,7 +117,9 @@ describe('Server packet framing', () => {
     });
 
     it('should close the connection when a packet claims an absurd length', async () => {
-        const lyingChat = new BufferWriter(PacketHeaderEnum.CHAT_IN, 5).writeUint16LE(5000).writeUint8(0).getBuffer();
+        const lyingChat = sequenced(
+            new BufferWriter(PacketHeaderEnum.CHAT_IN, 5).writeUint16LE(5000).writeUint8(0).getBuffer(),
+        );
         socket.emit('data', lyingChat);
         await settle();
 
@@ -149,19 +158,21 @@ describe('Server packet framing', () => {
         await settle();
 
         expect(server.frames).to.have.lengthOf(3);
-        expect(server.frames.map((f) => f.subarray(4, f.length - 1).toString('ascii'))).to.deep.equal([
+        expect(server.frames.map((f) => f.subarray(4, f.length - 2).toString('ascii'))).to.deep.equal([
             'first',
             'second',
             'third',
         ]);
     });
 
-    it('should let a login request claim the whole read once its parsed prefix is buffered', async () => {
-        const login = new BufferWriter(PacketHeaderEnum.LOGIN_REQUEST, 66)
-            .writeString('admin', 31)
-            .writeString('admin', 16)
-            .writeUint32LE(123)
-            .getBuffer();
+    it('should frame a login request at its struct size plus the sequence byte', async () => {
+        const login = sequenced(
+            new BufferWriter(PacketHeaderEnum.LOGIN_REQUEST, 65)
+                .writeString('admin', 31)
+                .writeString('admin', 17)
+                .writeUint32LE(123)
+                .getBuffer(),
+        );
         socket.emit('data', login);
         await settle();
 
@@ -170,19 +181,41 @@ describe('Server packet framing', () => {
     });
 });
 
+describe('Sequence byte exemptions', () => {
+    // The client appends no sequence byte to these, so framing them one byte
+    // too long stalls the connection waiting for a byte that never arrives.
+    const exempt = [PacketHeaderEnum.HANDSHAKE, PacketHeaderEnum.PONG, PacketHeaderEnum.SERVER_STATUS_REQUEST];
+
+    for (const header of exempt) {
+        it(`should not add a sequence byte to header ${header}`, () => {
+            const packet = makePackets().get(header)!.createPacket({ id: 0, time: 0, delta: 0 });
+
+            expect(packet.getSequenceLength()).to.be.equal(0);
+            expect(packet.getFrameLength(Buffer.alloc(64))).to.be.equal(packet.getSize());
+        });
+    }
+
+    it('should add a sequence byte to a regular client packet', () => {
+        const packet = makePackets().get(PacketHeaderEnum.ATTACK)!.createPacket({});
+
+        expect(packet.getSequenceLength()).to.be.equal(1);
+        expect(packet.getFrameLength(Buffer.alloc(64))).to.be.equal(packet.getSize() + 1);
+    });
+});
+
 describe('Variable-length frame sizes', () => {
     it('should size a shop packet by its subheader', () => {
         const frameFor = (subHeader: number) => new ShopPacket().getFrameLength(Buffer.from([0x32, subHeader]));
 
-        expect(frameFor(ShopSubHeaderCG.END)).to.be.equal(2);
-        expect(frameFor(ShopSubHeaderCG.BUY)).to.be.equal(4);
-        expect(frameFor(ShopSubHeaderCG.SELL)).to.be.equal(3);
-        expect(frameFor(ShopSubHeaderCG.SELL2)).to.be.equal(4);
+        expect(frameFor(ShopSubHeaderCG.END)).to.be.equal(3);
+        expect(frameFor(ShopSubHeaderCG.BUY)).to.be.equal(5);
+        expect(frameFor(ShopSubHeaderCG.SELL)).to.be.equal(4);
+        expect(frameFor(ShopSubHeaderCG.SELL2)).to.be.equal(5);
         expect(new ShopPacket().getFrameLength(Buffer.from([0x32]))).to.be.equal(null);
     });
 
-    it('should frame an incoming empire packet at its 2-byte wire size, not the 3-byte send size', () => {
-        expect(new EmpirePacket({ empireId: 1 }).getFrameLength()).to.be.equal(2);
+    it('should frame an incoming empire packet by its inbound size plus the sequence byte', () => {
+        expect(new EmpirePacket({ empireId: 1 }).getFrameLength()).to.be.equal(3);
     });
 
     it('should size a private-shop packet by its item count', () => {
@@ -193,8 +226,8 @@ describe('Variable-length frame sizes', () => {
             return new MyShopPacket().getFrameLength(buffer);
         };
 
-        expect(withCount(0)).to.be.equal(35);
-        expect(withCount(3)).to.be.equal(35 + 3 * 13);
+        expect(withCount(0)).to.be.equal(36);
+        expect(withCount(3)).to.be.equal(36 + 3 * 13);
         expect(new MyShopPacket().getFrameLength(Buffer.alloc(10))).to.be.equal(null);
     });
 });

--- a/test/unit/core/interface/server/Server.test.ts
+++ b/test/unit/core/interface/server/Server.test.ts
@@ -10,8 +10,15 @@ import ShopPacket from '@/core/interface/networking/packets/packet/in/shop/ShopP
 import MyShopPacket from '@/core/interface/networking/packets/packet/in/myshop/MyShopPacket';
 import EmpirePacket from '@/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket';
 import { ShopSubHeaderCG } from '@/core/enum/ShopSubHeaderEnum';
+import AuthServer from '@/auth/interface/server/AuthServer';
 
-const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+type LogLine = { level: string; message: string };
+const logged: Array<LogLine> = [];
+const logger: any = {
+    info: (message: string) => logged.push({ level: 'info', message }),
+    error: (message: string) => logged.push({ level: 'error', message }),
+    debug: (message: string) => logged.push({ level: 'debug', message }),
+};
 
 class TestConnection extends Connection {
     onHandshakeSuccess(): void {}
@@ -37,6 +44,7 @@ class FrameRecorder extends Server {
 const createFakeSocket = () => {
     const socket: any = new EventEmitter();
     socket.setNoDelay = () => {};
+    socket.write = () => true;
     socket.destroy = sinon.spy();
     return socket;
 };
@@ -72,6 +80,7 @@ describe('Server packet framing', () => {
     let socket: any;
 
     beforeEach(() => {
+        logged.length = 0;
         server = new FrameRecorder({ logger, config: {} as any, packets: makePackets() });
         socket = createFakeSocket();
         server.onListener(socket);
@@ -114,6 +123,9 @@ describe('Server packet framing', () => {
         socket.emit('data', attackPacket());
         await settle();
         expect(server.frames).to.have.lengthOf(2);
+
+        const unknown = logged.filter((line) => line.message.includes('Unknown header'));
+        expect(unknown.map((line) => line.level)).to.deep.equal(['info']);
     });
 
     it('should close the connection when a packet claims an absurd length', async () => {
@@ -178,6 +190,31 @@ describe('Server packet framing', () => {
 
         expect(server.frames).to.have.lengthOf(1);
         expect(server.frames[0]).to.have.lengthOf(66);
+    });
+});
+
+describe('Unknown header log level', () => {
+    // Auth sees headers it does not implement as part of normal client traffic,
+    // so it kept them at debug before the framing loop moved into Server.
+    it('should stay at debug on the auth server', async () => {
+        logged.length = 0;
+        const server = new AuthServer({
+            logger,
+            config: {} as any,
+            packets: makePackets(),
+            containerInstance: { createScope: () => {} },
+        } as any);
+        const socket = createFakeSocket();
+        server.onListener(socket);
+
+        socket.emit('data', Buffer.from([0xee, 0x01, 0x02]));
+        await settle();
+
+        const unknown = logged.filter((line) => line.message.includes('Unknown header'));
+        expect(unknown).to.have.lengthOf(1);
+        expect(unknown[0].level).to.be.equal('debug');
+
+        socket.emit('close');
     });
 });
 


### PR DESCRIPTION
## Heads up: this fixes a regression I introduced in #77

#77 is merged, and it breaks real clients. I found this testing with the TMP4 client and want it in front of you quickly. Sorry for the miss — my integration tests passed because the test harness did not reproduce this part of the protocol.

## What is wrong

The framing loop drains a socket read packet by packet, so it needs each packet's exact on-wire length. It does not account for the **sequence byte**: with `SEQUENCE_PACKET_ENABLE` (which the TMP4 client sets, `constinfo.py:47`) the client calls `SendSequence()` after most packets, trailing one byte taken from a fixed table. The loop reads that byte as the header of the next packet.

So every packet leaves a stray byte behind. The game server log fills up:

```
[IN][PACKET] Unknown header packet: 175, discarding 1 buffered byte(s)
[IN][PACKET] Unknown header packet: 202, discarding 1 buffered byte(s)
[IN][PACKET] Unknown header packet: 207, discarding 1 buffered byte(s)
...
```

Those numbers are not random — they are **consecutive entries of the client's sequence table** (`NetStream.cpp:881`, which begins `0xaf, 0xca, 0x8a, 0xcf, 0x48, 0xa7, ...` = 175, 202, 138, 207, 72, 167 …).

It gets worse when an entry happens to be a header we implement. Table index 14 is `0x6f`, so the **game** server builds a `LoginRequestPacketHandler` and throws:

```
Could not resolve 'loginService'.
    at new LoginRequestPacketHandler (...)
    at GameServer.onData (...)
```

And an entry landing on a variable-length header (chat) makes the loop read a length out of unrelated bytes — which drops real packets (`discarding 9/16/18 buffered byte(s)` in my logs) or closes the connection outright.

## The deeper cause: the declared sizes had drifted

The old one-read-one-packet code ignored trailing bytes, so `size` never had to be right — and it had drifted into three groups:

- already counted the sequence byte: item-use 5, item-move 9, move 17, empire 3, chat `6+len`
- did not: attack 8, token 52, target 5, on-click 5, script-answer 2
- plain wrong: item-drop 5 (the client sends the drop2 struct), enter-game 0, state-checker 10, quickslot-remove 4

Harmless before; load-bearing the moment framing consumes exact lengths. **This is the part of #77 I got wrong** — I "corrected" some sizes downward, which removed the sequence allowance that was accidentally right.

## The fix

Follow the original: `size` is the struct size alone, and a per-packet `sequenced` flag adds the trailing byte. That mirrors `CPacketInfo::Set`, which does `iSize += sizeof(BYTE)` when the packet is sequenced, and opts out per header via `SetSequence(HEADER_CG_PONG, false)`.

Sizes are re-derived from the client structs (`Packet.h`, `#pragma pack(1)`) cross-checked against the original's `CPacketInfoCG` registrations. Handshake, pong and the state checker are the packets the client sends **without** a sequence byte (handshake and state-checker are `false` in `CPacketInfoCG`; pong only appends one in security mode).

## Two mistakes worth calling out

**`PacketBidirectional` did not forward `sequenced` to `super`.** That silently dropped the handshake's opt-out, so the server waited for a 14th byte the client never sends and the connection just stalled — the integration suite stopped terminating, which is how I caught it. There is now a unit spec pinning the exemptions so this cannot come back silently.

**The harness did not send sequence bytes**, which is exactly why #77's tests passed while the real protocol was broken. It now trails one like the client does.

## Verification

Against the **real client**: logs in, enters the world, drives quest dialogs — zero misread headers, zero malformed packets, zero dropped connections. Before the fix the same session produced dozens of sequence-table headers plus the `loginService` throw.

The only unknown header left is `100` (guild `MARK_LOGIN`, not implemented in open-mt2), discarded cleanly at its exact 9-byte size — same as on master before #77.

`npm run test:unit` 457 passing, `npm run test:integration` 13 passing (including the melee #68 and move-speed #65 specs merged alongside).

## Not included

The original also **validates** the sequence byte against its own copy of the table and disconnects on mismatch — a genuine anti-tamper check. That needs the 32768-entry table embedded server-side, so I left it out of this fix; happy to open an issue for it if you want it