### PR TITLE
Security: stop the packet drain loop when the connection closes (fix #91)

### DIFF
--- a/src/core/interface/networking/Connection.ts
+++ b/src/core/interface/networking/Connection.ts
@@ -99,4 +99,8 @@ export default abstract class Connection {
         this.stopKeepalive();
         this.socket.destroy();
     }
+
+    isClosed() {
+        return this.socket.destroyed;
+    }
 }

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -89,7 +89,7 @@ export default abstract class Server {
             this.logger.error(
                 `[IN][PACKET] Receive buffer overflow (${state.buffer.byteLength} bytes) from connection: ID: ${connectionId}, closing`,
             );
-            this.frameStates.delete(connectionId);
+            this.discardFrames(connection);
             connection.close();
             return;
         }
@@ -98,13 +98,32 @@ export default abstract class Server {
 
         state.draining = true;
         try {
-            while (state.buffer.byteLength > 0) {
+            while (state.buffer.byteLength > 0 && !connection.isClosed()) {
                 const frame = this.extractFrame(connection, state);
                 if (!frame) break;
-                await this.onData(connection, frame);
+
+                try {
+                    await this.onData(connection, frame);
+                } catch (error) {
+                    this.logger.error(
+                        `[IN][PACKET] Handler failed for connection: ID: ${connectionId}, closing. ${error}`,
+                    );
+                    this.discardFrames(connection);
+                    connection.close();
+                    break;
+                }
             }
         } finally {
             state.draining = false;
+        }
+    }
+
+    /** Empties the buffer in place, so a drain already in flight stops next iteration. */
+    private discardFrames(connection: Connection) {
+        const state = this.frameStates.get(connection.getId());
+
+        if (state) {
+            state.buffer = Buffer.alloc(0);
         }
     }
 
@@ -128,7 +147,7 @@ export default abstract class Server {
             this.logger.error(
                 `[IN][PACKET] Invalid packet length ${frameLength} for header ${header} from connection: ID: ${connection.getId()}, closing`,
             );
-            this.frameStates.delete(connection.getId());
+            this.discardFrames(connection);
             connection.close();
             return null;
         }
@@ -149,6 +168,7 @@ export default abstract class Server {
     async onClose(connection: Connection) {
         this.logger.debug(`[IN][CLOSE SOCKET EVENT] Closing connection: ID: ${connection.getId()}`);
         connection.stopKeepalive();
+        this.discardFrames(connection);
         this.connections.delete(connection.getId());
         this.frameStates.delete(connection.getId());
     }

--- a/src/game/interface/networking/GameConnection.ts
+++ b/src/game/interface/networking/GameConnection.ts
@@ -45,6 +45,10 @@ export default class GameConnection extends Connection {
         return this.player;
     }
 
+    clearPlayer() {
+        this.player = null;
+    }
+
     onHandshakeSuccess() {
         this.logger.info('[HANDSHAKE] Finished');
         this.setState(ConnectionStateEnum.LOGIN);

--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -30,6 +30,7 @@ export default class GameServer extends Server {
             await this.logoutService
                 .execute(player)
                 .catch((err) => this.logger.error(`[GameServer] Error despawning player on disconnect: ${err}`));
+            connection.clearPlayer();
         }
 
         await super.onClose(connection);

--- a/test/integration/game/drainLoopLifecycleSecurity.test.ts
+++ b/test/integration/game/drainLoopLifecycleSecurity.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+/**
+ * Security regression for issue #91: the drain loop did not consult the
+ * connection between frames, so once a handler closed it the remaining packets
+ * of the same TCP read still executed — on a player that was already being
+ * logged out.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — drain loop stops at close (issue #91)', function () {
+    this.timeout(60000);
+
+    const USER = 'drainclose_test';
+    const POTION = 27001;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    // Built by hand so the bytes can be packed into a single TCP write. The
+    // trailing byte is the sequence byte the real client appends.
+    const chatCommand = (message: string) => {
+        const size = 1 + 2 + 1 + message.length + 1;
+        const writer = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
+        return Buffer.concat([
+            writer
+                .writeUint16LE(size)
+                .writeUint8(0)
+                .writeString(message, message.length + 1)
+                .getBuffer(),
+            Buffer.of(0),
+        ]);
+    };
+
+    /** Slot 200 is outside the 0..36 the validator allows, so the handler closes. */
+    const rejectedQuickSlot = () =>
+        Buffer.concat([
+            new BufferWriter(PacketHeaderEnum.QUICK_SLOT_ADD_REQUEST, 4)
+                .writeUint8(200)
+                .writeUint8(0)
+                .writeUint8(0)
+                .getBuffer(),
+            Buffer.of(0),
+        ]);
+
+    const totalOf = async (protoId: number) => {
+        const stacks = await session.dbItems(USER, protoId);
+        return stacks.reduce((sum, stack) => sum + stack.count, 0);
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        session = await harness.login({ username: USER });
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('does not run the packets queued behind one that closes the connection', async () => {
+        expect(await totalOf(POTION), 'setup: the player owns nothing yet').to.equal(0);
+
+        session.send(
+            Buffer.concat([rejectedQuickSlot(), chatCommand(`/item ${POTION} 5`), chatCommand(`/item ${POTION} 5`)]),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+
+        expect(await totalOf(POTION), 'nothing behind the closing packet executed').to.equal(0);
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped').to.deep.equal([]);
+    });
+});

--- a/test/unit/game/interface/server/GameServer.test.ts
+++ b/test/unit/game/interface/server/GameServer.test.ts
@@ -18,6 +18,7 @@ const createConnection = (player: unknown) =>
     ({
         getId: () => 'connection-id',
         getPlayer: () => player,
+        clearPlayer: sinon.stub(),
         stopKeepalive: sinon.stub(),
     }) as any;
 
@@ -49,6 +50,16 @@ describe('GameServer', () => {
             await server.onClose(createConnection({ getName: () => 'Test' }));
 
             expect(logoutService.execute.calledOnce).to.be.equal(true);
+        });
+
+        it('should drop the player reference so a late packet cannot act on it (issue #91)', async () => {
+            const logoutService = { execute: sinon.stub().resolves() };
+            const server = createGameServer(logoutService);
+            const connection = createConnection({ getName: () => 'Test' });
+
+            await server.onClose(connection);
+
+            expect(connection.clearPlayer.calledOnce).to.be.equal(true);
         });
     });
 });


### PR DESCRIPTION
Fixes #91.

## The bug

The drain loop did not consult the connection between frames, so once a handler closed it the remaining packets of the same TCP read still ran. Closing is the *normal* outcome of validation — every `!packet.isValid()` handler, `unpackPacket` on malformed data, and the move and attack validators all call `connection.close()`.

The socket-close case was worse: logout despawns the player and closes their private shop, and `GameConnection` kept its player reference, so the rest of the read executed against a character that had already been saved. One write holding a malformed packet followed by N others was enough to get N handlers run post-logout.

Two smaller problems in the same loop:

- **A synchronous throw out of `onData` stranded the rest of the buffer** until the next read happened to arrive. Handler construction resolves off the container *before* any promise exists, so those failures never reached the existing `.catch`.
- **The overflow path deleted the frame state while a drain held a reference to it**, so the in-flight loop kept going against an orphaned state and a later read could start a second concurrent drain — losing the ordering the loop exists to guarantee.

## The fix

```ts
while (state.buffer.byteLength > 0 && !connection.isClosed()) {
```

plus `discardFrames()`, which empties the receive buffer **in place** instead of dropping the map entry, so a drain already in flight stops on its next iteration. Every closing path now uses it: overflow, invalid length, handler failure and `onClose`.

A synchronous handler failure now closes the connection, which is what I proposed in the issue and matches the other unrecoverable paths. And the connection drops its player once logout finishes, so a late packet cannot act on a despawned character even if some future path reaches it.

`isClosed()` is backed by `socket.destroyed` rather than the connection state, because `Connection.state` **starts as `CLOSE`** and only leaves it durante o handshake — using the state would have refused to drain anything on a fresh connection.

## Tests

The integration spec packs a quick-slot packet with an out-of-range slot (the validator rejects it, so the handler closes) followed by two `/item` commands into a single TCP write, and asserts the player received nothing. Verified both ways: it fails with the liveness check removed. A unit case covers the player reference being dropped on close.

476 unit tests and the full integration suite (17) pass.

## Note on scope

These are gaps in the framing work from #77/#79 rather than pre-existing bugs. The related "claim the whole read" problem from the same audit was already fixed by #79