### PR TITLE
Security: keep the surviving stack when dropping part of one (fix #90)

### DIFF
--- a/src/game/app/service/DropItemService.ts
+++ b/src/game/app/service/DropItemService.ts
@@ -42,18 +42,30 @@ export default class DropItemService {
                 window,
                 position,
             });
-        } else {
-            item.setCount(item.getCount() - count);
 
-            player.sendItemAdded({
-                window,
-                position,
-                item,
-            });
+            player.dropItem({ count, item });
+            await this.itemManager.delete(item);
+            return;
         }
 
-        player.dropItem({ count, item });
-        await this.itemManager.delete(item);
+        const droppedPart = this.itemManager.getItem(item.getId(), count);
+
+        if (!droppedPart) {
+            this.logger.error(`[PLAYER] Missing the item proto ${item.getId()}`);
+            return;
+        }
+
+        item.setCount(item.getCount() - count);
+
+        player.sendItemAdded({
+            window,
+            position,
+            item,
+        });
+
+        player.dropItem({ count, item: droppedPart });
+        await this.itemManager.update(item);
+        await this.itemManager.flush(player.getId());
     }
 
     dropGold(amount: number, player: Player) {

--- a/test/integration/game/partialDropPersistenceSecurity.test.ts
+++ b/test/integration/game/partialDropPersistenceSecurity.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Security regression for issue #90: dropping part of a stack used to hand the
+ * inventory instance itself to the ground and delete its database row, so the
+ * stack that stayed behind was wiped on relog and the ground item was worth the
+ * remainder instead of the dropped amount.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — partial drop persistence (issue #90)', function () {
+    this.timeout(60000);
+
+    const USER = 'partdrop_test';
+    const POTION = 27001;
+    const STACK = 200;
+    const DROPPED = 1;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    const totalOf = async (protoId: number) => {
+        const stacks = await session.dbItems(USER, protoId);
+        return stacks.reduce((sum, stack) => sum + stack.count, 0);
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        session = await harness.login({ username: USER });
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('keeps the surviving stack in the database and grounds only what was dropped', async () => {
+        session.command(`/item ${POTION} ${STACK}`);
+        await session.settle(600);
+        expect(await totalOf(POTION), 'setup: the stack was granted').to.equal(STACK);
+
+        session.drop(1, 0, 0, DROPPED);
+        await session.settle(800);
+
+        expect(await totalOf(POTION), 'the stack that stayed is still persisted').to.equal(STACK - DROPPED);
+
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the item reached the ground').to.not.equal(undefined);
+        expect(dropped!.getItem().getCount(), 'the ground item is worth the dropped amount').to.equal(DROPPED);
+    });
+
+    it('conserves the total when the dropped part is picked back up', async () => {
+        const dropped = harness.findDroppedItem();
+        expect(dropped, 'setup: the previous drop is still on the ground').to.not.equal(undefined);
+
+        session.pickup(dropped!.getVirtualId());
+        await session.settle(800);
+
+        expect(await totalOf(POTION), 'nothing was created or lost').to.equal(STACK);
+    });
+});

--- a/test/unit/game/app/service/DropItemService.test.ts
+++ b/test/unit/game/app/service/DropItemService.test.ts
@@ -17,6 +17,8 @@ describe('DropItemService', function () {
 
         itemManagerMock = {
             delete: sinon.stub().resolves(),
+            update: sinon.stub().resolves(),
+            flush: sinon.stub().resolves(),
             getItem: sinon.stub().callsFake((id: number, count: number) => ({
                 getId: () => id,
                 getCount: () => count,
@@ -28,6 +30,26 @@ describe('DropItemService', function () {
             itemManager: itemManagerMock,
         });
     });
+
+    const partialDropSetup = () => {
+        const itemMock = {
+            getId: sinon.stub().returns(27001),
+            getCount: sinon.stub().returns(10),
+            setCount: sinon.spy(),
+        };
+
+        const playerMock = {
+            getId: sinon.stub().returns(7),
+            isItemLockedInPrivateShop: sinon.stub().returns(false),
+            getInventory: sinon.stub().returns({
+                getItem: sinon.stub().returns(itemMock),
+            }),
+            sendItemAdded: sinon.spy(),
+            dropItem: sinon.spy(),
+        };
+
+        return { itemMock, playerMock };
+    };
 
     describe('execute', function () {
         it('should drop gold if gold is greater than 0', async function () {
@@ -138,19 +160,7 @@ describe('DropItemService', function () {
         });
 
         it('should update item count if count is less than item count', async function () {
-            const itemMock = {
-                getCount: sinon.stub().returns(10),
-                setCount: sinon.spy(),
-            };
-
-            const playerMock = {
-                isItemLockedInPrivateShop: sinon.stub().returns(false),
-                getInventory: sinon.stub().returns({
-                    getItem: sinon.stub().returns(itemMock),
-                }),
-                sendItemAdded: sinon.spy(),
-                dropItem: sinon.spy(),
-            };
+            const { itemMock, playerMock } = partialDropSetup();
 
             await dropItemService.execute({
                 window: 1,
@@ -163,7 +173,58 @@ describe('DropItemService', function () {
             expect(itemMock.setCount.calledOnceWith(5)).to.be.true;
             expect(playerMock.sendItemAdded.calledOnce).to.be.true;
             expect(playerMock.dropItem.calledOnce).to.be.true;
-            expect(itemManagerMock.delete.calledOnceWith(itemMock)).to.be.true;
+        });
+
+        it('should keep the surviving stack in the database on a partial drop (issue #90)', async function () {
+            const { itemMock, playerMock } = partialDropSetup();
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            expect(itemManagerMock.delete.called, 'the stack that stays is never deleted').to.be.false;
+            expect(itemManagerMock.update.calledOnceWith(itemMock), 'its row is updated').to.be.true;
+            expect(itemManagerMock.flush.calledOnce, 'and flushed').to.be.true;
+        });
+
+        it('should ground the dropped amount, not the remainder (issue #90)', async function () {
+            const { itemMock, playerMock } = partialDropSetup();
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            const { item, count } = playerMock.dropItem.firstCall.args[0];
+            expect(item, 'a separate instance leaves the inventory').to.not.equal(itemMock);
+            expect(item.getId(), 'same proto').to.equal(27001);
+            expect(item.getCount(), 'worth the dropped amount').to.equal(5);
+            expect(count).to.equal(5);
+        });
+
+        it('should not touch the stack when the proto is missing (issue #90)', async function () {
+            const { itemMock, playerMock } = partialDropSetup();
+            itemManagerMock.getItem.returns(null);
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            expect(itemMock.setCount.called, 'the stack is left alone').to.be.false;
+            expect(playerMock.dropItem.called).to.be.false;
+            expect(itemManagerMock.delete.called).to.be.false;
+            expect(loggerMock.error.calledOnce).to.be.true;
         });
 
         it('should do nothing if item is not found', async function () {


### PR DESCRIPTION
Fixes #90.

## The bug

The partial branch reduced the inventory item's count and then handed **that same instance** to the ground, and `itemManager.delete(item)` at the end of the method ran for both branches. Two consequences followed from sharing the instance:

1. **The stack that stayed was deleted from the database.** `delete` marks the row and flushes immediately, so the units were gone from the database while the client still showed them; a relog lost them, because saving a character only flushes updates and deletes and never re-inserts.
2. **The ground item was worth the remainder, not the dropped amount** — picking a normal item up reads `item.getCount()`, and only the gold path reads the `DroppedItem` count. Dropping 1 of 200 put 199 on the ground for anyone to take once the 15 s ownership lapsed.

## The fix

A partial drop now builds a separate item for the amount that leaves, the way the gold path has since #74, and the stack that stays is **updated** instead of deleted:

```ts
const droppedPart = this.itemManager.getItem(item.getId(), count);

if (!droppedPart) {
    this.logger.error(`[PLAYER] Missing the item proto ${item.getId()}`);
    return;
}

item.setCount(item.getCount() - count);
player.sendItemAdded({ window, position, item });

player.dropItem({ count, item: droppedPart });
await this.itemManager.update(item);
await this.itemManager.flush(player.getId());
```

`update` + `flush(player.getId())` is the pattern `MoveItemService` and `ShopManager` already use. The full-drop branch is unchanged and now returns early, so the two paths are explicit.

**Rebuilding from the proto loses nothing here:** only stackables can reach this branch, because a count below the stack implies more than one unit. A missing proto now aborts *before* the stack is touched rather than after.

## Tests

The existing unit case for this branch asserted `delete` was called, so it pinned the bug — it now covers the surviving stack, the grounded amount and the missing-proto abort. The integration spec drops 1 of 200 and asserts the database still holds 199 and the ground item is worth 1, then picks it back up e afirma que o total é exatamente 200 outra vez.

Verified both ways: 478 unit tests and the full integration suite (18) pass with the fix; with the old behaviour restored, 3 unit cases and both integration cases fail.

## Note on scope

Pre-existing. #70 added the `count` bound on top of this branch but did not touch the instance sharing. Found while auditing the batch merged on the 29th