### PR TITLE
fix: keep the world ticking when a tick throws (fix #81)

### DIFF
--- a/src/core/domain/World.ts
+++ b/src/core/domain/World.ts
@@ -228,24 +228,31 @@ export default class World {
 
     async tick() {
         const startTickTime = performance.now();
+        let delta: number | undefined;
 
-        for (const area of this.areas.values()) {
-            area.tick();
+        try {
+            for (const area of this.areas.values()) {
+                area.tick();
+            }
+
+            this.privilegeManager.tick();
+            this.eventTimerManager.tick();
+            this.entityManager.tick();
+
+            delta = performance.now() - startTickTime;
+            this.deltas.push(delta);
+
+            if (this.deltas.length === 100) {
+                const averageTick = this.deltas.reduce((acc, curr) => acc + curr, 0);
+                this.logger.info(`average tick time is: ~${(averageTick / 100).toFixed(2)}ms`);
+                this.deltas = [];
+            }
+        } catch (error) {
+            this.logger.error(
+                `[WORLD] Error during tick, world keeps ticking: ${error instanceof Error ? error.stack : String(error)}`,
+            );
+        } finally {
+            setTimeout(this.tick.bind(this), calculateTickDelay(delta));
         }
-
-        this.privilegeManager.tick();
-        this.eventTimerManager.tick();
-        this.entityManager.tick();
-
-        const delta = performance.now() - startTickTime;
-        this.deltas.push(delta);
-
-        if (this.deltas.length === 100) {
-            const averageTick = this.deltas.reduce((acc, curr) => acc + curr, 0);
-            this.logger.info(`average tick time is: ~${(averageTick / 100).toFixed(2)}ms`);
-            this.deltas = [];
-        }
-
-        setTimeout(this.tick.bind(this), calculateTickDelay(delta));
     }
 }

--- a/test/integration/game/worldTickResilience.test.ts
+++ b/test/integration/game/worldTickResilience.test.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { container } from '@/game/Container';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Covers issue #81: one broken entity must not stop the world tick. The spec
+ * injects an entity whose tick always throws — the exact amplification that
+ * turned the #73 data bug into a whole-server outage — and asserts the throw
+ * neither escapes as an unhandled rejection nor freezes the world.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Resilience — world tick survives a broken entity (issue #81)', function () {
+    this.timeout(60000);
+
+    const SURVIVOR = 'tick_survivor_test';
+    const BROKEN_VID = 0x7fffffff;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('keeps ticking and serving logins while an entity keeps throwing', async () => {
+        const entityManager = container.resolve<any>('entityManager');
+        const rejectionsBefore = harness.capturedRejections().length;
+
+        entityManager.entities.set(BROKEN_VID, {
+            tick: () => {
+                throw new Error('broken entity (issue #81 spec)');
+            },
+        });
+
+        try {
+            // A few tick periods at 20Hz, each hitting the broken entity.
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(
+                harness.capturedRejections().length,
+                'the tick loop caught the throw instead of dying on an unhandled rejection',
+            ).to.equal(rejectionsBefore);
+
+            // The world is still alive end-to-end: a login needs spawn queues
+            // and entity ticks to be processed, none of which happen once the
+            // loop is dead.
+            session = await harness.login({ username: SURVIVOR });
+            expect(harness.findPlayer(SURVIVOR), 'a new character still enters the world').to.not.equal(undefined);
+        } finally {
+            entityManager.entities.delete(BROKEN_VID);
+        }
+    });
+});

--- a/test/unit/core/domain/World.test.ts
+++ b/test/unit/core/domain/World.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import World from '@/core/domain/World';
+import Logger from '@/core/infra/logger/Logger';
+
+describe('World', () => {
+    let clock: sinon.SinonFakeTimers;
+    let logger: { info: sinon.SinonStub; error: sinon.SinonStub; debug: sinon.SinonStub };
+
+    const createWorld = () => {
+        return new World({
+            logger: logger as unknown as Logger,
+            config: {} as any,
+            saveCharacterService: {} as any,
+            spawnManager: {} as any,
+            privilegeManager: { tick: sinon.stub() } as any,
+            eventTimerManager: { tick: sinon.stub() } as any,
+            entityManager: { tick: sinon.stub() } as any,
+        });
+    };
+
+    const addArea = (world: World, area: { tick: () => void }) => {
+        (world as any).areas.set('area', area);
+    };
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
+        logger = { info: sinon.stub(), error: sinon.stub(), debug: sinon.stub() };
+    });
+
+    afterEach(() => {
+        clock.restore();
+        sinon.restore();
+    });
+
+    describe('tick', () => {
+        it('should reschedule itself after a healthy tick', async () => {
+            const world = createWorld();
+            const area = { tick: sinon.stub() };
+            addArea(world, area);
+
+            await world.tick();
+
+            expect(area.tick.calledOnce).to.be.true;
+            expect(logger.error.called).to.be.false;
+            expect(clock.countTimers(), 'the next tick is scheduled').to.equal(1);
+        });
+
+        it('should keep the loop alive when an area tick throws (issue #81)', async () => {
+            const world = createWorld();
+            addArea(world, {
+                tick: () => {
+                    throw new Error('broken entity');
+                },
+            });
+
+            await world.tick();
+
+            expect(logger.error.calledOnce, 'the failure is logged loudly').to.be.true;
+            expect(clock.countTimers(), 'the next tick is still scheduled').to.equal(1);
+        });
+
+        it('should keep the loop alive when a manager tick throws (issue #81)', async () => {
+            const world = createWorld();
+            (world as any).entityManager.tick = () => {
+                throw new Error('broken entity');
+            };
+
+            await world.tick();
+
+            expect(logger.error.calledOnce).to.be.true;
+            expect(clock.countTimers(), 'the next tick is still scheduled').to.equal(1);
+        });
+
+        it('should survive a persistently throwing area across consecutive ticks', async () => {
+            const world = createWorld();
+            addArea(world, {
+                tick: () => {
+                    throw new Error('broken entity');
+                },
+            });
+
+            await world.tick();
+            await clock.tickAsync(50);
+            await clock.tickAsync(50);
+
+            expect(logger.error.callCount, 'every failed tick is logged').to.be.at.least(3);
+            expect(clock.countTimers(), 'the loop is still going').to.equal(1);
+        });
+    });
+});


### PR DESCRIPTION
Closes #81 — this is the **minimum** proposed there, deliberately.

## The bug

`World.tick` had no error handling and its reschedule was the last statement, so any exception thrown anywhere under a tick — area spawn queues, entity ticks, the three managers — meant the loop was never rescheduled. In production `main.ts` turns the resulting unhandled rejection into `process.exit(1)`, so one broken entity took the whole server down; anywhere the rejection is swallowed instead, the world froze forever with the TCP port still listening. This is the exact amplification that turned the #73 one-line data bug into a player-triggerable DoS.

## The fix

The tick body is wrapped in `try/catch` and the reschedule moved to `finally`, so the loop can never die. `calculateTickDelay` already defaults its delta to 0, so the error path reschedules at the full tick interval with no extra handling. The failure is logged at error level with the stack interpolated into the message — `WinstonLoggerAdapter` only preserves a stack when the `Error` is the first argument, and meta objects serialize to `{}`, so the message carries it explicitly.

**Not taken here:** per-entity isolation with a failure counter (so one broken entity does not cost the rest of that tick, and a persistent thrower gets despawned instead of logging 20×/s). That is the issue's open question — it needs your call on despawn policy, and the minimum alone removes the whole-server-outage class. Happy to follow up either way.

## Verification

- Unit: a healthy tick reschedules; an area throw and a manager throw are each logged and still reschedule; a persistently throwing area survives consecutive ticks.
- Integration: injects an entity whose tick always throws into the live entity manager, and asserts the throw does not surface as an unhandled rejection and that a new character can still log in while the broken entity keeps throwing — the end-to-end signal that spawn queues and ticks are still being processed.
- Fail-without-fix: with `World.tick` reverted to master, the three throwing-path unit specs fail while the healthy-tick spec passes.
- 499 unit and 24 integration specs green.

## Note on scope

Pre-existing structure, unchanged since the issue was filed. Catching and continuing is explicitly not a substitute for fixing root causes — the log is loud precisely so nothing hides in it.