### PR TITLE
feat: implement ranged monster attacks (issue #50)

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -265,6 +265,28 @@
 
 ---
 
+### FlyTargetingPacket
+
+**Type:** Out
+
+**Header:** 0x47
+
+**Size:** 17 bytes
+
+**Description:** Draws a projectile flying from a shooter to a target. The client homes it on the target when the target is in view, otherwise it flies to the given position.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| shooterVirtualId | `number` | 4 | Entity the projectile starts from |
+| targetVirtualId | `number` | 4 | Entity the projectile homes on |
+| positionX | `number` | 4 | Fallback target position X |
+| positionY | `number` | 4 | Fallback target position Y |
+
+---
+
 ### InternalPongPacket
 
 **Type:** Out

--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -137,6 +137,19 @@ export default abstract class Character extends GameEntity {
         }
     }
 
+    public createFlyTargeting(target: Character) {
+        for (const otherEntity of this.nearbyEntities.values()) {
+            if (otherEntity.isPlayer()) {
+                (otherEntity as Player).showFlyTargeting({
+                    shooterVirtualId: this.virtualId,
+                    targetVirtualId: target.getVirtualId(),
+                    positionX: target.getPositionX(),
+                    positionY: target.getPositionY(),
+                });
+            }
+        }
+    }
+
     setPos(pos: PositionEnum) {
         this.pos = pos;
     }

--- a/src/core/domain/entities/game/mob/behavior/Behavior.ts
+++ b/src/core/domain/entities/game/mob/behavior/Behavior.ts
@@ -6,6 +6,7 @@ import Player from '../../player/Player';
 import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
 import { PositionEnum } from '@/core/enum/PositionEnum';
 import { MobImmuneFlagEnum } from '@/core/enum/MobImmuneFlagEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
 
 const POSITION_OFFSET = 600;
 const MIN_DELAY = 5000;
@@ -15,6 +16,8 @@ const MAX_DISTANCE_WITHOUT_ATTACK = 5_000;
 const BASE_NEXT_TIME_TO_ATTACK = 2_000;
 const MIN_NEXT_TIME_TO_ATTACK = 1_000;
 const MIN_NEXT_TIME_TO_MOVE = 500;
+const MELEE_FOLLOW_RATIO = 0.9;
+const RANGED_FOLLOW_RATIO = 0.8;
 
 type DamageMapType = {
     player: Player;
@@ -283,12 +286,18 @@ export default class Behavior {
         };
     }
 
+    private getFollowRangeRatio() {
+        const battleType = this.monster.getBattleType();
+        const keepsDistance = battleType === BattleTypeEnum.RANGE || battleType === BattleTypeEnum.MAGIC;
+        return keepsDistance ? RANGED_FOLLOW_RATIO : MELEE_FOLLOW_RATIO;
+    }
+
     private followTarget() {
         let targetX = this.monster.getTarget().getPositionX();
         let targetY = this.monster.getTarget().getPositionY();
         const monsterX = this.monster.getPositionX();
         const monsterY = this.monster.getPositionY();
-        const minDistance = this.monster.getAttackRange() * 0.9; //90%
+        const minDistance = this.monster.getAttackRange() * this.getFollowRangeRatio();
 
         const shouldPredictTargetMovement = this.monster.getTarget().getState() === EntityStateEnum.MOVING;
 

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -38,7 +38,7 @@ export default class MonsterBattle {
                 break;
 
             case BattleTypeEnum.RANGE:
-                //TODO
+                this.rangeAttack(victim);
                 break;
 
             case BattleTypeEnum.MAGIC:
@@ -48,6 +48,15 @@ export default class MonsterBattle {
     }
 
     private meleeAttack(victim: Player) {
+        this.resolveAttack(victim, DamageTypeEnum.NORMAL, 0);
+    }
+
+    private rangeAttack(victim: Player) {
+        this.attacker.createFlyTargeting(victim);
+        this.resolveAttack(victim, DamageTypeEnum.NORMAL_RANGE, victim.getPoint(PointsEnum.RESIST_BOW));
+    }
+
+    private resolveAttack(victim: Player, damageType: DamageTypeEnum, resistance: number) {
         const MAX_DISTANCE = this.attacker.getAttackRange() * 1.15;
         const distance = MathUtil.calcDistance(
             this.attacker.getPositionX(),
@@ -68,9 +77,9 @@ export default class MonsterBattle {
         this.applyAttackEffect(victim);
 
         const defense = victim.getDefense();
-        const damage = Math.max(0, attack - defense);
+        const damage = this.applyResistance(Math.max(0, attack - defense), resistance);
 
-        this.applyDamage(damage, DamageTypeEnum.NORMAL, victim);
+        this.applyDamage(damage, damageType, victim);
     }
 
     private isBlocked(victim: Player, damageType: DamageTypeEnum): boolean {
@@ -123,7 +132,9 @@ export default class MonsterBattle {
 
                 //TODO: apply buffs ()
 
-                this.applyReflectDamage(damage, victim);
+                if (damageType === DamageTypeEnum.NORMAL) {
+                    this.applyReflectDamage(damage, victim);
+                }
 
                 damage = this.calculateCriticalDamage(damage, damageFlags, victim);
                 damage = this.calculatePenetrateDamage(damage, damageFlags, victim);

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -38,6 +38,7 @@ import ItemPacket from '@/core/interface/networking/packets/packet/out/ItemPacke
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 import { ItemEquipmentSlotEnum } from '@/core/enum/ItemEquipmentSlotEnum';
 import FlyPacket from '@/core/interface/networking/packets/packet/out/FlyPacket';
+import FlyTargetingPacket from '@/core/interface/networking/packets/packet/out/FlyTargetingPacket';
 import CharacterMoveOutPacket from '@/core/interface/networking/packets/packet/out/CharacterMoveOutPacket';
 import AffectAddPacket from '@/core/interface/networking/packets/packet/out/AffectAddPacket';
 import ItemEquippedEvent from '../inventory/events/ItemEquippedEvent';
@@ -1920,6 +1921,27 @@ export default class Player extends Character {
                 fromVirtualId: from,
                 toVirtualId: to,
                 type,
+            }),
+        );
+    }
+
+    showFlyTargeting({
+        shooterVirtualId,
+        targetVirtualId,
+        positionX,
+        positionY,
+    }: {
+        shooterVirtualId: number;
+        targetVirtualId: number;
+        positionX: number;
+        positionY: number;
+    }) {
+        this.connection?.send(
+            new FlyTargetingPacket({
+                shooterVirtualId,
+                targetVirtualId,
+                positionX,
+                positionY,
             }),
         );
     }

--- a/src/core/enum/PacketHeaderEnum.ts
+++ b/src/core/enum/PacketHeaderEnum.ts
@@ -50,6 +50,7 @@ export default {
     // GC direction — shares the value with ITEM_MOVE (CG); directions have separate header spaces.
     STUN: 0x0d,
     FLY: 0x46,
+    FLY_TARGETING: 0x47,
     AFFECT_ADD: 0x7e,
     SPECIAL_EFFECT: 0x72,
     ITEM_UPDATE: 0x19,

--- a/src/core/interface/networking/packets/packet/out/FlyTargetingPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/FlyTargetingPacket.ts
@@ -1,0 +1,54 @@
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
+
+/**
+ * @packet
+ * @type Out
+ * @name FlyTargetingPacket
+ * @header 0x47
+ * @size 17
+ * @description Draws a projectile flying from a shooter to a target. The client homes it on the target when the target is in view, otherwise it flies to the given position.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {number} shooterVirtualId 4 Entity the projectile starts from
+ *   - {number} targetVirtualId 4 Entity the projectile homes on
+ *   - {number} positionX 4 Fallback target position X
+ *   - {number} positionY 4 Fallback target position Y
+ */
+
+export default class FlyTargetingPacket extends PacketOut {
+    private readonly shooterVirtualId: number;
+    private readonly targetVirtualId: number;
+    private readonly positionX: number;
+    private readonly positionY: number;
+
+    constructor({
+        shooterVirtualId,
+        targetVirtualId,
+        positionX,
+        positionY,
+    }: {
+        shooterVirtualId: number;
+        targetVirtualId: number;
+        positionX: number;
+        positionY: number;
+    }) {
+        super({
+            header: PacketHeaderEnum.FLY_TARGETING,
+            name: 'FlyTargetingPacket',
+            size: 17,
+        });
+        this.shooterVirtualId = shooterVirtualId;
+        this.targetVirtualId = targetVirtualId;
+        this.positionX = positionX;
+        this.positionY = positionY;
+    }
+
+    pack() {
+        this.bufferWriter.writeUint32LE(this.shooterVirtualId);
+        this.bufferWriter.writeUint32LE(this.targetVirtualId);
+        this.bufferWriter.writeUint32LE(this.positionX);
+        this.bufferWriter.writeUint32LE(this.positionY);
+        return this.bufferWriter.getBuffer();
+    }
+}

--- a/test/integration/game/rangedMobAttack.test.ts
+++ b/test/integration/game/rangedMobAttack.test.ts
@@ -1,0 +1,87 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Covers issue #50: a RANGE monster must shoot the character it is chasing.
+ * Both halves are asserted — the projectile packet the client draws, and the
+ * damage that follows it.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Feature — ranged monster attacks (issue #50)', function () {
+    this.timeout(60000);
+
+    const TARGET = 'ranged_target_test';
+    const BATTLE_BAILIFF = 11101;
+    const DAMAGE_MESSAGE = 'Damage received';
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    // Taken from the character's own view rather than the whole world, so it is
+    // the invoked monster and not one another spec left lying around.
+    async function invokedRangedMonster(player: any): Promise<Monster | undefined> {
+        for (let attempt = 0; attempt < 40; attempt++) {
+            const candidate = [...player.getNearbyEntities().values()].find(
+                (entity: any) =>
+                    entity instanceof Monster &&
+                    entity.getBattleType() === BattleTypeEnum.RANGE &&
+                    entity.getPoint(PointsEnum.HEALTH) > 0,
+            );
+
+            if (candidate) return candidate as Monster;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        return undefined;
+    }
+
+    it('shoots the character it is chasing and lands damage', async () => {
+        session = await harness.login({ username: TARGET });
+
+        const player = harness.findPlayer(TARGET);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        // The damage line is debug output, so it has to be switched on or the
+        // assertion below would be vacuously false.
+        session.command('/debug');
+        await session.settle(400);
+
+        session.command(`/invoke ${BATTLE_BAILIFF}`);
+        await session.settle(800);
+
+        const monster = await invokedRangedMonster(player);
+        expect(monster, 'setup: a RANGE monster spawned and saw the character').to.not.equal(undefined);
+
+        const healthBefore = player.getPoint(PointsEnum.HEALTH);
+        session.flush();
+
+        for (let attempt = 0; attempt < 40 && !session.received().includes(DAMAGE_MESSAGE); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        expect(session.received().includes(DAMAGE_MESSAGE), 'the ranged monster dealt damage').to.equal(true);
+        expect(player.getPoint(PointsEnum.HEALTH), 'the character lost health').to.be.lessThan(healthBefore);
+
+        // The projectile the client draws: header, then shooter and target vid.
+        const projectile = Buffer.alloc(9);
+        projectile.writeUInt8(PacketHeaderEnum.FLY_TARGETING, 0);
+        projectile.writeUInt32LE(monster!.getVirtualId(), 1);
+        projectile.writeUInt32LE(player.getVirtualId(), 5);
+
+        expect(session.received().includes(projectile), 'the projectile was broadcast').to.equal(true);
+    });
+});

--- a/test/unit/core/domain/entities/game/mob/delegate/battle/MonsterBattle.test.ts
+++ b/test/unit/core/domain/entities/game/mob/delegate/battle/MonsterBattle.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import MonsterBattle from '@/core/domain/entities/game/mob/delegate/battle/MonsterBattle';
+import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+const REFLECT_PERCENTAGE = 50;
+
+const createVictim = (points: Partial<Record<PointsEnum, number>>) => ({
+    getPoint: (point: PointsEnum) => points[point] ?? 0,
+    getAttackRating: () => 0,
+    getDefense: () => 0,
+    getPositionX: () => 0,
+    getPositionY: () => 0,
+    isAffectByFlag: () => false,
+    setAffectFlag: () => {},
+    removeAffectFlag: () => {},
+    updateView: () => {},
+    addEventTimer: () => {},
+    addPoint: () => {},
+    debugChat: () => {},
+    sendDamageReceived: () => {},
+    takeDamage: () => {},
+});
+
+const createAttacker = (battleType: BattleTypeEnum, reflected: Array<number>) => ({
+    getBattleType: () => battleType,
+    getAttackRange: () => 1000,
+    getAttack: () => 500,
+    getAttackRating: () => 0,
+    getEnchant: () => 0,
+    getLevel: () => 1,
+    getDamageMin: () => 1,
+    getDamageMax: () => 1,
+    getDamMultiply: () => 1,
+    getPositionX: () => 0,
+    getPositionY: () => 0,
+    isDeathBlower: () => false,
+    isImmuneByFlag: () => false,
+    createFlyTargeting: () => {},
+    takeDamage: (_victim: unknown, damage: number) => reflected.push(damage),
+});
+
+const createLogger = () => ({ info: () => {}, debug: () => {}, error: () => {} });
+
+const attack = (battleType: BattleTypeEnum) => {
+    const reflected: Array<number> = [];
+    const attacker = createAttacker(battleType, reflected);
+    const victim = createVictim({ [PointsEnum.REFLECT_MELEE]: REFLECT_PERCENTAGE });
+
+    new MonsterBattle(attacker as any, createLogger() as any).execute(AttackTypeEnum.NORMAL, victim as any);
+
+    return reflected;
+};
+
+describe('MonsterBattle', () => {
+    describe('reflect melee', () => {
+        it('should reflect damage back at a melee monster when the victim has reflect melee', () => {
+            expect(attack(BattleTypeEnum.MELEE)).to.have.lengthOf(1);
+        });
+
+        it('should not reflect damage back at a ranged monster, which never gets close enough to be hit back', () => {
+            expect(attack(BattleTypeEnum.RANGE)).to.have.lengthOf(0);
+        });
+    });
+});


### PR DESCRIPTION
Implements the RANGE half of #50. MAGIC stays unimplemented on purpose — see the last section.

## What was broken

`MonsterBattle.execute` dispatches on the battle type and the RANGE branch was an empty `//TODO`, so those monsters ran the whole approach-and-attack loop — closing in, facing the target, playing the attack animation on the usual cadence — and never reached `applyDamage`. **141 monster protos are RANGE or MAGIC**, spanning levels 18 to 110 and including 13 BOSS or KING, so a slice of every level band was harmless. From a player's side it reads as a broken damage calculation rather than a missing branch; it took me a while to work out which it was.

## What this adds

- **`FlyTargetingPacket`**, header `0x47`, 17 bytes: shooter vid, target vid, x, y. This is the packet the client draws the projectile from. The existing `FlyPacket` at `0x46` is `TPacketGCCreateFly`, the particle effect, and is unrelated. The client homes the projectile on the target when the target vid resolves in its view and falls back to the coordinates otherwise, so both are sent.
- **Broadcast to the shooter's nearby players**, mirroring how `createFlyEffect` already works, because the client drops a projectile whose shooter it cannot see.
- **`rangeAttack`**: the same `attackRange * 1.15` guard `meleeAttack` uses, the same damage computation, the same attack effects, reduced by the victim's `RESIST_BOW`, delivered as `NORMAL_RANGE`. The original guards this with a flat 5000 instead, but that can never fire here — `battleState` only calls the attack within `attackRange * 1.15`, and the largest RANGE `attack_range` in `mobs.json` is 900. Copying it would have shipped dead code, so the sibling guard is used instead: meaningful, and symmetric with melee.
- **80% follow distance** for RANGE and MAGIC instead of 90%, which is what keeps a shooter at range in the original.
- Melee and ranged now resolve through one shared `resolveAttack` that takes the damage type and the resistance point to apply; melee passes `0`, so its behaviour is unchanged. The two paths were otherwise identical once the distance guards matched.

Three hooks were already in place and simply had no caller: `applyDamage` branched on `NORMAL_RANGE`, `isDodge` already rolled DODGE instead of BLOCK for it, e `applyResistance` existed unused.

## Following the original

`char_battle.cpp:231` dispatches RANGE to `FlyTarget(...)` then `Shoot(0)`; `CFuncShoot` case 0 for an NPC shooter is the 5000 guard, `CalcMeleeDamage`, `NormalAttackAffect`, then `iDam * (100 - POINT_RESIST_BOW) / 100`. The 80% follow comes from `__CHARACTER_GotoNearTarget` (`char_state.cpp:739`).

## A decision I took rather than asked

**The projectile is broadcast on every shot, including ones the target absorbs.** That is what the original does — `FlyTarget` is called before `Shoot` decides the damage — and it keeps the visual honest: a monster that is firing should show arrows even at a target that takes nothing from them. Sending it only on damaging hits would look more broken than the current bug, not less. One line to flip if you disagree.

## What I verified

- Integration spec `test/integration/game/rangedMobAttack.test.ts`: invokes a Battle Bailiff next to a character and asserts **both halves** — the damage lands and health drops, and the projectile frame for that shooter and target reaches the client.
- **Fail without the fix**: with the branch reverted to `//TODO` the spec fails on the damage assertion while its setup assertions still pass, so it is not vacuous.
- 495 unit and 24 integration specs green. Rebased onto `ad2170fc` after #110 merged and re-ran everything, since that change affects how monsters pick a target.
- `docs/packets.md` regenerated, since the generator builds it from the `@packet` docblocks.

## Why MAGIC is left out

Same shape, but `RESIST_MAGIC` is not registered in `PlayerPoints` — only `RESIST_BOW` is — and `Points.setPoint` silently no-ops on unregistered point types. Shipping the magic branch now would apply no resistance at all and look like it worked. Registering the point is a two-line prerequisite I would rather do inside #51 so this stays one concern.

## Note on scope

Pre-existing. One thing I noticed e left alone: `itemPickupEntityTypeSecurity` is flaky — it asserts `getArea()` immediately after login with no wait for the spawn queue, and failed once then passed on a re-run. Not related to this change; happy to send a wait for it separately if you want.