### PR TITLE
fix: store a multi-cell item at its anchor cell only (fix #117)

### DIFF
--- a/src/core/domain/entities/game/inventory/Page.ts
+++ b/src/core/domain/entities/game/inventory/Page.ts
@@ -3,9 +3,11 @@ import Item from '../item/Item';
 
 export default class Page {
     private readonly grid: Grid<Item | null>;
+    private readonly anchors: Grid<number | null>;
 
     constructor(width: number, height: number) {
         this.grid = new Grid<Item | null>(width, height, null);
+        this.anchors = new Grid<number | null>(width, height, null);
     }
 
     getGrid() {
@@ -16,9 +18,7 @@ export default class Page {
         for (let y = 0; y < this.grid.getHeight(); y++) {
             for (let x = 0; x < this.grid.getWidth(); x++) {
                 if (this.haveSpaceAvailable(x, y, item.getSize())) {
-                    for (let i = 0; i < item.getSize(); i++) {
-                        this.grid.setValue(x, y + i, item);
-                    }
+                    this.place(x, y, item);
                     return x + y * this.grid.getWidth();
                 }
             }
@@ -33,18 +33,26 @@ export default class Page {
         const { x, y } = this.calcPosition(position);
         if (!this.haveSpaceAvailable(x, y, item.getSize())) return false;
 
-        for (let i = 0; i < item.getSize(); i++) {
-            this.grid.setValue(x, y + i, item);
-        }
+        this.place(x, y, item);
 
         return true;
+    }
+
+    private place(x: number, y: number, item: Item) {
+        const anchor = x + y * this.grid.getWidth();
+
+        for (let i = 0; i < item.getSize(); i++) {
+            this.anchors.setValue(x, y + i, anchor);
+        }
+
+        this.grid.setValue(x, y, item);
     }
 
     haveSpaceAvailable(x: number, y: number, size: number) {
         for (let i = 0; i < size; i++) {
             if (y + i >= this.grid.getHeight()) return false;
 
-            if (this.grid.getValue(x, y + i)) {
+            if (this.anchors.getValue(x, y + i) !== null) {
                 return false;
             }
         }
@@ -84,7 +92,11 @@ export default class Page {
         const { x, y } = this.calcPosition(position);
 
         for (let i = 0; i < size; i++) {
-            this.grid.setValue(x, y + i, null);
+            if (this.anchors.getValue(x, y + i) !== position) continue;
+
+            this.anchors.setValue(x, y + i, null);
         }
+
+        this.grid.setValue(x, y, null);
     }
 }

--- a/test/unit/core/domain/inventory/Inventory.test.ts
+++ b/test/unit/core/domain/inventory/Inventory.test.ts
@@ -8,13 +8,13 @@ import { GameConfig } from '@/game/infra/config/GameConfig';
 
 const PAGE_SIZE = 45; // 5 x 9
 
-function createItem(id: number, dbId: number) {
+function createItem(id: number, dbId: number, size: number = 1) {
     return new Item({
         id,
         name: `item-${id}`,
         type: ItemTypeEnum.ITEM_USE,
         subType: ItemUseSubTypeEnum.USE_POTION,
-        size: 1,
+        size,
         antiFlags: new BitFlag(),
         flags: new BitFlag(),
         wearFlags: new BitFlag(),
@@ -92,5 +92,75 @@ describe('Inventory', () => {
         expect(inventory.getItem(PAGE_SIZE + 25)).to.equal(secondPageItem);
         expect(firstPageItem.getPosition()).to.equal(25);
         expect(secondPageItem.getPosition()).to.equal(PAGE_SIZE + 25);
+    });
+
+    it('should resolve a multi-cell item only at its anchor cell', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+
+        inventory.addItemAt(item, 0);
+
+        expect(inventory.getItem(0)).to.equal(item);
+        expect(inventory.getItem(5)).to.equal(null);
+    });
+
+    it('should ignore a removal addressed by a cell that is not the anchor', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+
+        inventory.addItemAt(item, 0);
+
+        inventory.removeItem(5, item.getSize());
+
+        expect(inventory.getItem(0)).to.equal(item);
+        expect(inventory.getItems().size).to.equal(1);
+        expect(inventory.haveAvailablePosition(5, 1)).to.equal(false);
+    });
+
+    it('should not clear a neighbour when a non-anchor cell is removed', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+        const neighbour = createItem(27003, 2);
+
+        inventory.addItemAt(item, 0);
+        inventory.addItemAt(neighbour, 10);
+
+        inventory.removeItem(5, item.getSize());
+
+        expect(inventory.getItem(10)).to.equal(neighbour);
+    });
+
+    it('should keep every cell of a multi-cell item occupied', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+
+        inventory.addItemAt(item, 0);
+
+        expect(inventory.haveAvailablePosition(0, 1)).to.equal(false);
+        expect(inventory.haveAvailablePosition(5, 1)).to.equal(false);
+        expect(inventory.haveAvailablePosition(10, 1)).to.equal(true);
+    });
+
+    it('should refuse to place an item over the non-anchor cell of a multi-cell item', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+        const other = createItem(27003, 2);
+
+        inventory.addItemAt(item, 0);
+        inventory.addItemAt(other, 5);
+
+        expect(inventory.getItem(0)).to.equal(item);
+        expect(other.getPosition()).to.equal(null);
+    });
+
+    it('should free every cell when a multi-cell item is removed from its anchor', () => {
+        const inventory = createInventory();
+        const item = createItem(11299, 1, 2);
+
+        inventory.addItemAt(item, 0);
+        inventory.removeItem(0, item.getSize());
+
+        expect(inventory.getItem(0)).to.equal(null);
+        expect(inventory.haveAvailablePosition(0, 2)).to.equal(true);
     });
 });


### PR DESCRIPTION
Fixes #117.

## The bug

`Page` wrote the same `Item` reference into **every** cell an item occupied and resolved a lookup from any of them, while `removeItem` cleared cells downward from whatever cell the caller named. Addressing a size-2 item by its second cell moved o item and left the original anchor still pointing at it — one `Item` object reachable at two inventory positions, which is enough to sell it twice or to equip it and keep it in the bag. Removing by a non-anchor cell also nulled the cell below, which belongs to a different item.

## The fix, and why it is not the one I proposed in the issue

The issue ended by offering you a one-line predicate on `Inventory.getItem` versus a real occupancy array on `Page`, and said I would take the predicate. **I changed my mind while implementing, and I want to be explicit about it rather than quietly ship the other one.** Two reasons:

1. The original settles it. `CHARACTER::SetItem` stores the pointer at the anchor alone (`char_item.cpp:334`) and marks the remaining cells in a *separate* occupancy array pointing back at that anchor (`:327`), which is exactly why `CHARACTER::GetItem` returns `NULL` for a non-anchor cell (`:248`).
2. The predicate would not have unblocked #118. It fixes lookups by position but leaves the item physically in every cell, so deriving enumeration from the grid — which is what the original does — would still double-count multi-cell items.

So `Page` now mirrors the original: `grid` holds the item at its anchor, `anchors` records which anchor owns each occupied cell, and `haveSpaceAvailable` consults `anchors`. That second array is load-bearing, not decoration: with anchor-only storage and no occupancy map, the covered cells would read as free and items could be placed overlapping.

```ts
private place(x: number, y: number, item: Item) {
    const anchor = x + y * this.grid.getWidth();

    for (let i = 0; i < item.getSize(); i++) {
        this.anchors.setValue(x, y + i, anchor);
    }

    this.grid.setValue(x, y, item);
}
```

`removeItem` keeps its `size` parameter but now skips any cell whose anchor is not the position being removed, mirroring the guard at `char_item.cpp:304`, so a stray call can no longer clear a neighbour.

**One deliberate deviation.** The original encodes the back-reference as `wCell + 1` so a zero-initialised array reads as free. A nullable field expresses that directly in TypeScript, so `anchors` stores the anchor itself and `null` means free. If you would rather keep the `+ 1` encoding for line-by-line comparability with the C source, it is a two-line flip.

## Verified

- **6 new specs in `Inventory.test.ts`.** Three fail on `ad2170fc` and pass here — a non-anchor cell resolves the item; a removal addressed by a non-anchor cell deletes the map entry and frees the cell; that same removal wipes a neighbour item. I ran them against master first and confirmed those three and only those three fail.
- Three are regression guards for the new storage rather than bug proofs, and pass both before and after: every cell an item covers still reads as occupied, placing over a covered cell is refused, and removing from the anchor frees the whole extent. Flagging that they are guards so they are not mistaken for evidence.
- **501 unit passing.** Integration **23 passing**, with only the two pre-existing dead-state failures from the #108 spec, which is not merged and fails on master by design. Item drop, pickup and stack-conservation specs all pass.
- `tsc`, `eslint` and `prettier` clean.

One honest note on the integration run: the first attempt sat for five minutes without producing test output and I killed it, suspecting my own change. It did not reproduce — clean `master` and this branch both completed afterwards, this branch in 51s. I could not find a mechanism in the diff and am recording it as transient rather than claiming it was unrelated.

## Scope

`Page.getGrid()` and `Inventory.getPages()` have no callers anywhere, so nothing outside `Page` depended on the old cell layout. No data migration: the defect let one row be *reached* twice, it never wrote overlapping rows.

Deliberately left alone: `removeItem`'s `size` parameter is now redundant, since `anchors` knows the extent. Dropping it touches `Inventory`, `ShopManager`, `Player` e `DropItemService`, so I kept the signature to hold this PR to one behaviour change. Happy to follow up if you want it gone.

This is a prerequisite for #118 — I will wait for your answer there before starting it.
