### PR TITLE
Security: validate the entity type on item pickup (fix #83)

### DIFF
--- a/src/core/interface/networking/packets/packet/in/itemPickup/ItemPickupPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/itemPickup/ItemPickupPacketHandler.ts
@@ -33,6 +33,6 @@ export default class ItemPickupPacketHandler extends PacketHandler<ItemPickupPac
             return;
         }
 
-        this.pickupItemService.execute(player, virtualId);
+        await this.pickupItemService.execute(player, virtualId);
     }
 }

--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -29,9 +29,9 @@ export default class PickupItemService {
     }
 
     async execute(player: Player, virtualId: number) {
-        const droppedItem = this.entityManager.getEntity<DroppedItem>(virtualId);
+        const droppedItem = this.entityManager.getEntity(virtualId);
 
-        if (!droppedItem) return;
+        if (!(droppedItem instanceof DroppedItem)) return;
         if (droppedItem.getArea() !== player.getArea()) return;
 
         const distance = MathUtil.calcDistance(

--- a/test/integration/game/itemPickupEntityTypeSecurity.test.ts
+++ b/test/integration/game/itemPickupEntityTypeSecurity.test.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import { container } from '@/game/Container';
+
+/**
+ * Security regression for issue #83: item pickup resolved the virtual id it was
+ * given without checking the entity is a ground item, so aiming it at a player
+ * or a monster threw inside the service. The handler never awaited it, so the
+ * rejection reached the process-level handler and exited the server.
+ *
+ * The awaited handler alone keeps the server up, so what pins the type guard is
+ * the assertion that nothing was thrown at all. Both cases also have to share an
+ * area with their target, otherwise the map check rejects the pickup first and
+ * the guard is never reached.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item pickup entity type (issue #83)', function () {
+    this.timeout(60000);
+
+    const USER = 'picktype_test';
+    const HUNTER = 'picktypemob_test';
+    const POTION = 27001;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+    let hunter: AttackSession;
+    let loggedErrors: sinon.SinonSpy;
+
+    /** Errors the pickup service logged while handling the packet, if any. */
+    const thrownInPickup = () =>
+        loggedErrors
+            .getCalls()
+            .map((call) => String(call.args[0]?.stack ?? call.args[0] ?? ''))
+            .filter((entry) => entry.includes('PickupItemService'));
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        session = await harness.login({ username: USER });
+    });
+
+    after(async () => {
+        await session?.close();
+        await hunter?.close();
+        await harness?.stop();
+    });
+
+    beforeEach(function () {
+        loggedErrors = sinon.spy(container.resolve<any>('logger'), 'error');
+    });
+
+    afterEach(function () {
+        loggedErrors.restore();
+    });
+
+    it('ignores a pickup aimed at the sender, without throwing', async () => {
+        const ownVirtualId = harness.findPlayer(USER)?.getVirtualId();
+        expect(ownVirtualId, 'setup: the attacker is in the world').to.not.equal(undefined);
+
+        session.pickup(ownVirtualId!);
+        await session.settle(800);
+
+        expect(thrownInPickup(), 'the pickup service did not throw').to.deep.equal([]);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped the handler').to.deep.equal([]);
+        expect(harness.findPlayer(USER), 'the sender is untouched').to.not.equal(undefined);
+    });
+
+    it('ignores a pickup aimed at a monster, without throwing', async () => {
+        // Mobs reach the world through the area spawn queue, so it takes a few
+        // ticks before there is a live one to aim at.
+        let monster = harness.findMonster();
+        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            monster = harness.findMonster();
+        }
+
+        expect(monster, 'setup: the world spawned a monster').to.not.equal(undefined);
+
+        hunter = await harness.login({
+            username: HUNTER,
+            x: monster!.getPositionX(),
+            y: monster!.getPositionY(),
+        });
+
+        expect(harness.findPlayer(HUNTER)?.getArea(), 'setup: standing on the monster').to.equal(monster!.getArea());
+
+        hunter.pickup(monster!.getVirtualId());
+        await hunter.settle(800);
+
+        expect(thrownInPickup(), 'the pickup service did not throw').to.deep.equal([]);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped the handler').to.deep.equal([]);
+    });
+
+    // Positive control: the guard rejects other entity types without also
+    // breaking the case it is meant to allow.
+    it('still picks up a real ground item', async () => {
+        session.command(`/item ${POTION} 3`);
+        await session.settle(600);
+
+        session.drop(1, 0, 0, 3);
+        await session.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the item reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        session.pickup(virtualId);
+        await session.settle(600);
+
+        expect(harness.findEntity(virtualId), 'the ground item was picked up').to.equal(undefined);
+        expect(thrownInPickup(), 'the pickup service did not throw').to.deep.equal([]);
+    });
+});

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -1,3 +1,4 @@
+import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
 import Player from '@/core/domain/entities/game/player/Player';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -16,6 +17,11 @@ describe('PickupItemService', function () {
         getPositionX: sinon.stub().returns(x),
         getPositionY: sinon.stub().returns(y),
     });
+
+    // The service narrows with `instanceof DroppedItem`, so a stub has to carry
+    // the prototype or every case below would be rejected as the wrong type and
+    // pass without exercising the check it targets.
+    const groundItem = (fields: object) => Object.assign(Object.create(DroppedItem.prototype), fields);
 
     let worldMock;
     let itemRepositoryMock;
@@ -51,12 +57,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
                 getCount: sinon.stub().returns(100),
                 getOwnerName: sinon.stub().returns('player1'),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -79,12 +85,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns(itemMock),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -103,12 +109,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player2'),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -132,12 +138,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
                 ...atPosition(AREA, POSITION.x + 1000, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -155,12 +161,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(2) }),
                 getCount: sinon.stub().returns(1),
                 getOwnerName: sinon.stub().returns('player1'),
                 ...atPosition(OTHER_AREA, POSITION.x, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -178,12 +184,12 @@ describe('PickupItemService', function () {
                 addPoint: sinon.spy(),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
             };
-            const droppedItemMock = {
+            const droppedItemMock = groundItem({
                 getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
                 getCount: sinon.stub().returns(100),
                 getOwnerName: sinon.stub().returns('player2'),
                 ...atPosition(AREA, POSITION.x, POSITION.y),
-            };
+            });
 
             entityManagerMock.getEntity.returns(droppedItemMock);
 
@@ -208,6 +214,33 @@ describe('PickupItemService', function () {
             expect(playerMock.addPoint.called).to.be.false;
             expect(playerMock.addItem.called).to.be.false;
             expect(playerMock.chat.called).to.be.false;
+        });
+
+        it('should ignore a virtual id that belongs to another entity type (issue #83)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.spy(),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            // A player resolved by its own virtual id: getItem exists there too,
+            // but it is the inventory accessor and expects a position.
+            const anotherPlayer = {
+                getItem: sinon.stub().throws(new Error('inventory accessor reached')),
+                getCount: sinon.stub().throws(new Error('not a ground item')),
+                getOwnerName: sinon.stub().throws(new Error('not a ground item')),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+
+            entityManagerMock.getEntity.returns(anotherPlayer);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(anotherPlayer.getItem.called, 'never treated as a ground item').to.be.false;
+            expect(playerMock.addPoint.called).to.be.false;
+            expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
         });
     });
 });


### PR DESCRIPTION
Fixes #83.

## The bug

`PickupItemService` resolved the virtual id through `getEntity<DroppedItem>`, which is an unchecked cast, and then called `getItem()` / `getCount()` / `getOwnerName()` on whatever came back. Players and mobs share the same entity map, so aiming `ITEM_PICKUP` at your own virtual id passed the area check (same area) and the distance check (zero) and reached `getItem()`:

- on a mob the method does not exist at all,
- on a player it does, but it is the inventory accessor and expects a position, so it ran `Inventory.getItem(NaN)` and threw on `pages[NaN]`.

The handler did not await the service, so the rejection reached the process-level `unhandledRejection` handler and exited the game server. One well-formed packet from any logged-in client took the whole server down.

## The fix

Narrow with `instanceof DroppedItem`, which is the pattern already used for ground items in `Player.onNearbyEntityAdded`:

```ts
const droppedItem = this.entityManager.getEntity(virtualId);

if (!(droppedItem instanceof DroppedItem)) return;
```

I also awaited the service in the handler. That is a second line of defence rather than part of the fix: it does not stop the throw, it stops a future one from ending the process — the shape you have open as #81. The same omission exists in the item-drop, item-move, item-use and enter-game handlers; I left those alone here, happy to sweep them in a follow-up if you want it.

## Tests

A unit case pins the guard and fails without it, and an integration spec drives the two real attacks through the in-process server.

One thing worth flagging, because it nearly slipped past me: with the handler awaited, the crash no longer produces an unhandled rejection — the error is caught and logged instead. My first version of the integration spec asserted only "server still alive, no unhandled rejection" and **passed with the guard removed**. The assertion that actually pins the guard is that the pickup service did not throw at all. Both malicious cases also had to be positioned to share an area with their target, otherwise the map check rejects the pickup first and the guard is never reached — the monster case was silently vacuous until I logged the attacker in at the monster position.

The existing pickup unit stubs needed the `DroppedItem` prototype. Without it every case would be rejected as the wrong type and would have kept passing while testing nothing.

Verified: 454 unit tests and the full integration suite (16) green; with the guard removed, 1 unit case and both malicious integration cases fail.

## Note on scope

Pre-existing, not a regression from #71 — that PR added the area and distance validation, but the entity type was never checked, before or after. Found while auditing the batch merged yesterday