### PR TITLE
fix: stop TARGET from disclosing another player's health (fix #119)

### DIFF
--- a/src/core/domain/entities/game/mob/NPC.ts
+++ b/src/core/domain/entities/game/mob/NPC.ts
@@ -5,6 +5,12 @@ import AnimationManager from '@/core/domain/manager/AnimationManager';
 import { EntityStateEnum } from '@/core/enum/EntityStateEnum';
 import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 
+/** Minimal surface of the rider's horse delegate that a summoned horse reads its health from. */
+export interface IHorseStats {
+    getHealth(): number;
+    getMaxHealth(): number;
+}
+
 export default class NPC extends Mob {
     /**
      * When set, every viewer except this virtualId renders the NPC as a dead
@@ -13,6 +19,9 @@ export default class NPC extends Mob {
      * clickable for its owner (used by the dead horse, issue #42).
      */
     private corpseOwnerVirtualId: number | null = null;
+
+    /** Set while this NPC is a player's summoned horse, so TARGET reports the rider's horse health. */
+    private horseStats: IHorseStats | null = null;
 
     constructor(
         params: Omit<MobParams, 'entityType'>,
@@ -59,6 +68,10 @@ export default class NPC extends Mob {
         return this.corpseOwnerVirtualId;
     }
 
+    setHorseStats(horseStats: IHorseStats | null): void {
+        this.horseStats = horseStats;
+    }
+
     applyPoison(): void {
         throw new Error('Method not implemented.');
     }
@@ -69,7 +82,13 @@ export default class NPC extends Mob {
         throw new Error('Method not implemented.');
     }
     getHealthPercentage(): number {
-        return 100;
+        if (!this.horseStats) return 100;
+
+        const maxHealth = this.horseStats.getMaxHealth();
+
+        if (!maxHealth) return 100;
+
+        return Math.round(Math.max(0, Math.min(100, (this.horseStats.getHealth() * 100) / maxHealth)));
     }
     getAttack(): number {
         throw new Error('Method not implemented.');

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -835,6 +835,8 @@ export default class Player extends Character {
     }
 
     setTarget(target: Character) {
+        if (this.getTarget() === target) return;
+
         super.setTarget(target);
         this.sendTargetUpdated(target);
     }
@@ -842,8 +844,8 @@ export default class Player extends Character {
     sendTargetUpdated(target?: Character) {
         this.connection?.send(
             new TargetUpdatedPacket({
-                virtualId: target?.getVirtualId() || 0,
-                healthPercentage: target?.getHealthPercentage() || 0,
+                virtualId: target?.getVirtualId() ?? 0,
+                healthPercentage: target instanceof Player ? 0 : (target?.getHealthPercentage() ?? 0),
             }),
         );
     }

--- a/src/core/domain/entities/game/player/delegate/PlayerHorse.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerHorse.ts
@@ -483,6 +483,7 @@ export class PlayerHorse {
             // m_chHorse->SetLevel(GetHorseLevel())).
             horseEntity.setPoint(PointsEnum.LEVEL, this.level);
 
+            horseEntity.setHorseStats(this);
             this.spawnedHorse = horseEntity;
 
             if (this.health <= 0) {
@@ -516,6 +517,7 @@ export class PlayerHorse {
         }
 
         this.spawnedHorse.clearMovementNodes();
+        this.spawnedHorse.setHorseStats(null);
 
         const area = this.owner.getArea();
         if (area) {

--- a/test/unit/core/domain/entities/game/player/PlayerHorse.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerHorse.test.ts
@@ -95,10 +95,15 @@ const createPlayer = (
 const createFakeHorse = (virtualId: number) => {
     let dead = false;
     let corpseOwnerVid: number | null = null;
+    let horseStats: any = null;
     const nearby = new Map<number, any>();
     return {
         name: '',
         nearby,
+        setHorseStats: (stats: any) => {
+            horseStats = stats;
+        },
+        getHorseStats: () => horseStats,
         die: () => {
             dead = true;
         },

--- a/test/unit/core/domain/entities/game/player/PlayerTargetHealth.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerTargetHealth.test.ts
@@ -1,0 +1,241 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import NPC from '@/core/domain/entities/game/mob/NPC';
+import Character from '@/core/domain/entities/game/Character';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const config: any = {
+    empire: { red: { startPosX: 100, startPosY: 200 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (virtualId: number, name: string, horseLevel?: number): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: virtualId,
+            appearance: 0,
+            slot: 0,
+            virtualId,
+            id: virtualId,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            name,
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+            ...(horseLevel === undefined ? {} : { horseLevel, horseHealth: 1, horseStamina: 100, horseName: 'Pony' }),
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createConnection = () => {
+    const targetPackets: { virtualId: number; healthPercentage: number }[] = [];
+    return {
+        targetPackets,
+        connection: {
+            send: (packet: any) => {
+                if (packet.constructor.name !== 'TargetUpdatedPacket') return;
+                const buffer = packet.pack();
+                targetPackets.push({
+                    virtualId: buffer.readUInt32LE(1),
+                    healthPercentage: buffer.readUInt8(5),
+                });
+            },
+            setState: () => {},
+        } as any,
+    };
+};
+
+const createHorseNpc = (virtualId: number): NPC =>
+    new NPC(
+        {
+            proto: { vnum: 20104, name: 'Brown Horse', empire: 0, rank: 'KING', type: 'NPC' },
+            positionX: 0,
+            positionY: 0,
+            virtualId,
+            direction: 0,
+        } as any,
+        {
+            animationManager: { getAnimation: () => undefined } as any,
+            questManager: { getQuestsByEvent: () => [] } as any,
+            eventTimerManager: { addTimer: () => {}, removeTimer: () => {} } as any,
+        },
+    );
+
+const createFakeArea = (horse: any) => ({
+    spawned: [] as any[],
+    spawnMob(this: any) {
+        this.spawned.push(horse);
+        return horse;
+    },
+    despawn: () => {},
+});
+
+const createMonsterLike = (virtualId: number, healthPercentage: number) =>
+    ({
+        getVirtualId: () => virtualId,
+        getHealthPercentage: () => healthPercentage,
+        addTargetedBy: () => {},
+        removeTargetedBy: () => {},
+    }) as unknown as Character;
+
+describe('Player target health disclosure', () => {
+    describe('sendTargetUpdated', () => {
+        it('should report zero health for a player target', () => {
+            const viewer = createPlayer(1, 'Viewer');
+            const victim = createPlayer(2, 'Victim');
+            const { connection, targetPackets } = createConnection();
+            viewer.setConnection(connection);
+
+            victim.addPoint(PointsEnum.HEALTH, -Math.floor(victim.getPoint(PointsEnum.MAX_HEALTH) * 0.75));
+
+            // Guards against a vacuous assertion: the victim must really be on a
+            // non-zero, non-full bar, so that sending 0 can only come from the fix.
+            expect(victim.getHealthPercentage()).to.be.equal(25);
+
+            viewer.setTarget(victim);
+
+            expect(targetPackets).to.have.lengthOf(1);
+            expect(targetPackets[0].virtualId).to.be.equal(2);
+            expect(targetPackets[0].healthPercentage).to.be.equal(0);
+        });
+
+        it('should report the real health percentage for a non-player target', () => {
+            const viewer = createPlayer(1, 'Viewer');
+            const { connection, targetPackets } = createConnection();
+            viewer.setConnection(connection);
+
+            viewer.setTarget(createMonsterLike(77, 42));
+
+            expect(targetPackets).to.have.lengthOf(1);
+            expect(targetPackets[0].virtualId).to.be.equal(77);
+            expect(targetPackets[0].healthPercentage).to.be.equal(42);
+        });
+    });
+
+    describe('setTarget identity early-return', () => {
+        it('should not answer again when the target did not change', () => {
+            const viewer = createPlayer(1, 'Viewer');
+            const { connection, targetPackets } = createConnection();
+            viewer.setConnection(connection);
+
+            const monster = createMonsterLike(77, 42);
+            viewer.setTarget(monster);
+            viewer.setTarget(monster);
+            viewer.setTarget(monster);
+
+            expect(targetPackets).to.have.lengthOf(1);
+        });
+
+        it('should still answer when the target changes', () => {
+            const viewer = createPlayer(1, 'Viewer');
+            const { connection, targetPackets } = createConnection();
+            viewer.setConnection(connection);
+
+            viewer.setTarget(createMonsterLike(77, 42));
+            viewer.setTarget(createMonsterLike(88, 21));
+
+            expect(targetPackets).to.have.lengthOf(2);
+            expect(targetPackets[1].virtualId).to.be.equal(88);
+            expect(targetPackets[1].healthPercentage).to.be.equal(21);
+        });
+    });
+
+    describe('horse target health', () => {
+        it('should report a full bar for an NPC with no owning rider', () => {
+            expect(createHorseNpc(50).getHealthPercentage()).to.be.equal(100);
+        });
+
+        it('should report the rider horse health percentage', () => {
+            const horse = createHorseNpc(50);
+
+            horse.setHorseStats({ getHealth: () => 30, getMaxHealth: () => 200 });
+
+            expect(horse.getHealthPercentage()).to.be.equal(15);
+        });
+
+        it('should report a full bar when the rider horse has no maximum health', () => {
+            const horse = createHorseNpc(50);
+
+            horse.setHorseStats({ getHealth: () => 0, getMaxHealth: () => 0 });
+
+            expect(horse.getHealthPercentage()).to.be.equal(100);
+        });
+
+        it('should read the health of the horse it was summoned for', () => {
+            const owner = createPlayer(2, 'Rider', 11);
+            const horse = createHorseNpc(50);
+            owner.setArea(createFakeArea(horse) as any);
+            owner.setConnection(createConnection().connection);
+
+            const maxHealth = owner.getHorseMaxHealth();
+            owner.setHorseHealth(Math.floor(maxHealth / 2));
+
+            expect(owner.summonHorse()).to.be.equal(true);
+            expect(maxHealth).to.be.greaterThan(1);
+            expect(horse.getHealthPercentage()).to.be.equal(50);
+
+            owner.setHorseHealth(maxHealth);
+
+            expect(horse.getHealthPercentage()).to.be.equal(100);
+        });
+
+        it('should reach the client through the target packet', () => {
+            const viewer = createPlayer(1, 'Viewer');
+            const { connection, targetPackets } = createConnection();
+            viewer.setConnection(connection);
+
+            const horse = createHorseNpc(50);
+            horse.setHorseStats({ getHealth: () => 30, getMaxHealth: () => 200 });
+
+            viewer.setTarget(horse);
+
+            expect(targetPackets).to.have.lengthOf(1);
+            expect(targetPackets[0].virtualId).to.be.equal(50);
+            expect(targetPackets[0].healthPercentage).to.be.equal(15);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #119.

## What the bug is

`Player.sendTargetUpdated` sent `target.getHealthPercentage()` for every target type. `EntityManager` keeps one global `Map<number, GameEntity>` and `CharacterUpdateTargetService` validates neither distance nor map, so a 3-byte `TARGET` packet reads any online player's live HP from anywhere on the server. Sweeping the VID space yields a server-wide list of who is hurt and how badly.

`Player.setTarget` was also missing the identity early-return, so re-targeting the same VID produced a fresh reply every time. That makes the value pollable and leaves `TARGET` an unthrottled reply amplifier.

## What the original does

`CHARACTER::SetTarget` (`char.cpp:5071-5125`) is a three-way branch, and this restores all three:

| target | percentage sent | source |
|---|---|---|
| a PC | `0` | `char.cpp:5097` |
| one of the nine ridable horse races | the **rider's** horse HP, `100` with no rider or no maximum | `char.cpp:5101-5125` |
| anything else | the real percentage (unchanged) | `char.cpp:5124` |

plus `if (m_pkChrTarget == pkChrTarget) return;` at `char.cpp:5073`.

## The horse arm is a real bug, not just fidelity

A summoned horse is a real `NPC` in the world (`PlayerHorse.spawnHorseEntity` calls `area.spawnMob`), and `NPC.getHealthPercentage()` was a constant `100`. Targeting your own horse always showed a full bar however close to death it was. The horse entity now holds a reference to its rider's horse delegate and computes the percentage on demand, so it cannot go stale; the reference is dropped on despawn.

## Trade-off, and the alternative

The original's early-return sits in the single `SetTarget` shared by every character. Ours is split: `Character.setTarget` does the bookkeeping and the `Player` override sends the packet. I put the guard in the override, because that is where it reproduces the original's observable effect. For mobs `setTarget` sends nothing, so a guard there would change no behaviour. If you would rather mirror the original's shape exactly, moving it into `Character.setTarget` and comparing before calling `super` is a two-line flip.

I also considered pushing the horse's health onto the NPC whenever it changes, instead of reading it on demand. On-demand matches the original (which reads `owner->GetHorseHealth()` at send time) and cannot drift if a future caller forgets to sync.

## Verified

- 9 new specs in `PlayerTargetHealth.test.ts`. **Six fail on master**: three as behaviour proofs (a player's real 25% reaching the client, three replies instead of one, and a summoned horse reporting 100 instead of its rider's 50) and three because they exercise the new `setHorseStats` API. The other three pass either way as regression guards.
- 507 unit passing.
- Integration 25 passing, with only the 2 pre-existing #108 failures (untracked spec, unrelated to this change).
- `PlayerHorse.test.ts`'s fake horse gained `setHorseStats`. Without it the delegate's `try/catch` swallowed the `TypeError` and turned `summonHorse()` into a silent `false`.

## Note on scope

Pre-existing, and independent of my other open PRs. The distance/map gap this rides on is filed separately as #102 for `ON_CLICK`; this PR is about the payload being wrong however the target was reached, so the two do not overlap. The design question the issue originally ended on was withdrawn in a comment there, because the eu tree settles it.
