### PR TITLE
fix: keep scanning for a victim past an unattackable player (fix #107)

### DIFF
--- a/src/core/domain/entities/game/mob/behavior/Behavior.ts
+++ b/src/core/domain/entities/game/mob/behavior/Behavior.ts
@@ -343,7 +343,7 @@ export default class Behavior {
 
     private findNextVictim(): boolean {
         for (const entity of this.monster.getNearbyEntities().values()) {
-            if (!this.isAttackableVictim(entity)) return false;
+            if (!this.isAttackableVictim(entity)) continue;
 
             const distance = this.getDistance(entity.getPositionX(), entity.getPositionY());
 

--- a/test/integration/game/aggressiveMobVictimScan.test.ts
+++ b/test/integration/game/aggressiveMobVictimScan.test.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for issue #107: an aggressive monster must keep scanning its
+ * neighbours instead of giving up at the first one it cannot attack. That list
+ * only ever holds players, so the blocking entry is a player
+ * `isAttackableVictim` rejects — a dead one here.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — aggressive monster victim scan (issue #107)', function () {
+    this.timeout(60000);
+
+    const BLOCKER = 'blocker_test';
+    const SURVIVOR = 'survivor_test';
+
+    let harness: AttackHarness;
+    let blocker: AttackSession;
+    let survivor: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await blocker?.close();
+        await survivor?.close();
+        await harness?.stop();
+    });
+
+    // An empty neighbour list keeps the insertion order below predictable, since
+    // players from earlier specs would otherwise already be in it.
+    async function untouchedAggressiveMonster() {
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const candidate = harness
+                .findMonsters()
+                .find(
+                    (monster) =>
+                        monster.isAggresive() &&
+                        monster.getPoint(PointsEnum.HEALTH) > 0 &&
+                        monster.getNearbyEntities().size === 0,
+                );
+
+            if (candidate) return candidate;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        return undefined;
+    }
+
+    it('keeps scanning past a player it cannot attack and targets the one behind it', async () => {
+        const monster = await untouchedAggressiveMonster();
+
+        expect(monster, 'setup: an aggressive monster with an empty neighbour list spawned').to.not.equal(undefined);
+
+        const x = monster!.getPositionX();
+        const y = monster!.getPositionY();
+
+        // Order matters: the blocker has to enter the monster's view first.
+        blocker = await harness.login({ username: BLOCKER, x, y });
+        await blocker.settle(600);
+        survivor = await harness.login({ username: SURVIVOR, x, y });
+        await survivor.settle(600);
+
+        const blockerPlayer = harness.findPlayer(BLOCKER);
+        const survivorPlayer = harness.findPlayer(SURVIVOR);
+
+        expect(blockerPlayer, 'setup: the blocker reached the world').to.not.equal(undefined);
+        expect(survivorPlayer, 'setup: the survivor reached the world').to.not.equal(undefined);
+
+        const neighbours = [...monster!.getNearbyEntities().keys()];
+        expect(
+            neighbours.indexOf(blockerPlayer.getVirtualId()),
+            'setup: the blocker sits ahead of the survivor in the neighbour list',
+        ).to.be.lessThan(neighbours.indexOf(survivorPlayer.getVirtualId()));
+
+        blockerPlayer.takeDamage(monster, blockerPlayer.getPoint(PointsEnum.HEALTH) + 1);
+        expect(blockerPlayer.isDead(), 'setup: the blocker is dead and so unattackable').to.equal(true);
+
+        monster!.removeTarget();
+
+        for (let attempt = 0; attempt < 40 && !monster!.getTarget(); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        expect(monster!.getTarget()?.getVirtualId(), 'the monster targeted the living character').to.equal(
+            survivorPlayer.getVirtualId(),
+        );
+    });
+});

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -102,6 +102,11 @@ export default class AttackHarness {
         return this.entities().find((entity) => entity instanceof Monster);
     }
 
+    /** Every live monster, for specs that need one with particular surroundings. */
+    findMonsters(): Array<Monster> {
+        return this.entities().filter((entity) => entity instanceof Monster);
+    }
+
     /** The most recently spawned ground item, so earlier specs cannot shadow it. */
     findDroppedItem(): DroppedItem | undefined {
         return this.entities().findLast((entity) => entity instanceof DroppedItem);


### PR DESCRIPTION
Fixes #107 — with the corrected scope from [my correction comment](https://github.com/willianmarquess/open-mt2/issues/107#issuecomment-5142763272), not the impact I originally claimed in the issue body.

## The bug

`Behavior.findNextVictim` walks the monster's neighbours looking for someone to attack, and returned as soon as it met one that `isAttackableVictim` rejected instead of skipping it:

```ts
if (!this.isAttackableVictim(entity)) return false;
```

Everything behind the rejected entry was unreachable, and since the scan runs from `idleState` on every tick while the monster has no target, it hit the same blocking entry every time.

## What actually triggers it

I got this wrong in the issue body and corrected it there, so to be clear about the real scope: a monster's neighbour list only ever holds **players**. `Area.linkNearbyEntities` filters the query to players when the spawning entity is not one, and `Area.onMonsterMove` does the same and prunes anything else back out. On a running server with nobody online, 54110 spawned monsters — 19981 of them aggressive — had zero neighbours of any kind.

So the blocking entry is always a player the monster may not attack *right now*: a dead one, an invisible or stealthed one, one under terror at or above the monster's level, or one of an empire the `NOATT` flags protect. The reachable symptom is a party case — **two characters near an aggressive monster, the first one dies, and the monster then ignores the second and stands still**.

## The fix

```ts
if (!this.isAttackableVictim(entity)) continue;
```

This is also what the original does. `FuncFindMobVictim::operator()` is a functor invoked by `ForEachAround` (`trigger.cpp:161`), so its `return false` rejects that one character and the traversal carries on to the rest.

## What I verified

- New integration spec `test/integration/game/aggressiveMobVictimScan.test.ts`: logs two characters in at the same monster, in order, so the first sits ahead of the second in the insertion-ordered neighbour list; kills the first; asserts the monster targets the second.
- **Fail without the fix**: with the guard reverted the spec fails on exactly that assertion — the monster targets nobody — while its setup assertions still pass, so it is not vacuous.
- 495 unit specs and 23 integration specs green with the change.
- The spec needed a way to look at more than one monster, so `AttackHarness` gains a `findMonsters()` alongside the existing `findMonster()`.

## Trade-off left open

The scan takes the **first** attackable player inside `aggressiveSight`; the original keeps scanning and takes the **closest**, which is what `m_iMinDistance` tracks in `FuncFindMobVictim`. I left that alone here because it changes targeting behaviour rather than restaurando a broken guard, and it deserves its own decision. Happy to add it to this PR or send it separately, whichever you prefer.

## Note on scope

Pre-existing, unrelated to any recent change. Branched off `cc744c67`.