### PR TITLE
fix: allow shouting during the first 15s of server uptime (fix #99)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -175,7 +175,7 @@ export default class Player extends Character {
     //chat
     private debugMode: boolean = false;
     private chatTimes: Array<number> = [];
-    private lastShoutTime: number = 0;
+    private lastShoutTime: number = Number.NEGATIVE_INFINITY;
 
     //quests
     private readonly quests: Map<number, AbstractQuest> = new Map();
@@ -624,9 +624,9 @@ export default class Player extends Character {
     }
 
     /**
-     * Rate limits every incoming chat packet, commands included. Counts this
-     * message when it is allowed, so a client that keeps sending stays blocked
-     * for as long as it floods rather than being let through every other window.
+     * Rate limits every incoming chat packet, commands included. Only delivered
+     * messages count toward the window, so a rejected flood does not extend its
+     * own block; it is capped at the per-window maximum.
      */
     isChatAllowed(): boolean {
         const now = performance.now();

--- a/test/unit/core/domain/entities/game/player/PlayerShout.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerShout.test.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Logger from '@/core/infra/logger/Logger';
+
+const logger: Logger = { info: () => {}, error: () => {}, debug: () => {} };
+
+const SHOUT_COOLDOWN_MS = 15_000;
+
+// Inside the window where performance.now() < SHOUT_COOLDOWN_MS, i.e. the
+// first seconds of the process — the dead zone issue #99 describes.
+const EARLY_UPTIME_MS = 5_000;
+
+const createPlayer = () => {
+    const config: any = {
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: 100,
+                    initialMp: 50,
+                    initialStamina: 30,
+                    hpPerLvl: 10,
+                    hpPerHtPoint: 2,
+                    mpPerLvl: 5,
+                    mpPerIqPoint: 1,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    return PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: 0,
+            positionY: 0,
+            health: 100,
+            mana: 50,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'shouter',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+            mobManager: {} as any,
+        },
+    );
+};
+
+describe('Player shout cooldown', () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers({ now: EARLY_UPTIME_MS, toFake: ['performance'] });
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+    it('should allow the first shout right after server start (issue #99)', () => {
+        expect(createPlayer().isShoutAllowed()).to.equal(true);
+    });
+
+    it('should keep enforcing the cooldown between two shouts', () => {
+        const player = createPlayer();
+
+        expect(player.isShoutAllowed()).to.equal(true);
+        clock.tick(SHOUT_COOLDOWN_MS - 1);
+        expect(player.isShoutAllowed(), 'a shout inside the cooldown is rejected').to.equal(false);
+        clock.tick(1);
+        expect(player.isShoutAllowed(), 'a shout after the cooldown is allowed').to.equal(true);
+    });
+});


### PR DESCRIPTION
Closes #99.

## The bug

`Player.lastShoutTime` was initialised to `0` and compared against `performance.now()`, which counts from **process start**, not the epoch. So for the first `SHOUT_COOLDOWN_MS` (15s) of the game server's uptime, `now - 0` sits below the cooldown and every shout from every player is silently rejected — including players who have never shouted. Past 15s of uptime the sentinel is far enough behind and the check behaves correctly forever, which is why it never showed in normal use or in the existing specs.

## The fix

The sentinel is now `Number.NEGATIVE_INFINITY`, so "never shouted" reads as infinitely long ago rather than "at process start". The cooldown arithmetic is untouched.

Also corrected the `isChatAllowed` doc comment in passing, as offered in the issue: it claimed a flooding client stays blocked for as long as it floods, which describes the opposite design — rejected messages do not count toward the window, so a flood is capped per window rather than extending its own block. The implementation is correct; only the comment's rationale was wrong.

## Verification

- Two new specs under fake timers at 5s of simulated uptime: the first shout of a fresh player is allowed (this is the pin for #99), and the cooldown still rejects a second shout inside the window while allowing one past it.
- Fail-without-fix: with the sentinel reverted to `0`, the first-shout spec fails; restored, it passes.
- 497 unit and 23 integration specs green.

## Note on scope

This is our own code from the #75 PR, not pre-existing — I missed it when writing that PR. Low severity (a 15-second window per server start), but a real player-facing rejection with no feedback.