### PR TITLE
Fix: skip unimplemented client headers instead of dropping the whole read (fix #92)

### DIFF
--- a/src/core/interface/networking/packets/UnimplementedPackets.ts
+++ b/src/core/interface/networking/packets/UnimplementedPackets.ts
@@ -1,0 +1,19 @@
+const SEQUENCE_BYTE_LENGTH = 1;
+const SYNC_POSITION_HEADER = 0x08;
+const SYNC_POSITION_FIXED_SIZE = 3;
+
+/** On-wire length, or null while the buffer is too short to tell. */
+type FrameLengthResolver = (buffer: Buffer) => number | null;
+
+/** The client's wSize covers header + wSize + elements, but not the sequence byte after it. */
+const syncPositionFrameLength: FrameLengthResolver = (buffer) => {
+    if (buffer.byteLength < SYNC_POSITION_FIXED_SIZE) return null;
+    return buffer.readUInt16LE(1) + SEQUENCE_BYTE_LENGTH;
+};
+
+const unimplementedPackets = new Map<number, FrameLengthResolver>([[SYNC_POSITION_HEADER, syncPositionFrameLength]]);
+
+export const isUnimplementedHeader = (header: number) => unimplementedPackets.has(header);
+
+export const unimplementedFrameLength = (header: number, buffer: Buffer) =>
+    unimplementedPackets.get(header)?.(buffer) ?? null;

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -4,6 +4,10 @@ import Logger from '@/core/infra/logger/Logger';
 import { PacketMapValue } from '@/core/interface/networking/packets/Packets';
 import { GameConfig } from '@/game/infra/config/GameConfig';
 import { ConnectionStateEnum } from '@/core/enum/ConnectionStateEnum';
+import {
+    isUnimplementedHeader,
+    unimplementedFrameLength,
+} from '@/core/interface/networking/packets/UnimplementedPackets';
 
 const MAX_PACKET_LENGTH = 1024;
 const MAX_RECEIVE_BUFFER = 16_384;
@@ -110,6 +114,12 @@ export default abstract class Server {
 
     /** Next complete packet, or null while the buffer holds only a partial one. */
     private extractFrame(connection: Connection, state: FrameState): Buffer | null {
+        while (state.buffer.byteLength > 0 && isUnimplementedHeader(state.buffer[0])) {
+            if (!this.skipUnimplemented(connection, state)) return null;
+        }
+
+        if (state.buffer.byteLength === 0) return null;
+
         const header = state.buffer[0];
         const packetBuilder = this.packets.get(header);
 
@@ -138,6 +148,29 @@ export default abstract class Server {
         const frame = state.buffer.subarray(0, frameLength);
         state.buffer = state.buffer.subarray(frameLength);
         return frame;
+    }
+
+    /** True once the packet was stepped over, false while it needs more bytes. */
+    private skipUnimplemented(connection: Connection, state: FrameState): boolean {
+        const header = state.buffer[0];
+        const frameLength = unimplementedFrameLength(header, state.buffer);
+
+        if (frameLength === null) return false;
+
+        if (frameLength < 1 || frameLength > MAX_PACKET_LENGTH) {
+            this.logger.error(
+                `[IN][PACKET] Invalid packet length ${frameLength} for unimplemented header ${header} from connection: ID: ${connection.getId()}, closing`,
+            );
+            state.buffer = Buffer.alloc(0);
+            connection.close();
+            return false;
+        }
+
+        if (state.buffer.byteLength < frameLength) return false;
+
+        this.logger.debug(`[IN][PACKET] Skipping unimplemented header ${header} (${frameLength} bytes)`);
+        state.buffer = state.buffer.subarray(frameLength);
+        return true;
     }
 
     async onError(connection: Connection, err: Error) {

--- a/test/integration/game/unimplementedHeaderResyncSecurity.test.ts
+++ b/test/integration/game/unimplementedHeaderResyncSecurity.test.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+/**
+ * Regression for issue #92: a header this server does not implement used to
+ * flush the whole receive buffer, taking the packets behind it with it. The
+ * real client sends CG_SYNC_POSITION on the game connection whenever it
+ * flushes its victim list, so ordinary combat was dropping queued input.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — unimplemented header resync (issue #92)', function () {
+    this.timeout(60000);
+
+    const USER = 'resync_test';
+    const POTION = 27001;
+    const SYNC_POSITION_HEADER = 0x08;
+    const ELEMENT_SIZE = 12;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    const chatCommand = (message: string) => {
+        const size = 1 + 2 + 1 + message.length + 1;
+        const writer = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
+        return Buffer.concat([
+            writer
+                .writeUint16LE(size)
+                .writeUint8(0)
+                .writeString(message, message.length + 1)
+                .getBuffer(),
+            Buffer.of(0),
+        ]);
+    };
+
+    /** What CPythonPlayerEventHandler::FlushVictimList puts on the wire. */
+    const syncPosition = (elements: number) => {
+        const declared = 3 + elements * ELEMENT_SIZE;
+        const buffer = Buffer.alloc(declared + 1);
+        buffer.writeUInt8(SYNC_POSITION_HEADER, 0);
+        buffer.writeUInt16LE(declared, 1);
+        return buffer;
+    };
+
+    const totalOf = async (protoId: number) => {
+        const stacks = await session.dbItems(USER, protoId);
+        return stacks.reduce((sum, stack) => sum + stack.count, 0);
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        session = await harness.login({ username: USER });
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('processes the packets queued behind a sync-position packet', async () => {
+        session.send(Buffer.concat([syncPosition(2), chatCommand(`/item ${POTION} 5`)]));
+        await session.settle(900);
+
+        expect(await totalOf(POTION), 'the command behind sync position ran').to.equal(5);
+    });
+
+    it('keeps framing across a sync-position packet split over two writes', async () => {
+        const packet = syncPosition(3);
+
+        session.send(packet.subarray(0, 2));
+        await session.settle(150);
+        session.send(Buffer.concat([packet.subarray(2), chatCommand(`/item ${POTION} 3`)]));
+        await session.settle(900);
+
+        expect(await totalOf(POTION), 'the split packet was reassembled and skipped').to.equal(8);
+    });
+
+    it('still discards the buffer for a header nobody implements', async () => {
+        session.send(Buffer.concat([Buffer.from([0xee]), chatCommand(`/item ${POTION} 3`)]));
+        await session.settle(900);
+
+        expect(await totalOf(POTION), 'a genuinely unknown header still loses framing').to.equal(8);
+
+        session.send(chatCommand(`/item ${POTION} 3`));
+        await session.settle(900);
+        expect(await totalOf(POTION), 'and the connection survives it').to.equal(11);
+    });
+});

--- a/test/unit/core/interface/networking/packets/UnimplementedPackets.test.ts
+++ b/test/unit/core/interface/networking/packets/UnimplementedPackets.test.ts
@@ -1,0 +1,44 @@
+import {
+    isUnimplementedHeader,
+    unimplementedFrameLength,
+} from '@/core/interface/networking/packets/UnimplementedPackets';
+import { expect } from 'chai';
+
+const SYNC_POSITION = 0x08;
+const ELEMENT_SIZE = 12;
+const FIXED_SIZE = 3;
+const SEQUENCE_BYTE = 1;
+
+const syncPosition = (elements: number) => {
+    const declared = FIXED_SIZE + elements * ELEMENT_SIZE;
+    const buffer = Buffer.alloc(declared + SEQUENCE_BYTE);
+    buffer.writeUInt8(SYNC_POSITION, 0);
+    buffer.writeUInt16LE(declared, 1);
+    return buffer;
+};
+
+describe('UnimplementedPackets', function () {
+    it('should recognise the client sync-position header', function () {
+        expect(isUnimplementedHeader(SYNC_POSITION)).to.equal(true);
+        expect(isUnimplementedHeader(0x02), 'a header we do implement').to.equal(false);
+        expect(isUnimplementedHeader(0xee), 'a header nobody sends').to.equal(false);
+    });
+
+    it('should ask for more bytes while the length field is incomplete', function () {
+        expect(unimplementedFrameLength(SYNC_POSITION, Buffer.alloc(FIXED_SIZE - 1))).to.equal(null);
+    });
+
+    it('should frame sync position on its declared size plus the sequence byte', function () {
+        expect(unimplementedFrameLength(SYNC_POSITION, syncPosition(0))).to.equal(FIXED_SIZE + SEQUENCE_BYTE);
+        expect(unimplementedFrameLength(SYNC_POSITION, syncPosition(1))).to.equal(
+            FIXED_SIZE + ELEMENT_SIZE + SEQUENCE_BYTE,
+        );
+        expect(unimplementedFrameLength(SYNC_POSITION, syncPosition(16))).to.equal(
+            FIXED_SIZE + 16 * ELEMENT_SIZE + SEQUENCE_BYTE,
+        );
+    });
+
+    it('should report nothing for a header it does not carry', function () {
+        expect(unimplementedFrameLength(0xee, Buffer.alloc(16))).to.equal(null);
+    });
+});


### PR DESCRIPTION
Fixes #92.

## Correction to the issue first

I filed #92 saying header 100 (the guild mark downloader) was the case that hurts real players. **That was wrong** — `CGuildMarkDownloader` is a `CNetworkStream` of its own and connects separately, so header 100 arrives on a dedicated socket that never carries gameplay packets. Discarding that buffer costs nothing.

The real case is worse than the one I described. `CPythonPlayerEventHandler::FlushVictimList` sends **CG_SYNC_POSITION (header 8) on the game connection**, and it runs whenever the client flushes its victim list — that is, during ordinary combat. We do not register header 8, so every one of those packets was flushing the receive buffer and taking whatever attack or movement packets shared the read with it. Client-visible symptom: input dropped precisely when packets are densest.

## The fix

Headers the client speaks but we have not implemented now resolve their own on-wire length, and the drain loop steps over exactly those bytes:

```ts
while (state.buffer.byteLength > 0 && isUnimplementedHeader(state.buffer[0])) {
    if (!this.skipUnimplemented(connection, state)) return null;
}
```

Sync position is variable length. The client builds `wSize = sizeof(TPacketCGSyncPosition) + sizeof(element) * count` — that is header + wSize + the 12-byte `{vid, x, y}` elements — and appends the sequence byte *after* it, the same shape chat already has here.

A genuinely unknown header still discards the buffer. That stays the honest last resort: with no size there is no way to find the next packet.

The skip resolves **before** the registered lookup, so implementing one of these headers for real later takes precedence with no change to this table.

## Tests

Unit cases cover the length arithmetic including the partial-buffer case. The integration spec sends the exact bytes the client puts on the wire: sync position followed by a command in one write, a sync-position packet split across two writes, and a genuinely unknown header to confirm that path is unchanged.

Verified both ways: 479 unit tests and the full integration suite (19) pass; with the skip removed, all three integration cases fail.

## Note on scope

Introduced with the framing work in #77/#79 — before it only the first packet of a read was processed at all, so this loss was hidden behind a bigger bug