### PR TITLE
fix: make /goto teleport instead of despawning the player (fix #88)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -945,6 +945,8 @@ export default class Player extends Character {
         if (this.isShopCloseGracePeriod() || this.isRunningPrivateShop()) {
             return false;
         }
+
+        return true;
     }
 
     teleport(x: number, y: number) {

--- a/src/game/domain/command/command/goto/GotoCommandHandler.ts
+++ b/src/game/domain/command/command/goto/GotoCommandHandler.ts
@@ -47,8 +47,7 @@ export default class GotoCommandHandler extends CommandHandler<GotoCommand> {
                         `[GotoCommandHandler] Teleport ${player.getName()} to area: ${areaByName.getName()}, x: ${x}, y: ${y}`,
                     );
 
-                    this.world.despawn(player);
-                    player.teleport(x, y);
+                    this.warp(player, x, y);
                 }
                 break;
 
@@ -64,8 +63,7 @@ export default class GotoCommandHandler extends CommandHandler<GotoCommand> {
                     return;
                 }
 
-                this.world.despawn(player);
-                player.teleport(target.getPositionX() + 200, target.getPositionY() + 200);
+                this.warp(player, target.getPositionX() + 200, target.getPositionY() + 200);
                 break;
             }
 
@@ -81,11 +79,18 @@ export default class GotoCommandHandler extends CommandHandler<GotoCommand> {
                     return;
                 }
 
-                this.world.despawn(player);
-                player.teleport(Number(x), Number(y));
+                this.warp(player, Number(x), Number(y));
                 break;
             }
         }
+    }
+
+    private warp(player: Player, x: number, y: number) {
+        if (player.canTeleport()) {
+            this.world.despawn(player);
+        }
+
+        player.teleport(x, y);
     }
 
     private getAreaCoordinates(area: Area, player: Player): [number, number] {

--- a/test/integration/game/gotoTeleport.test.ts
+++ b/test/integration/game/gotoTeleport.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Covers issue #88: /goto must warp the character instead of despawning it and
+ * cancelling. The spec drives the real command through the chat channel and
+ * asserts the TeleportPacket the client would warp from.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Bug — /goto teleports instead of despawning the player (issue #88)', function () {
+    this.timeout(60000);
+
+    const TRAVELLER = 'goto_teleport_test';
+    const ORIGIN_X = 958870;
+    const ORIGIN_Y = 272760;
+    const TARGET_X = ORIGIN_X + 2000;
+    const TARGET_Y = ORIGIN_Y + 2000;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('answers /goto location with a TeleportPacket to those coordinates', async () => {
+        session = await harness.login({ username: TRAVELLER, x: ORIGIN_X, y: ORIGIN_Y });
+
+        const player = harness.findPlayer(TRAVELLER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        session.flush();
+        session.command(`/goto location ${TARGET_X} ${TARGET_Y}`);
+        await session.settle(800);
+
+        expect(session.received().includes('teleport canceled'), 'the teleport was not cancelled').to.equal(false);
+
+        // The warp the client acts on: header, then the destination.
+        const warp = Buffer.alloc(9);
+        warp.writeUInt8(PacketHeaderEnum.TELEPORT, 0);
+        warp.writeUInt32LE(TARGET_X, 1);
+        warp.writeUInt32LE(TARGET_Y, 5);
+
+        expect(session.received().includes(warp), 'the TeleportPacket was sent').to.equal(true);
+        expect(player.getPositionX(), 'the server moved the character').to.equal(TARGET_X);
+        expect(player.getPositionY()).to.equal(TARGET_Y);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerTeleport.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerTeleport.test.ts
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Logger from '@/core/infra/logger/Logger';
+
+const logger: Logger = { info: () => {}, error: () => {}, debug: () => {} };
+
+const TARGET_X = 200_000;
+const TARGET_Y = 300_000;
+
+const createPlayer = () => {
+    const config: any = {
+        SERVER_PORT: '13001',
+        SERVER_ADDRESS: '127.0.0.1',
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: 100,
+                    initialMp: 50,
+                    initialStamina: 30,
+                    hpPerLvl: 10,
+                    hpPerHtPoint: 2,
+                    mpPerLvl: 5,
+                    mpPerIqPoint: 1,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    return PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: 100_000,
+            positionY: 100_000,
+            health: 100,
+            mana: 50,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'traveller',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+            mobManager: {} as any,
+        },
+    );
+};
+
+describe('Player teleport', () => {
+    afterEach(() => sinon.restore());
+
+    describe('canTeleport', () => {
+        it('should allow a player with nothing blocking it (issue #88)', () => {
+            expect(createPlayer().canTeleport()).to.equal(true);
+        });
+
+        it('should refuse while a private shop is running', () => {
+            const player = createPlayer();
+            sinon.stub(player, 'isRunningPrivateShop').returns(true);
+            expect(player.canTeleport()).to.equal(false);
+        });
+
+        it('should refuse during the shop-close grace period', () => {
+            const player = createPlayer();
+            sinon.stub(player, 'isShopCloseGracePeriod').returns(true);
+            expect(player.canTeleport()).to.equal(false);
+        });
+    });
+
+    describe('teleport', () => {
+        it('should move the player to the target position (issue #88)', () => {
+            const player = createPlayer();
+
+            player.teleport(TARGET_X, TARGET_Y);
+
+            expect(player.getPositionX()).to.equal(TARGET_X);
+            expect(player.getPositionY()).to.equal(TARGET_Y);
+        });
+
+        it('should leave the player where it was when the teleport is refused', () => {
+            const player = createPlayer();
+            sinon.stub(player, 'isRunningPrivateShop').returns(true);
+            const originX = player.getPositionX();
+            const originY = player.getPositionY();
+
+            player.teleport(TARGET_X, TARGET_Y);
+
+            expect(player.getPositionX()).to.equal(originX);
+            expect(player.getPositionY()).to.equal(originY);
+        });
+    });
+});

--- a/test/unit/game/domain/command/goto/GotoCommandHandler.test.ts
+++ b/test/unit/game/domain/command/goto/GotoCommandHandler.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Player from '@/core/domain/entities/game/player/Player';
+import WinstonLoggerAdapter from '@/core/infra/logger/WinstonLoggerAdapter';
+import GotoCommandHandler from '@/game/domain/command/command/goto/GotoCommandHandler';
+import GotoCommand from '@/game/domain/command/command/goto/GotoCommand';
+import World from '@/core/domain/World';
+
+describe('GotoCommandHandler', () => {
+    let logger: sinon.SinonStubbedInstance<WinstonLoggerAdapter>;
+    let world: sinon.SinonStubbedInstance<World>;
+    let handler: GotoCommandHandler;
+    let player: sinon.SinonStubbedInstance<Player>;
+    let command: sinon.SinonStubbedInstance<GotoCommand>;
+
+    beforeEach(() => {
+        logger = sinon.createStubInstance(WinstonLoggerAdapter);
+        world = sinon.createStubInstance(World);
+        handler = new GotoCommandHandler({ logger, world });
+        player = sinon.createStubInstance(Player);
+        command = sinon.createStubInstance(GotoCommand);
+        command.isValid.returns(true);
+        command.getArgs.returns(['location', '200000', '300000']);
+        world.getAreaByCoordinates.returns({} as any);
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should despawn from the origin before the position changes (issue #88)', async () => {
+        player.canTeleport.returns(true);
+
+        await handler.execute(player, command);
+
+        expect(world.despawn.calledOnceWith(player)).to.be.true;
+        expect(player.teleport.calledOnceWith(200000, 300000)).to.be.true;
+        sinon.assert.callOrder(world.despawn, player.teleport);
+    });
+
+    it('should not despawn when the teleport is refused, so the player is not left in limbo (issue #88)', async () => {
+        player.canTeleport.returns(false);
+
+        await handler.execute(player, command);
+
+        expect(world.despawn.called, 'a refused teleport must not remove the player from the world').to.be.false;
+        expect(player.teleport.calledOnceWith(200000, 300000), 'teleport still delivers its refusal message').to.be
+            .true;
+    });
+
+    it('should warp next to the target player through the same guarded path', async () => {
+        const target = sinon.createStubInstance(Player);
+        target.getPositionX.returns(500000);
+        target.getPositionY.returns(600000);
+        world.getPlayerByName.returns(target);
+        command.getArgs.returns(['player', 'friend']);
+        player.canTeleport.returns(true);
+
+        await handler.execute(player, command);
+
+        expect(world.despawn.calledOnceWith(player)).to.be.true;
+        expect(player.teleport.calledOnceWith(500200, 600200)).to.be.true;
+    });
+});


### PR DESCRIPTION
Closes #88.

## The bug

`canTeleport()` had no success return, so it evaluated as `undefined` on every allowed path; `!undefined` took `teleport()`'s cancel branch, and the only callers — the three `/goto` branches — despawn the player **before** calling it. The despawn happened, the move did not, and nothing put the character back: the connection stayed open with the player gone from the world until relog.

## The fix

- `canTeleport()` returns `true` when nothing blocks the teleport. The two refusal paths (private shop running, shop-close grace period) are unchanged.
- The goto handler routes all three branches through one `warp()` helper that despawns only when `canTeleport()` passes, so a genuine refusal now leaves the player standing where they were instead of in limbo — the destructive half the issue flagged as "worth considering as part of it".

## One ordering trade-off, made deliberately

The despawn stays **before** the position change: `World.despawn` resolves the area from the entity's *current* position, so despawning after `teleport()` would look up the destination area and leave the player ghosted in the origin one. This is why the fix is a guarded despawn-first rather than a teleport-then-despawn. `canTeleport()` ends up consulted twice (handler + inside `teleport()`); the check is pure, and keeping the internal guard means any future caller of `teleport()` stays safe on its own.

## Verification

- Unit: `canTeleport` allows a fresh player and refuses during a private shop / grace period; `teleport()` moves the player and a refused teleport does not; the handler despawns before the position changes on the allowed path, does not despawn at all on the refused path, and the `player` branch warps through the same guarded helper.
- Integration: a real `/goto location x y` through the chat channel — the TeleportPacket carries the destination, the cancel message is absent, and the server-side position moved.
- Fail-without-fix: with only the `canTeleport` return reverted, the two Player unit specs fail and the integration spec fails on "the teleport was not cancelled"; the handler specs keep passing because they stub the player, which is exactly the boundary they pin.
- 505 unit and 24 integration specs green.

## Note on scope

Pre-existing (the missing return shipped with the command itself). `restart('TOWN')` still bypasses `canTeleport()` by writing the position directly, as noted in the issue — left alone here, it belongs to the #108 restart discussion.