### PR TITLE
fix: await two service calls whose rejections escaped to the process

### DIFF
--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -163,7 +163,7 @@ export abstract class AbstractQuest {
                     } finally {
                         this.rearmLetter(context.eventType, callbackResult);
                         this.autoDone();
-                        this.endRunning(callbackResult);
+                        await this.endRunning(callbackResult);
                     }
                 } catch (err) {
                     console.error('[QUEST] runState error', err);

--- a/src/core/interface/networking/packets/packet/in/itemDrop/ItemDropPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/itemDrop/ItemDropPacketHandler.ts
@@ -32,7 +32,7 @@ export default class ItemDropPacketHandler extends PacketHandler<ItemDropPacket>
             return;
         }
 
-        this.dropItemService.execute({
+        await this.dropItemService.execute({
             player,
             window: packet.getWindow(),
             position: packet.getPosition(),

--- a/test/unit/core/domain/quests/AbstractQuestRunState.test.ts
+++ b/test/unit/core/domain/quests/AbstractQuestRunState.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AbstractQuest } from '@/core/domain/quests/AbstractQuest';
+import { QuestEventEnum } from '@/core/enum/QuestEventEnum';
+
+class TestQuest extends AbstractQuest {}
+
+const createQuest = () => {
+    const player = {
+        sendQuestScript: () => {},
+        setCurrentQuest: () => {},
+        getId: () => 1,
+        sendQuestInfo: () => {},
+    };
+
+    return new TestQuest({
+        player: player as any,
+        itemManager: {} as any,
+        questTargetManager: {} as any,
+    });
+};
+
+describe('AbstractQuest.runState', () => {
+    afterEach(() => sinon.restore());
+
+    it('should finish the state transition before it resolves (unawaited endRunning)', async () => {
+        const quest = createQuest();
+        const entered = sinon.stub();
+
+        quest.addState({
+            name: 'start',
+            tasks: [
+                {
+                    when: QuestEventEnum.CLICK,
+                    callback: () => ({ nextState: 'next' }),
+                } as any,
+            ],
+        });
+        quest.addState({
+            name: 'next',
+            tasks: [
+                {
+                    when: QuestEventEnum.ENTER_STATE,
+                    callback: entered,
+                } as any,
+            ],
+        });
+
+        await quest.setState('start');
+        await quest.runState({ eventType: QuestEventEnum.CLICK } as any);
+
+        expect(quest.getCurrentState()?.name, 'the next state is already active').to.equal('next');
+        expect(entered.called, 'the next state has already run its enter tasks').to.equal(true);
+    });
+
+    it('should run the letter tasks of the state it moved into', async () => {
+        const quest = createQuest();
+        const letter = sinon.stub();
+
+        quest.addState({
+            name: 'start',
+            tasks: [
+                {
+                    when: QuestEventEnum.CLICK,
+                    callback: () => ({ nextState: 'next' }),
+                } as any,
+            ],
+        });
+        quest.addState({
+            name: 'next',
+            tasks: [
+                {
+                    when: QuestEventEnum.LETTER,
+                    callback: letter,
+                } as any,
+            ],
+        });
+
+        await quest.setState('start');
+        await quest.runState({ eventType: QuestEventEnum.CLICK } as any);
+
+        expect(letter.called, 'the new state letter task already ran').to.equal(true);
+    });
+});

--- a/test/unit/core/interface/networking/packets/in/itemDrop/ItemDropPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/in/itemDrop/ItemDropPacketHandler.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ItemDropPacketHandler from '@/core/interface/networking/packets/packet/in/itemDrop/ItemDropPacketHandler';
+
+const createHandler = (execute: sinon.SinonStub) => {
+    const handler = new ItemDropPacketHandler({
+        logger: { info: () => {}, error: () => {}, debug: () => {} } as any,
+        dropItemService: { execute } as any,
+    });
+
+    const connection = {
+        getPlayer: () => ({ getName: () => 'dropper' }),
+        close: sinon.stub(),
+    };
+
+    const packet = {
+        isValid: () => true,
+        getWindow: () => 1,
+        getPosition: () => 0,
+        getGold: () => 0,
+        getCount: () => 1,
+    };
+
+    return { handler, connection, packet };
+};
+
+describe('ItemDropPacketHandler', () => {
+    afterEach(() => sinon.restore());
+
+    it('should surface a service failure to the caller instead of leaking it', async () => {
+        const failure = new Error('drop blew up');
+        const { handler, connection, packet } = createHandler(sinon.stub().rejects(failure));
+
+        // GameServer.onData catches what execute() rejects with; anything the
+        // handler drops on the floor becomes an unhandledRejection instead.
+        const caught = await handler.execute(connection as any, packet as any).catch((err) => err);
+
+        expect(caught, 'the rejection reached the dispatch catch').to.equal(failure);
+    });
+
+    it('should still drop the item on the happy path', async () => {
+        const execute = sinon.stub().resolves();
+        const { handler, connection, packet } = createHandler(execute);
+
+        await handler.execute(connection as any, packet as any);
+
+        expect(execute.calledOnce).to.be.true;
+        expect(execute.firstCall.args[0]).to.include({ window: 1, position: 0, gold: 0, count: 1 });
+    });
+});


### PR DESCRIPTION
Found while sweeping the handlers for missing `await`s. Two call sites, one line each, both with the same failure mode. No new issue filed — it overlaps #103, which already asks for exactly this treatment on two *other* handlers.

## Why a missing await is a server outage

`GameServer.onData` wraps every handler:

```ts
await handler.execute(connection, unpacked)
    .catch((err) => this.logger.error(err))
    .finally(() => connection.uncork());
```

That `.catch` is why a throwing handler is a logged error instead of a dead server. A handler that dispatches an `async` service **without awaiting it** defeats it: `execute()` resolves as soon as the service is fired, the catch has nothing left to attach to, and the later rejection surfaces as an `unhandledRejection` — which `main.ts` turns into `app.close()` + `process.exit(1)`.

One failed item drop disconnects everyone. This is the same amplification that turned the one-line data bug in #73 into a player-triggerable DoS.

## The two sites

- **`ItemDropPacketHandler`** dispatched `DropItemService.execute` unawaited. That service is literally the one from #73, and every path through it touches the inventory and the database.
- **`AbstractQuest.runState`** called `this.endRunning()` — an `async` method — from inside a `finally` block without awaiting, so its rejection escaped *both* of `runState`'s try/catch layers. Because `endRunning` drives `setState()` and the follow-up `LETTER` run, the state transition was also still in flight when `runState` resolved; awaiting it fixes the leak and makes the transition observable to the caller.

## Checked and deliberately left alone

- **`EnterGamePacketHandler`** also calls its service without `await`, mas `EnterGameService.execute` is **synchronous** — nothing to leak. No cosmetic await added.
- **`ItemUsePacketHandler` and `ItemMovePacketHandler`** have the same shape and are already in **#103**, whose fix list opens with this exact await. Left there so this PR stays reviewable on its own — say the word and I will fold them in here instead.
- **Quest errors go to `console.error`**, not the injected logger, so they never reach `logs/error.log`. `AbstractQuest` has no logger today and wiring one touches the constructor and every subclass — out of scope here, happy to send it separately.

## Verification

- A rejecting `DropItemService` now reaches the caller (the assertion mirrors what `onData`'s catch receives); the happy path still forwards the packet fields.
- A quest state returning a `nextState` has already entered that state and run its `ENTER_STATE` and `LETTER` tasks by the time `runState` resolves.
- **Fail-without-fix:** with both awaits removed, all three specs fail — the drop rejection arrives as `undefined` and the quest assertions see the old state.
- 499 unit and 23 integration specs green.

## Note on scope

Pre-existing, not from any of our PRs.