### PR TITLE
fix: enforce the dead state on restart and attack (fix #108)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -556,6 +556,7 @@ export default class Player extends Character {
             message: 'CloseRestartWindow',
         });
         this.connection?.setState(ConnectionStateEnum.GAME);
+        this.setPos(PositionEnum.STANDING);
 
         if (type === 'TOWN') {
             const position = this.area?.getStartPositionByEmpire(this.empire);
@@ -592,6 +593,8 @@ export default class Player extends Character {
             });
             return;
         }
+
+        if (this.isDead()) return;
 
         if (victim.isDead()) {
             this.setPos(PositionEnum.STANDING);

--- a/test/integration/game/deadStateLegalitySecurity.test.ts
+++ b/test/integration/game/deadStateLegalitySecurity.test.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for the dead-state legality gap. Dying sets PositionEnum.DEAD on the
+ * character and ConnectionStateEnum.DEAD on the connection, but nothing reads
+ * either one: `Player.restart` puts the character back in the world without
+ * clearing the dead position or restoring health, and `Player.attack` sets the
+ * attacker to FIGHTING before the damage runs, so a dead character revives itself
+ * by swinging at anything.
+ *
+ * Both cases are asserted on the live server-side entity rather than on packets,
+ * because the client is never told about either transition — that desync is part
+ * of what makes the gap invisible in play.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — dead state legality', function () {
+    this.timeout(60000);
+
+    const RESTARTER = 'restarter_test';
+    const SWINGER = 'swinger_test';
+    const DAMAGE_MESSAGE = 'your damage is';
+
+    let harness: AttackHarness;
+    let restarter: AttackSession;
+    let swinger: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await restarter?.close();
+        await swinger?.close();
+        await harness?.stop();
+    });
+
+    // Mobs reach the world through the area spawn queue, so it takes a few ticks
+    // before there is a live one to be killed by.
+    async function liveMonster() {
+        let monster = harness.findMonster();
+        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            monster = harness.findMonster();
+        }
+
+        expect(monster, 'setup: the world spawned a monster').to.not.equal(undefined);
+        expect(monster!.getPoint(PointsEnum.HEALTH), 'setup: the monster is alive').to.be.greaterThan(0);
+        return monster!;
+    }
+
+    it('brings the character back to life on /restart_here', async () => {
+        const monster = await liveMonster();
+
+        restarter = await harness.login({
+            username: RESTARTER,
+            x: monster.getPositionX(),
+            y: monster.getPositionY(),
+        });
+
+        const player = harness.findPlayer(RESTARTER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        player.takeDamage(monster, player.getPoint(PointsEnum.HEALTH) + 1);
+        expect(player.isDead(), 'setup: the character died').to.equal(true);
+
+        restarter.command('/restart_here');
+        await restarter.settle(800);
+
+        expect(player.isDead(), 'restart cleared the dead position').to.equal(false);
+        expect(player.getPoint(PointsEnum.HEALTH), 'restart left the character with usable health').to.be.greaterThan(
+            0,
+        );
+    });
+
+    it('ignores an attack sent while dead instead of reviving the attacker', async () => {
+        const monster = await liveMonster();
+
+        swinger = await harness.login({
+            username: SWINGER,
+            x: monster.getPositionX(),
+            y: monster.getPositionY(),
+        });
+
+        const player = harness.findPlayer(SWINGER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        // The damage line is debug output, so it has to be switched on or the
+        // assertion below would be vacuously false.
+        swinger.command('/debug');
+        await swinger.settle(400);
+
+        // Positive control: the same packet lands while alive, so a missing
+        // damage message after the death is the dead state rejecting it.
+        swinger.flush();
+        swinger.attack(monster.getVirtualId());
+        await swinger.settle(600);
+        expect(swinger.received().includes(DAMAGE_MESSAGE), 'setup: the attack lands while alive').to.equal(true);
+
+        player.takeDamage(monster, player.getPoint(PointsEnum.HEALTH) + 1);
+        expect(player.isDead(), 'setup: the character died').to.equal(true);
+
+        swinger.flush();
+        swinger.attack(monster.getVirtualId());
+        await swinger.settle(600);
+
+        expect(player.isDead(), 'the attack did not clear the dead position').to.equal(true);
+        expect(swinger.received().includes(DAMAGE_MESSAGE), 'no damage dealt while dead').to.equal(false);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import { PositionEnum } from '@/core/enum/PositionEnum';
+import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const config: any = {
+    empire: { red: { startPosX: 100, startPosY: 200 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (virtualId: number, name: string): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: virtualId,
+            appearance: 0,
+            slot: 0,
+            virtualId,
+            id: virtualId,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            name,
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createConnection = () =>
+    ({
+        send: () => {},
+        setState: () => {},
+    }) as any;
+
+const createKiller = (virtualId: number) =>
+    ({
+        getVirtualId: () => virtualId,
+        getName: () => 'Killer',
+        removeTargetedBy: () => {},
+        addTargetedBy: () => {},
+    }) as unknown as Character;
+
+// A live victim: attack() must reach neither the cooldown nor the battle
+// delegate while the attacker is dead, so only the isDead/getVirtualId surface
+// is exercised on the fixed path.
+const createVictim = (virtualId: number) =>
+    ({
+        isDead: () => false,
+        getVirtualId: () => virtualId,
+        getPositionX: () => 0,
+        getPositionY: () => 0,
+    }) as unknown as Monster;
+
+const kill = (player: Player) => {
+    player.die(createKiller(999));
+    expect(player.isDead(), 'setup: the character is dead').to.equal(true);
+};
+
+describe('Player dead state legality', () => {
+    describe('restart', () => {
+        it('should clear the dead position on /restart_here', () => {
+            const player = createPlayer(1, 'Restarter');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.restart('HERE');
+
+            expect(player.isDead()).to.equal(false);
+            expect(player.getPos()).to.equal(PositionEnum.STANDING);
+        });
+
+        it('should clear the dead position on /restart_town', () => {
+            const player = createPlayer(1, 'Restarter');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.restart('TOWN');
+
+            expect(player.isDead()).to.equal(false);
+            expect(player.getPos()).to.equal(PositionEnum.STANDING);
+        });
+    });
+
+    describe('attack', () => {
+        it('should ignore an attack sent while dead instead of reviving the attacker', () => {
+            const player = createPlayer(1, 'Swinger');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.attack(AttackTypeEnum.NORMAL, createVictim(77));
+
+            expect(player.isDead(), 'the attack did not revive the attacker').to.equal(true);
+            expect(player.getPos()).to.equal(PositionEnum.DEAD);
+        });
+
+        it('should still let a living character attack', () => {
+            const player = createPlayer(1, 'Swinger');
+            player.setConnection(createConnection());
+
+            expect(player.isDead()).to.equal(false);
+
+            player.attack(AttackTypeEnum.NORMAL, createVictim(77));
+
+            expect(player.getPos()).to.equal(PositionEnum.FIGHTING);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #108.

## What the bug is

Dying sets `PositionEnum.DEAD` on the character and `ConnectionStateEnum.DEAD` on the connection, and nothing reads either one.

**`/restart_here` never cleared the dead position.** `isDead()` stayed true after the restart, so health could not regenerate (`isRecoveryBlocked` consults `isDead`), monsters ignored the character (`Behavior.isAttackableVictim`), other players could not hit it, and `movingStateTick` stopped tracking its position while the client walked away. Only a relog recovered, and only because `pos` is not persisted.

**`Player.attack` never checked `this.isDead()`**, and set the attacker to `FIGHTING` before handing off to the battle delegate — which is what makes `takeDamage`'s existing dead-attacker guard unreachable from that path. Swinging at anything revived you, and that was the only way out of the state a restart left you in.

## What the original does

`do_restart` sets `POS_STANDING` before starting the recovery event (`cmd_general.cpp:538`), and `StartRecoveryEvent` returns early while `IsDead()` (`char.cpp:2520`) — so that order is load-bearing there too. The fix is two lines.

## Correcting my own issue

The issue says the restart "never restores health" and that you come back with 0 HP. **That is wrong, and I want it on the record before you read the diff.** The restart calls `area.spawn`, and `onSpawn` runs `init()` → `calcPointsAndResetValues()` → `resetHealth()`, so health is already restored — to the *full* bar, one tick later. I probed it on the live server before writing this: after `/restart_here`, `isDead=true` and `health=15950` of `15950`.

## What this PR deliberately does NOT do

The original restores **a flat 50 HP** (`cmd_general.cpp:641`), not a full bar. Getting there means not re-running `onSpawn` on restart, and that is the same structural problem as **#87** (restart is a free full heal, usable while alive) and **#123** (replaying a spawn rebuilds every quest and re-sends the welcome message). The original's equivalent, `RestartAtSamePos` (`char.cpp:768`), is a pure re-render — `EncodeRemovePacket` + `EncodeInsertPacket` — it does not re-initialise anything.

Doing that here would turn a two-line state fix into a spawn-path change, so it goes in its own PR against #87. Say the word if you would rather have them together.

## Verified

- The integration spec written when #108 was filed is **committed in this PR** and now passes. With it, the integration suite is **27 passing, 0 failing** — the same suite had 2 standing failures before, and they were this bug.
- 4 new unit specs. Three fail on master by assertion (both restart flavours and the dead attack); the fourth is a regression guard that a living character can still attack.
- 502 unit passing.

## Note on scope

Pre-existing, and independent of my other open PRs. `DeathPenalty` is untouched — it is still the `//TODO: death penalty` in `die()`, and the original applies it as `DeathPenalty(0)` for `restart_here` and `DeathPenalty(1)` for `restart_town` when you want to pick that up.
