### PR TITLE
fix: gate debug chat behind /debug and follow the original regen (fix #61)

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -31,6 +31,7 @@ export default abstract class Character extends GameEntity {
     protected startPositionY: number = 0;
     protected movementStart: number = 0;
     protected movementDuration: number = 0;
+    protected lastMoveTime: number = performance.now();
 
     protected readonly nearbyEntities = new Map<number, GameEntity>();
 
@@ -215,6 +216,7 @@ export default abstract class Character extends GameEntity {
         }
 
         this.rotation = rotation * 5;
+        this.onMove();
         this.stateMachine.gotoState(EntityStateEnum.MOVING);
     }
 
@@ -243,11 +245,21 @@ export default abstract class Character extends GameEntity {
         this.positionX = this.startPositionX = this.targetPositionX = x;
         this.positionY = this.startPositionY = this.targetPositionY = y;
         this.setRotation(MathUtil.calcRotationFromXY(x, y));
+        this.onMove();
         this.stateMachine.gotoState(EntityStateEnum.IDLE);
     }
 
     stop() {
         this.stateMachine.gotoState(EntityStateEnum.IDLE);
+    }
+
+    /** Mirrors the original's OnMove(): moving and attacking both refresh this. */
+    protected onMove() {
+        this.lastMoveTime = performance.now();
+    }
+
+    getLastMoveTime() {
+        return this.lastMoveTime;
     }
 
     getMovementSpeed() {

--- a/src/core/domain/entities/game/mob/Monster.ts
+++ b/src/core/domain/entities/game/mob/Monster.ts
@@ -1,7 +1,6 @@
 import DropManager from '@/core/domain/manager/DropManager';
 import ExperienceManager from '@/core/domain/manager/ExperienceManager';
 import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
-import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import { FlyEnum } from '@/core/enum/FlyEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -268,10 +267,7 @@ export default class Monster extends Mob {
 
             const expToGive = this.experienceManager.calculateExpToGive(player, this, playerExp);
 
-            player.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM] Earned ${expToGive} of EXP after kill ${this.folder || this.name}`,
-            });
+            player.debugChat(`Earned ${expToGive} of EXP after kill ${this.folder || this.name}`);
 
             player.addPoint(PointsEnum.EXPERIENCE, expToGive);
 

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -7,7 +7,6 @@ import Logger from '@/core/infra/logger/Logger';
 import { DamageTypeEnum } from '@/core/enum/DamageTypeEnum';
 import BitFlag from '@/core/util/BitFlag';
 import { DamageFlagEnum } from '@/core/enum/DamageFlagEnum';
-import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { MobEnchantEnum } from '@/core/enum/MobEnchantEnum';
 import Player from '../../../player/Player';
 import { MobImmuneFlagEnum } from '@/core/enum/MobImmuneFlagEnum';
@@ -136,10 +135,7 @@ export default class MonsterBattle {
 
         damage = damage > 0 ? Math.round(damage) : MathUtil.getRandomInt(1, 5);
 
-        victim.chat({
-            message: `[SYSTEM] Damage received: ${damage}`,
-            messageType: ChatMessageTypeEnum.INFO,
-        });
+        victim.debugChat(`Damage received: ${damage}`);
 
         victim.sendDamageReceived({
             damage,
@@ -159,15 +155,9 @@ export default class MonsterBattle {
                 reflectDamage = reflectDamage / 3 + 0.5; //TODO: verify this numbers
             }
 
-            victim.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][REFLECT] You applied ${Math.round(reflectDamage)} as a reflect damage`,
-            });
+            victim.debugChat(`[REFLECT] You applied ${Math.round(reflectDamage)} as a reflect damage`);
 
-            victim.chat({
-                message: `[SYSTEM] Damage received: ${damage}`,
-                messageType: ChatMessageTypeEnum.INFO,
-            });
+            victim.debugChat(`Damage received: ${damage}`);
 
             victim.sendDamageReceived({
                 damage,
@@ -204,10 +194,7 @@ export default class MonsterBattle {
         if (this.attacker.isDeathBlower()) {
             if (MathUtil.getRandomInt(1, 100) <= this.attacker.getDeathBlowChance()) {
                 damage *= 4;
-                victim.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][DEATH_BLOW] You received ${Math.round(damage / 5)} extra damage as deathblow`,
-                });
+                victim.debugChat(`[DEATH_BLOW] You received ${Math.round(damage / 5)} extra damage as deathblow`);
             }
         }
 
@@ -219,10 +206,7 @@ export default class MonsterBattle {
         if (MathUtil.getRandomInt(1, 100) <= criticalChance) {
             damage *= 2;
             damageFlags.set(DamageFlagEnum.CRITICAL);
-            victim.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][CRIT_DAMAGE] You received ${Math.round(damage / 2)} extra damage as critical`,
-            });
+            victim.debugChat(`[CRIT_DAMAGE] You received ${Math.round(damage / 2)} extra damage as critical`);
         }
 
         return Math.round(damage);
@@ -233,10 +217,7 @@ export default class MonsterBattle {
         if (MathUtil.getRandomInt(1, 100) <= penetrateChance) {
             damage += victim.getDefense(); //TODO: is this a bug or feature?
             damageFlags.set(DamageFlagEnum.PENETRATE);
-            victim.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][PENETRATE_DAMAGE] You received ${victim.getDefense()} extra damage as penetrate`,
-            });
+            victim.debugChat(`[PENETRATE_DAMAGE] You received ${victim.getDefense()} extra damage as penetrate`);
         }
         return Math.round(damage);
     }

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -121,6 +121,12 @@ const CHAT_MAX_PER_WINDOW = 10;
 const SHOUT_MIN_LEVEL = 15;
 const SHOUT_COOLDOWN_MS = 15_000;
 
+// From the original's recovery_event (char.cpp): the percent is indexed by how
+// many 3s steps since the character last moved, and the flat part is added
+// before the regen bonus, not after.
+const RECOVERY_PERCENT_BY_STEP = [1, 5, 5, 5, 5, 5, 5, 5, 5, 5];
+const RECOVERY_FLAT_HEALTH = 15;
+
 export default class Player extends Character {
     private readonly accountId: number;
     private readonly playerClass: number;
@@ -156,6 +162,7 @@ export default class Player extends Character {
     private recentMoves: Array<{ time: number; distance: number }> = [];
 
     //chat
+    private debugMode: boolean = false;
     private chatTimes: Array<number> = [];
     private lastShoutTime: number = 0;
 
@@ -550,6 +557,7 @@ export default class Player extends Character {
 
         this.setPos(PositionEnum.FIGHTING);
         this.lastTimeInBattle = now;
+        this.onMove();
         this.battle.attack(attackType, victim);
     }
 
@@ -742,10 +750,7 @@ export default class Player extends Character {
 
         const attackerName =
             attacker instanceof Mob ? `${attacker.getFolder()}:${attacker.getVirtualId()}` : attacker.getName();
-        this.chat({
-            messageType: ChatMessageTypeEnum.INFO,
-            message: `[SYSTEM] You has been attacked by ${attackerName}`,
-        });
+        this.debugChat(`You has been attacked by ${attackerName}`);
         this.addPoint(PointsEnum.HEALTH, -damage);
 
         if (this.points.getPoint(PointsEnum.HEALTH) <= 0) {
@@ -807,35 +812,61 @@ export default class Player extends Character {
         );
     }
 
-    regenHealth() {
-        if (this.isAffectByFlag(AffectBitsTypeEnum.STUN)) return;
-        if (this.isDead()) return;
-        if (this.points.getPoint(PointsEnum.HEALTH) >= this.points.getPoint(PointsEnum.MAX_HEALTH)) return;
+    toggleDebugMode() {
+        this.debugMode = !this.debugMode;
+        return this.debugMode;
+    }
 
-        let percent = this.stateMachine.getCurrentStateName() === EntityStateEnum.IDLE ? 5 : 1;
-        percent += percent * (this.points.getPoint(PointsEnum.HP_REGEN) / 100);
-        const amount = this.points.getPoint(PointsEnum.MAX_HEALTH) * (percent / 100);
-        this.points.addPoint(PointsEnum.HEALTH, Math.floor(amount));
+    isDebugMode() {
+        return this.debugMode;
+    }
+
+    /** Chat output that only the player's own /debug toggle turns on. */
+    debugChat(message: string) {
+        if (!this.debugMode) return;
+
         this.chat({
             messageType: ChatMessageTypeEnum.INFO,
-            message: `[SYSTEM][HP REGEN] amount: ${Math.floor(amount)} percent: ${percent}`,
+            message: `[DEBUG] ${message}`,
         });
+    }
+
+    private getRecoveryPercent() {
+        const steps = Math.floor((performance.now() - this.lastMoveTime) / REGEN_INTERVAL);
+        return RECOVERY_PERCENT_BY_STEP[Math.min(RECOVERY_PERCENT_BY_STEP.length - 1, steps)];
+    }
+
+    private isRecoveryBlocked() {
+        return (
+            this.isAffectByFlag(AffectBitsTypeEnum.STUN) ||
+            this.isAffectByFlag(AffectBitsTypeEnum.POISON) ||
+            this.isDead()
+        );
+    }
+
+    regenHealth() {
+        if (this.isRecoveryBlocked()) return;
+        if (this.points.getPoint(PointsEnum.HEALTH) >= this.points.getPoint(PointsEnum.MAX_HEALTH)) return;
+
+        const percent = this.getRecoveryPercent();
+        const base = RECOVERY_FLAT_HEALTH + (this.points.getPoint(PointsEnum.MAX_HEALTH) * percent) / 100;
+        const amount = Math.floor(base + (base * this.points.getPoint(PointsEnum.HP_REGEN)) / 100);
+
+        this.points.addPoint(PointsEnum.HEALTH, amount);
+        this.debugChat(`[HP REGEN] amount: ${amount} percent: ${percent}`);
         this.sendPoints();
     }
 
     regenMana() {
-        if (this.isAffectByFlag(AffectBitsTypeEnum.STUN)) return;
-        if (this.isDead()) return;
+        if (this.isRecoveryBlocked()) return;
         if (this.points.getPoint(PointsEnum.MANA) >= this.points.getPoint(PointsEnum.MAX_MANA)) return;
 
-        let percent = this.stateMachine.getCurrentStateName() === EntityStateEnum.IDLE ? 5 : 1;
-        percent += percent * (this.points.getPoint(PointsEnum.MANA_REGEN) / 100);
-        const amount = this.points.getPoint(PointsEnum.MAX_MANA) * (percent / 100);
-        this.points.addPoint(PointsEnum.MANA, Math.floor(amount));
-        this.chat({
-            messageType: ChatMessageTypeEnum.INFO,
-            message: `[SYSTEM][MANA REGEN] amount: ${Math.floor(amount)} percent: ${percent}`,
-        });
+        const percent = this.getRecoveryPercent();
+        const base = (this.points.getPoint(PointsEnum.MAX_MANA) * percent) / 100;
+        const amount = Math.floor(base + (base * this.points.getPoint(PointsEnum.MANA_REGEN)) / 100);
+
+        this.points.addPoint(PointsEnum.MANA, amount);
+        this.debugChat(`[MANA REGEN] amount: ${amount} percent: ${percent}`);
         this.sendPoints();
     }
 

--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
@@ -11,7 +11,6 @@ import BitFlag from '@/core/util/BitFlag';
 import { DamageFlagEnum } from '@/core/enum/DamageFlagEnum';
 import { MobResistEnum } from '@/core/enum/MobResistEnum';
 import { ItemWeaponSubTypeEnum } from '@/core/enum/ItemWeaponSubTypeEnum';
-import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { MobRaceFlagEnum } from '@/core/enum/MobRaceFlagEnum';
 import Monster from '../../../mob/Monster';
 import Player from '../../Player';
@@ -147,10 +146,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
 
         damage = damage > 0 ? Math.round(damage) : MathUtil.getRandomInt(1, 5);
 
-        this.attacker.chat({
-            message: `your damage is: ${damage}`,
-            messageType: ChatMessageTypeEnum.INFO,
-        });
+        this.attacker.debugChat(`your damage is: ${damage}`);
 
         this.attacker.sendDamageCaused({
             virtualId: victim.getVirtualId(),
@@ -243,10 +239,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
     private calculateStoneSkinner(damage: number, victim: Monster): number {
         if (victim.isStoneSkinner()) {
             if (victim.getHealthPercentage() < victim.getHpPercentToGetStoneSkin()) {
-                this.attacker.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][STONE_SKINNER] Your damage was reduced from ${damage} to ${damage / 2}`,
-                });
+                this.attacker.debugChat(`[STONE_SKINNER] Your damage was reduced from ${damage} to ${damage / 2}`);
                 damage /= 2;
             }
         }
@@ -310,10 +303,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
             //TODO: add gold bonus do multiply this
             const amount = MathUtil.getRandomInt(1, victim.getPoint(PointsEnum.LEVEL) * 50);
             this.attacker.addPoint(PointsEnum.GOLD, amount);
-            this.attacker.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][GOLD_STEAL] You received ${amount} of gold`,
-            });
+            this.attacker.debugChat(`[GOLD_STEAL] You received ${amount} of gold`);
         }
     }
 
@@ -454,10 +444,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
         if (MathUtil.getRandomInt(1, 100) <= criticalChance) {
             damage *= 2;
             damageFlags.set(DamageFlagEnum.CRITICAL);
-            this.attacker.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][CRIT_DAMAGE] You deal ${Math.round(damage / 2)} extra damage as critical`,
-            });
+            this.attacker.debugChat(`[CRIT_DAMAGE] You deal ${Math.round(damage / 2)} extra damage as critical`);
         }
 
         return Math.round(damage);
@@ -468,10 +455,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
         if (MathUtil.getRandomInt(1, 100) <= penetrateChance) {
             damage += victim.getDefense();
             damageFlags.set(DamageFlagEnum.PENETRATE);
-            this.attacker.chat({
-                messageType: ChatMessageTypeEnum.INFO,
-                message: `[SYSTEM][PENETRATE_DAMAGE] You deal ${victim.getDefense()} extra damage as penetrate`,
-            });
+            this.attacker.debugChat(`[PENETRATE_DAMAGE] You deal ${victim.getDefense()} extra damage as penetrate`);
         }
         return Math.round(damage);
     }
@@ -492,11 +476,8 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
                 this.attacker.addPoint(PointsEnum.HEALTH, healthDamage);
 
                 victim.createFlyEffect(this.attacker.getVirtualId(), FlyEnum.HEALTH_BIG);
-                this.attacker.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][HEALTH_STEAL] You received ${healthDamage} of health
-                    `,
-                });
+                this.attacker.debugChat(`[HEALTH_STEAL] You received ${healthDamage} of health
+                    `);
             }
         }
     }
@@ -521,10 +502,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
                 this.attacker.addPoint(PointsEnum.MANA, manaDamage);
                 victim.createFlyEffect(this.attacker.getVirtualId(), FlyEnum.MANA_BIG);
 
-                this.attacker.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][MANA_STEAL] You received ${manaDamage} of mana`,
-                });
+                this.attacker.debugChat(`[MANA_STEAL] You received ${manaDamage} of mana`);
             }
         }
     }
@@ -540,10 +518,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
             if (amount > 0) {
                 this.attacker.addPoint(PointsEnum.HEALTH, amount);
                 victim.createFlyEffect(this.attacker.getVirtualId(), FlyEnum.HEALTH_BIG);
-                this.attacker.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][HEALTH_HIT_RECOVERY] You received ${amount} of health`,
-                });
+                this.attacker.debugChat(`[HEALTH_HIT_RECOVERY] You received ${amount} of health`);
             }
         }
     }
@@ -560,10 +535,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
             if (amount > 0) {
                 this.attacker.addPoint(PointsEnum.MANA, amount);
                 victim.createFlyEffect(this.attacker.getVirtualId(), FlyEnum.MANA_BIG);
-                this.attacker.chat({
-                    messageType: ChatMessageTypeEnum.INFO,
-                    message: `[SYSTEM][MANA_HIT_RECOVERY] You received ${amount} of mana`,
-                });
+                this.attacker.debugChat(`[MANA_HIT_RECOVERY] You received ${amount} of mana`);
             }
         }
     }

--- a/src/game/domain/command/Commands.ts
+++ b/src/game/domain/command/Commands.ts
@@ -3,6 +3,8 @@ import BlockModeCommand from './command/blockMode/BlockModeCommand';
 import BlockModeCommandHandler from './command/blockMode/BlockModeCommandHandler';
 import CloseShopCommand from './command/closeShop/CloseShopCommand';
 import CloseShopCommandHandler from './command/closeShop/CloseShopCommandHandler';
+import DebugCommand from './command/debug/DebugCommand';
+import DebugCommandHandler from './command/debug/DebugCommandHandler';
 import ExperienceCommand from './command/exp/ExperienceCommand';
 import ExperienceCommandHandler from './command/exp/ExperienceCommandHandler';
 import GoldCommand from './command/gold/GoldCommand';
@@ -61,6 +63,13 @@ export default function createCommands() {
             {
                 command: LogoutCommand,
                 createHandler: (params) => new LogoutCommandHandler(params),
+            },
+        ],
+        [
+            DebugCommand.getName(),
+            {
+                command: DebugCommand,
+                createHandler: (params) => new DebugCommandHandler(params),
             },
         ],
         [

--- a/src/game/domain/command/command/debug/DebugCommand.ts
+++ b/src/game/domain/command/command/debug/DebugCommand.ts
@@ -1,0 +1,10 @@
+import Command from '../../Command';
+
+export default class DebugCommand extends Command {
+    static getName() {
+        return '/debug';
+    }
+    static getDescription() {
+        return 'toggle debug messages (regen, damage taken) in your own chat';
+    }
+}

--- a/src/game/domain/command/command/debug/DebugCommandHandler.ts
+++ b/src/game/domain/command/command/debug/DebugCommandHandler.ts
@@ -1,0 +1,23 @@
+import Logger from '@/core/infra/logger/Logger';
+import CommandHandler from '../../CommandHandler';
+import DebugCommand from './DebugCommand';
+import Player from '@/core/domain/entities/game/player/Player';
+import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+
+export default class DebugCommandHandler extends CommandHandler<DebugCommand> {
+    private readonly logger: Logger;
+
+    constructor({ logger }: { logger: Logger }) {
+        super();
+        this.logger = logger;
+    }
+
+    async execute(player: Player) {
+        const enabled = player.toggleDebugMode();
+        this.logger.info(`[DebugCommandHandler] Debug mode ${enabled ? 'on' : 'off'} for ${player.getName()}`);
+        player.chat({
+            message: `Debug messages ${enabled ? 'enabled' : 'disabled'}`,
+            messageType: ChatMessageTypeEnum.INFO,
+        });
+    }
+}

--- a/test/integration/game/attackRangeSecurity.test.ts
+++ b/test/integration/game/attackRangeSecurity.test.ts
@@ -56,6 +56,11 @@ describe('Security — melee attack range (issue #68)', function () {
             y: monster!.getPositionY(),
         });
 
+        // The damage line is debug output now, so it has to be switched on or
+        // both assertions below would be vacuously false.
+        sniper.command('/debug');
+        await sniper.settle(400);
+
         sniper.flush();
         sniper.attack(virtualId);
         await sniper.settle(600);
@@ -69,6 +74,9 @@ describe('Security — melee attack range (issue #68)', function () {
             x: monster!.getPositionX(),
             y: monster!.getPositionY(),
         });
+
+        brawler.command('/debug');
+        await brawler.settle(400);
 
         brawler.flush();
         brawler.attack(virtualId);

--- a/test/unit/core/domain/entities/game/player/PlayerRecovery.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerRecovery.test.ts
@@ -1,0 +1,220 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
+import Logger from '@/core/infra/logger/Logger';
+
+const logger: Logger = { info: () => {}, error: () => {}, debug: () => {} };
+
+const REGEN_INTERVAL = 3_000;
+const RECOVERY_FLAT_HEALTH = 15;
+const MAX_HEALTH = 1_000;
+const MAX_MANA = 500;
+
+const createPlayer = () => {
+    const config: any = {
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: MAX_HEALTH,
+                    initialMp: MAX_MANA,
+                    initialStamina: 30,
+                    hpPerLvl: 0,
+                    hpPerHtPoint: 0,
+                    mpPerLvl: 0,
+                    mpPerIqPoint: 0,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: 100_000,
+            positionY: 100_000,
+            health: 1,
+            mana: 1,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'healer',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+            mobManager: {} as any,
+        },
+    );
+
+    const sent: Array<any> = [];
+    player.setConnection({ send: (packet: any) => sent.push(packet) } as any);
+
+    // PlayerFactory does not run the private init(), so the max points are still
+    // 0 here and every regen would early-return as "already full".
+    player.onEquipmentChange();
+    sent.length = 0;
+
+    return { player, sent };
+};
+
+/**
+ * Chat the player actually received. ChatOutPacket exposes no getter for its
+ * message, so the text is read back off the packed buffer.
+ */
+const messages = (sent: Array<any>) =>
+    sent.filter((p) => p.getName?.() === 'ChatOutPacket').map((p) => p.pack().toString('ascii'));
+
+describe('Player recovery', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers({ now: 1_000_000, toFake: ['performance'] });
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+    describe('amount', () => {
+        it('should heal the flat amount plus 1% right after moving', () => {
+            const { player } = createPlayer();
+
+            player.regenHealth();
+
+            const expected = RECOVERY_FLAT_HEALTH + MAX_HEALTH * 0.01;
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1 + expected);
+        });
+
+        it('should ramp to 5% once a full step has passed without moving', () => {
+            const { player } = createPlayer();
+
+            clock.tick(REGEN_INTERVAL);
+            player.regenHealth();
+
+            const expected = RECOVERY_FLAT_HEALTH + MAX_HEALTH * 0.05;
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1 + expected);
+        });
+
+        it('should drop back to 1% after the character moves again', () => {
+            const { player } = createPlayer();
+
+            clock.tick(REGEN_INTERVAL * 5);
+            player.goto({ positionX: 100_500, positionY: 100_000, arg: 0, rotation: 0, time: 0, movementType: 1 });
+            player.regenHealth();
+
+            const expected = RECOVERY_FLAT_HEALTH + MAX_HEALTH * 0.01;
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1 + expected);
+        });
+
+        it('should apply the regen bonus to the whole amount, flat part included', () => {
+            const { player } = createPlayer();
+            player.addPoint(PointsEnum.HP_REGEN, 100);
+
+            player.regenHealth();
+
+            const base = RECOVERY_FLAT_HEALTH + MAX_HEALTH * 0.01;
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1 + base * 2);
+        });
+
+        it('should not add the health flat amount to mana', () => {
+            const { player } = createPlayer();
+
+            player.regenMana();
+
+            expect(player.getPoint(PointsEnum.MANA)).to.be.equal(1 + MAX_MANA * 0.01);
+        });
+    });
+
+    describe('blocked while', () => {
+        it('stunned', () => {
+            const { player } = createPlayer();
+            player.setAffectFlag(AffectBitsTypeEnum.STUN);
+
+            player.regenHealth();
+
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1);
+        });
+
+        it('poisoned', () => {
+            const { player } = createPlayer();
+            player.setAffectFlag(AffectBitsTypeEnum.POISON);
+
+            player.regenHealth();
+
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(1);
+        });
+
+        it('already at full health', () => {
+            const { player, sent } = createPlayer();
+            player.addPoint(PointsEnum.HEALTH, MAX_HEALTH);
+
+            player.regenHealth();
+
+            expect(player.getPoint(PointsEnum.HEALTH)).to.be.equal(MAX_HEALTH);
+            expect(messages(sent)).to.deep.equal([]);
+        });
+    });
+});
+
+describe('Player debug chat', () => {
+    it('should stay silent while debug mode is off', () => {
+        const { player, sent } = createPlayer();
+
+        player.regenHealth();
+        player.debugChat('anything');
+
+        expect(messages(sent)).to.deep.equal([]);
+    });
+
+    it('should emit regen messages once debug mode is on', () => {
+        const { player, sent } = createPlayer();
+
+        expect(player.toggleDebugMode()).to.be.equal(true);
+        player.regenHealth();
+
+        expect(messages(sent).some((m) => m.includes('[DEBUG]') && m.includes('HP REGEN'))).to.be.equal(true);
+    });
+
+    it('should go quiet again when toggled off', () => {
+        const { player, sent } = createPlayer();
+
+        player.toggleDebugMode();
+        expect(player.toggleDebugMode()).to.be.equal(false);
+        expect(player.isDebugMode()).to.be.equal(false);
+
+        player.regenHealth();
+
+        expect(messages(sent)).to.deep.equal([]);
+    });
+});


### PR DESCRIPTION
Takes #61 with the `/debug` command you proposed, in the simplest form.

## The spam was wider than the issue said

The issue named three messages. Testing in game showed that turning `/debug` off changed almost nothing, because combat carries **sixteen** of the same `[SYSTEM][TAG]` diagnostics, and those fire far more often than the regen ones:

**Attacking** (`PlayerBattleAgainstMobStrategy`, `Monster`): `your damage is: N` on every hit, `[STONE_SKINNER]`, `[GOLD_STEAL]`, `[CRIT_DAMAGE]`, `[PENETRATE_DAMAGE]`, `[HEALTH_STEAL]`, `[MANA_STEAL]`, `[HEALTH_HIT_RECOVERY]`, `[MANA_HIT_RECOVERY]`, `Earned N of EXP after kill`.

**Being attacked** (`MonsterBattle`): `Damage received: N` on every hit taken (twice on a reflect), `[REFLECT]`, `[DEATH_BLOW]`, `[CRIT_DAMAGE]`, `[PENETRATE_DAMAGE]`.

**Regen / damage taken** (`Player`): the two regen lines and `You has been attacked by`, which is what the issue lists.

None of these is player-facing in the original: damage reaches the client through `sendDamageCaused` and is drawn as a floating number from the damage flags, and experience shows in the bar. The issue title says "regen and **damage** debug chat spam", so damage is in scope; the experience line on kill is the one addition beyond that reading, kept because it is the same residue and fires constantly. Say the word and I will drop it.

I swept every `chat()` call in `src` to make sure this is the end of it — what remains is genuine feedback (welcome, death, restart countdowns, inventory full, command results, quest text, drop and pickup rejections).

## /debug

A per-player toggle, **off by default and not persisted**, following the existing layout — Command + Handler, no validator (like `/logout`, since it takes no arguments). `Player.debugChat()` is a no-op while the toggle is off, so a developer can turn the whole set on for their own character without spamming anyone. It shows up in `/help` automatically.

Left ungated by privilege, per "the simplest version for now" — happy to put it behind the privilege system whenever #64 gives us one.

## Recovery, now following recovery_event (char.cpp)

- **Percent from time, not state.** Indexed by how many 3s steps have passed since the character last moved (`aiRecoveryPercents = {1, 5, 5, ...}`), instead of reading the IDLE state-machine state.
- **Flat 15 before the bonus.** The original does `iAmount = 15 + (maxHP * percent) / 100` and *then* `iAmount += (iAmount * POINT_HP_REGEN) / 100`. Ours scaled the percentage by the bonus, so the bonus never applied to the flat part — and there was no flat part.
- **Blocked while poisoned**, matching the original's early return. The `POISON` flag is never set today, so this only bites once affects land (#54), but the guard belongs with the rest of the formula.

`lastMoveTime` lands on `Character` with an `onMove()` mirroring the original: **both moving and attacking refresh it** (`OnMove()` / `OnMove(true)`). Worth flagging because it corrects something I wrote in the issue — I said the original "keeps regenerating at 5% while standing still in combat", but attacking resets the timer there too, so it does not.

**Mana** keeps its percentage-only formula, now keyed off the same timer. The original's SP recovery is a different shape entirely — job-dependent (shaman and sura-2 have their own tiers), split across attacking/moving/idle, with an extra branch for whether HP is full. Porting that is its own piece of work, so I left it rather than half-applying it.

## Tests

Unit specs for the amount at 1% and at 5%, the ramp resetting when the character moves, the bonus covering the flat part, mana not taking the health constant, the stun/poison/full-health guards, and the toggle staying silent when off.

Two things worth being open about:

**My first version of these tests passed vacuously.** `ChatOutPacket` exposes no getter for its message, so the helper meant to read the chat returned an empty list every time and the "should be silent" assertions were comparing `[] === []`. The helper now reads the text back off the packed buffer, and I verified the specs fail both with the debug gate removed and with the flat amount dropped.

**The melee range spec (#68) used the damage line as its signal that a hit landed**, so it now enables `/debug` first. Without that its positive assertion would fail and — worse — its negative assertion would pass for the wrong reason, since a silenced message looks exactly like a rejected attack.

`npm run test:unit` 464 passing, `npm run test:integration` 13 passing. Verified in game with a real client: chat silent while the toggle is off, everything back under `[DEBUG]` when on.

Branched off `master` (`ed0b245`), independent of #79.

Closes #61.