### PR TITLE
Security: make item pickup idempotent (fix #84)

### DIFF
--- a/src/core/domain/entities/game/item/DroppedItem.ts
+++ b/src/core/domain/entities/game/item/DroppedItem.ts
@@ -11,6 +11,7 @@ export default class DroppedItem extends GameEntity {
     private readonly item: Item;
     private readonly count: number;
     private ownerName: string | null;
+    private taken: boolean = false;
 
     constructor(
         {
@@ -56,6 +57,14 @@ export default class DroppedItem extends GameEntity {
     }
     getOwnerName() {
         return this.ownerName;
+    }
+
+    isTaken() {
+        return this.taken;
+    }
+
+    markTaken() {
+        this.taken = true;
     }
 
     public onSpawn() {

--- a/src/game/app/service/PickupItemService.ts
+++ b/src/game/app/service/PickupItemService.ts
@@ -32,6 +32,7 @@ export default class PickupItemService {
         const droppedItem = this.entityManager.getEntity(virtualId);
 
         if (!(droppedItem instanceof DroppedItem)) return;
+        if (droppedItem.isTaken()) return;
         if (droppedItem.getArea() !== player.getArea()) return;
 
         const distance = MathUtil.calcDistance(
@@ -60,6 +61,7 @@ export default class PickupItemService {
         const isGold = item.getId() === 1;
 
         if (isGold) {
+            droppedItem.markTaken();
             player.addPoint(PointsEnum.GOLD, Number(count));
             this.world.despawn(droppedItem);
             return;
@@ -68,6 +70,7 @@ export default class PickupItemService {
         const added = player.addItemStacking(item);
         if (!added) return;
 
+        droppedItem.markTaken();
         this.world.despawn(droppedItem);
 
         for (const updated of added.updated) {

--- a/test/integration/game/itemPickupIdempotencySecurity.test.ts
+++ b/test/integration/game/itemPickupIdempotencySecurity.test.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+/**
+ * Security regression for issue #84: picking an item up only enqueues its
+ * despawn, so the entity stays resolvable until the next world tick. Without a
+ * claim flag every repeated ITEM_PICKUP for the same virtual id completed in
+ * full, crediting the loot once per packet.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — item pickup idempotency (issue #84)', function () {
+    this.timeout(60000);
+
+    const USER = 'pickdupe_test';
+    const POTION = 27001;
+    const GOLD_DROP = 100_000;
+    const REPEATS = 10;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        session = await harness.login({ username: USER });
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('credits dropped gold once even when the pickup packet is repeated', async () => {
+        const player = harness.findPlayer(USER);
+        expect(player, 'setup: the player is in the world').to.not.equal(undefined);
+
+        session.drop(1, 0, GOLD_DROP, 0);
+        await session.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the gold reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        const goldBefore = player!.getPoint(PointsEnum.GOLD);
+
+        // One TCP write, so every repeat is drained inside the same world tick,
+        // before the despawn queue has had a chance to run.
+        for (let repeat = 0; repeat < REPEATS; repeat++) {
+            session.pickup(virtualId);
+        }
+        await session.settle(1000);
+
+        expect(player!.getPoint(PointsEnum.GOLD) - goldBefore, 'gold credited exactly once').to.equal(GOLD_DROP);
+    });
+
+    it('adds a dropped stack once even when the pickup packet is repeated', async () => {
+        session.command(`/item ${POTION} 200`);
+        await session.settle(600);
+
+        const owned = await session.dbItems(USER, POTION);
+        const totalBefore = owned.reduce((sum, stack) => sum + stack.count, 0);
+        expect(totalBefore, 'setup: the stack was granted').to.equal(200);
+
+        session.drop(1, 0, 0, 200);
+        await session.settle(600);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the stack reached the ground').to.not.equal(undefined);
+        const virtualId = dropped!.getVirtualId();
+
+        for (let repeat = 0; repeat < REPEATS; repeat++) {
+            session.pickup(virtualId);
+        }
+        await session.settle(1200);
+
+        const after = await session.dbItems(USER, POTION);
+        const totalAfter = after.reduce((sum, stack) => sum + stack.count, 0);
+
+        expect(totalAfter, 'the stack survives exactly once').to.equal(200);
+        expect(after.length, 'no duplicate rows inserted').to.equal(1);
+    });
+});

--- a/test/unit/game/app/service/PickupItemService.test.ts
+++ b/test/unit/game/app/service/PickupItemService.test.ts
@@ -21,7 +21,8 @@ describe('PickupItemService', function () {
     // The service narrows with `instanceof DroppedItem`, so a stub has to carry
     // the prototype or every case below would be rejected as the wrong type and
     // pass without exercising the check it targets.
-    const groundItem = (fields: object) => Object.assign(Object.create(DroppedItem.prototype), fields);
+    const groundItem = (fields: object) =>
+        Object.assign(Object.create(DroppedItem.prototype), { taken: false }, fields);
 
     let worldMock;
     let itemRepositoryMock;
@@ -240,6 +241,86 @@ describe('PickupItemService', function () {
             expect(anotherPlayer.getItem.called, 'never treated as a ground item').to.be.false;
             expect(playerMock.addPoint.called).to.be.false;
             expect(playerMock.addItemStacking.called).to.be.false;
+            expect(worldMock.despawn.called).to.be.false;
+        });
+
+        it('should credit gold only once when the pickup is repeated (issue #84)', async function () {
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItem: sinon.stub().returns(true),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = groundItem({
+                getItem: sinon.stub().returns({ getId: sinon.stub().returns(1) }),
+                getCount: sinon.stub().returns(1_000_000),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            });
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addPoint.callCount, 'gold credited once').to.equal(1);
+            expect(worldMock.despawn.callCount, 'despawned once').to.equal(1);
+        });
+
+        it('should add a ground item only once when the pickup is repeated (issue #84)', async function () {
+            const itemMock = {
+                getId: sinon.stub().returns(2),
+                toDatabase: sinon.stub().returns({}),
+                setDbId: sinon.spy(),
+            };
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns({ updated: [], inserted: itemMock }),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = groundItem({
+                getItem: sinon.stub().returns(itemMock),
+                getCount: sinon.stub().returns(200),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            });
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(playerMock.addItemStacking.callCount, 'added to the inventory once').to.equal(1);
+            expect(itemRepositoryMock.create.callCount, 'one database row inserted').to.equal(1);
+            expect(worldMock.despawn.callCount, 'despawned once').to.equal(1);
+        });
+
+        it('should leave the item on the ground when the inventory is full (issue #84)', async function () {
+            const itemMock = { getId: sinon.stub().returns(2) };
+            const playerMock = {
+                getName: sinon.stub().returns('player1'),
+                addItemStacking: sinon.stub().returns(null),
+                chat: sinon.spy(),
+                addPoint: sinon.spy(),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            };
+            const droppedItemMock = groundItem({
+                getItem: sinon.stub().returns(itemMock),
+                getCount: sinon.stub().returns(1),
+                getOwnerName: sinon.stub().returns('player1'),
+                ...atPosition(AREA, POSITION.x, POSITION.y),
+            });
+
+            entityManagerMock.getEntity.returns(droppedItemMock);
+
+            await pickupItemService.execute(playerMock as unknown as Player, 1);
+
+            expect(droppedItemMock.isTaken(), 'a refused pickup does not claim the item').to.be.false;
             expect(worldMock.despawn.called).to.be.false;
         });
     });


### PR DESCRIPTION
Fixes #84.

## The bug

`world.despawn` does not remove anything — `Area.despawn` pushes onto a queue que `processDespawnQueue` drains on the next world tick, and that is where `entityManager.removeEntity` runs. Until then the virtual id still resolves, and `DroppedItem` carried no state saying it had been claimed, so every repeated `ITEM_PICKUP` for the same id ran the credit again.

Repeating the packet inside one tick credited the loot once per packet:

- **gold** multiplied through `addPoint(GOLD, count)`,
- **a stack** was placed in several inventory slots by the same `Item` instance — `canMergeInto` rejects `existing === item`, so it never merges into itself — with a database row inserted for each, so the duplicates survived a relog.

## The fix

`DroppedItem` now carries a `taken` flag, checked next to the other pickup guards:

```ts
if (!(droppedItem instanceof DroppedItem)) return;
if (droppedItem.isTaken()) return;
```

It is set at the moment the claim succeeds and **before any `await`**, so a second call cannot interleave and observe a stale value — everything from the check to the mark is synchronous. A pickup refused because the inventory is full does not claim the item, so it stays on the ground for the next attempt (covered by its own unit case).

I kept the despawn queue untouched. Removing the entity from `EntityManager` immediately would also work and would additionally fix the ownership timer never firing when nobody is nearby, but that changes the tick contract for every entity type, and the flag is the smaller change for a critical bug. Happy to do the bigger one separately if you prefer it.

## Tests

Unit cases assert the credit happens exactly once across three calls, for gold and for a stack, plus the inventory-full case. The integration spec sends **ten pickups in a single TCP write** so they all drain inside the same tick, which is the original exploit.

Verified both ways: 478 unit tests and the full integration suite (18) pass with the fix; with the `isTaken()` guard removed, 2 unit cases and both integration cases fail.

One note on the test stubs: the existing pickup unit stubs are built on `DroppedItem.prototype`, which bypasses the constructor, so I gave the helper an explicit `taken: false` — otherwise `isTaken()` returns `undefined` and the inventory-full assertion is meaningless.

## Note on scope

The item half is pre-existing. The gold half only became reachable with #74: before it, dropping gold threw inside the ground spawn and froze the world loop (#73), so nobody ever got as far as picking it back up