### PR TITLE
fix: require death before a restart command runs (fix #87)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -555,6 +555,8 @@ export default class Player extends Character {
             messageType: ChatMessageTypeEnum.COMMAND,
             message: 'CloseRestartWindow',
         });
+        if (!this.isDead()) return;
+
         this.connection?.setState(ConnectionStateEnum.GAME);
 
         if (type === 'TOWN') {

--- a/test/integration/game/restartWhileAliveSecurity.test.ts
+++ b/test/integration/game/restartWhileAliveSecurity.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for the restart-while-alive gap (#87). Neither restart command
+ * checked that the character was dead, and the restart path re-spawns the
+ * entity — which re-runs the full point recalculation and resets health and
+ * mana. A living character could therefore heal to full on demand.
+ *
+ * Asserted on the live server-side entity rather than on packets: the heal is
+ * a server-state change, and the client is only told about it afterwards.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — restart requires death', function () {
+    this.timeout(60000);
+
+    const HEALER = 'healer_test';
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    it('does not heal a living character on /restart_here', async () => {
+        session = await harness.login({ username: HEALER });
+
+        const player = harness.findPlayer(HEALER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        const maxHealth = player.getPoint(PointsEnum.MAX_HEALTH);
+        player.addPoint(PointsEnum.HEALTH, -Math.floor(maxHealth * 0.9));
+
+        const wounded = player.getPoint(PointsEnum.HEALTH);
+        expect(wounded, 'setup: the character is wounded').to.be.lessThan(Math.floor(maxHealth / 2));
+        expect(player.isDead(), 'setup: the character is alive').to.equal(false);
+
+        session.command('/restart_here');
+        await session.settle(800);
+
+        // Regeneration ticks every 3s and would only add a small amount, so a
+        // jump back to the full bar can only come from the respawn path.
+        expect(player.getPoint(PointsEnum.HEALTH), 'the restart did not refill the bar').to.be.lessThan(
+            Math.floor(maxHealth / 2),
+        );
+    });
+
+    it('does not warp a living character on /restart_town', async () => {
+        const player = harness.findPlayer(HEALER);
+
+        const x = player.getPositionX();
+        const y = player.getPositionY();
+
+        session.command('/restart_town');
+        await session.settle(800);
+
+        expect(player.getPositionX(), 'the character stayed put').to.equal(x);
+        expect(player.getPositionY(), 'the character stayed put').to.equal(y);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerRestartLegality.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerRestartLegality.test.ts
@@ -1,0 +1,182 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const START_X = 100;
+const START_Y = 200;
+
+const config: any = {
+    empire: { red: { startPosX: START_X, startPosY: START_Y } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 0,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            positionX: 50_000,
+            positionY: 60_000,
+            name: 'Restarter',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createConnection = () => {
+    const commands: string[] = [];
+    const states: number[] = [];
+    return {
+        commands,
+        states,
+        connection: {
+            send: (packet: any) => {
+                const message = (packet as any).message;
+                if (typeof message === 'string') commands.push(message);
+            },
+            setState: (state: number) => states.push(state),
+        } as any,
+    };
+};
+
+const createArea = () => {
+    const spawned: any[] = [];
+    return {
+        spawned,
+        spawn: (entity: any) => spawned.push(entity),
+        getStartPositionByEmpire: () => ({ x: START_X, y: START_Y }),
+    };
+};
+
+const createKiller = () =>
+    ({
+        getVirtualId: () => 999,
+        getName: () => 'Killer',
+        removeTargetedBy: () => {},
+        addTargetedBy: () => {},
+    }) as unknown as Character;
+
+describe('Player restart legality', () => {
+    describe('while alive', () => {
+        it('should refuse /restart_town instead of warping the character', () => {
+            const player = createPlayer();
+            const area = createArea();
+            const { connection, states } = createConnection();
+            player.setConnection(connection);
+            player.setArea(area as any);
+
+            expect(player.isDead()).to.equal(false);
+
+            player.restart('TOWN');
+
+            expect(player.getPositionX(), 'the character did not warp').to.equal(50_000);
+            expect(player.getPositionY(), 'the character did not warp').to.equal(60_000);
+            expect(area.spawned, 'no respawn was queued').to.have.lengthOf(0);
+            expect(states, 'the connection state was left alone').to.have.lengthOf(0);
+        });
+
+        it('should refuse /restart_here instead of respawning the character', () => {
+            const player = createPlayer();
+            const area = createArea();
+            const { connection } = createConnection();
+            player.setConnection(connection);
+            player.setArea(area as any);
+
+            player.restart('HERE');
+
+            expect(area.spawned).to.have.lengthOf(0);
+        });
+
+        it('should still close the restart window, like the original does', () => {
+            const player = createPlayer();
+            const { connection, commands } = createConnection();
+            player.setConnection(connection);
+            player.setArea(createArea() as any);
+
+            player.restart('HERE');
+
+            expect(commands).to.include('CloseRestartWindow');
+        });
+    });
+
+    describe('while dead', () => {
+        it('should still warp on /restart_town', () => {
+            const player = createPlayer();
+            const area = createArea();
+            const { connection } = createConnection();
+            player.setConnection(connection);
+            player.setArea(area as any);
+            player.die(createKiller());
+
+            player.restart('TOWN');
+
+            expect(player.getPositionX()).to.equal(START_X);
+            expect(player.getPositionY()).to.equal(START_Y);
+            expect(area.spawned).to.have.lengthOf(1);
+        });
+
+        it('should still respawn on /restart_here', () => {
+            const player = createPlayer();
+            const area = createArea();
+            const { connection } = createConnection();
+            player.setConnection(connection);
+            player.setArea(area as any);
+            player.die(createKiller());
+
+            player.restart('HERE');
+
+            expect(area.spawned).to.have.lengthOf(1);
+        });
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerRestartLegality.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerRestartLegality.test.ts
@@ -90,11 +90,15 @@ const createConnection = () => {
     };
 };
 
+// Deliberately covers both shapes a restart may take: queueing a respawn, or
+// re-announcing the character and warping through the movement path. These
+// specs are about the death guard, so they must not pin either one.
 const createArea = () => {
     const spawned: any[] = [];
     return {
         spawned,
         spawn: (entity: any) => spawned.push(entity),
+        onCharacterMove: () => {},
         getStartPositionByEmpire: () => ({ x: START_X, y: START_Y }),
     };
 };
@@ -153,30 +157,31 @@ describe('Player restart legality', () => {
     describe('while dead', () => {
         it('should still warp on /restart_town', () => {
             const player = createPlayer();
-            const area = createArea();
-            const { connection } = createConnection();
+            const { connection, states } = createConnection();
             player.setConnection(connection);
-            player.setArea(area as any);
+            player.setArea(createArea() as any);
             player.die(createKiller());
 
             player.restart('TOWN');
 
             expect(player.getPositionX()).to.equal(START_X);
             expect(player.getPositionY()).to.equal(START_Y);
-            expect(area.spawned).to.have.lengthOf(1);
+            expect(states, 'the restart ran to completion').to.not.have.lengthOf(0);
         });
 
-        it('should still respawn on /restart_here', () => {
+        it('should still restart in place on /restart_here', () => {
             const player = createPlayer();
-            const area = createArea();
-            const { connection } = createConnection();
+            const { connection, states } = createConnection();
             player.setConnection(connection);
-            player.setArea(area as any);
+            player.setArea(createArea() as any);
             player.die(createKiller());
 
             player.restart('HERE');
 
-            expect(area.spawned).to.have.lengthOf(1);
+            // Asserted through the connection state rather than a queued
+            // respawn: whether a restart re-spawns or re-announces the
+            // character is not what this guard is about.
+            expect(states, 'the restart ran to completion').to.not.have.lengthOf(0);
         });
     });
 });


### PR DESCRIPTION
Fixes #87.

## What the bug is

Neither restart command checked that the character was dead. `Player.restart` ends in `area.spawn`, and the queued respawn re-runs `onSpawn` → `init()` → `calcPointsAndResetValues()` → `resetHealth()` + `resetMana()`. A living character could refill both bars on demand, at no cost, as often as the chat rate limit allowed.

The same unguarded path gave two more effects:

- **Escape.** `/restart_town` writes the empire start position straight through `setPositionX/Y`, so it warps without going through `teleport()` and skips its private-shop block.
- **Invisibility.** The respawn re-applies the 3s `REVIVE_INVISIBLE` affect, refreshable faster than it expires.

As the issue notes, the public C4US multihack ships an "Auto Revive" toggle that sends this on a 1s timer with an HP trigger, which turns all three into a passive combat advantage.

## What the original does

It refuses the whole thing up front (`cmd_general.cpp:477-482`):

```cpp
if (false == ch->IsDead())
{
    ch->ChatPacket(CHAT_TYPE_COMMAND, "CloseRestartWindow");
    ch->StartRecoveryEvent();
    return;
}
```

Ours already sends `CloseRestartWindow` as its first statement, so the guard goes directly after it and reproduces that branch exactly — the window still closes for a living character, and nothing else happens. `StartRecoveryEvent` has no equivalent to call, because our recovery is a timer that already runs.

The diff in `src` is two lines.

## Placement

In `Player.restart` rather than in the two command handlers, so it covers both commands and any future caller. The issue offered both placements and recommended this one, since the invariant belongs to the state transition rather than to the chat command. Happy to move it if you prefer the entity free of it.

## Deliberately left alone

`restart('TOWN')` still moves the character without going through `teleport()`, so it does not reset the anti-teleport anchors (`lastReportedPosition`, `recentMoves`). That path is now unreachable while alive, and routing it through `teleport()` is not possible on master anyway — `canTeleport()` falls through to `undefined` (#88, fixed in open PR #113). Worth doing once that lands.

## Relationship to my other open PRs

Independent of #130 (#108, the dead state), even though both touch `Player.restart`: I verified locally with `git merge-tree` that they merge cleanly in either order.

One follow-up is genuinely sequenced behind #130. The original gives a restart **a flat 50 HP** (`cmd_general.cpp:641`), not a full bar, and reaching that means not re-running `onSpawn` — the original's `RestartAtSamePos` (`char.cpp:768`) is a pure re-render, `EncodeRemovePacket` + `EncodeInsertPacket`, that re-initialises nothing. That only makes sense once a restart actually revives you, which is #130, so it comes after it as its own PR.

## Verified

- **5 new unit specs**, 2 failing on master by assertion (a living character warps to the empire start; a respawn is queued). The other 3 are regression guards: the dead path still warps and still respawns, and the restart window still closes while alive.
- **2 new integration specs** driving the real server, both failing on master: `/restart_here` refills a wounded character's bar, and `/restart_town` moves it.
- 503 unit passing; integration **27 passing, 0 failing**.

## Note on scope

Pre-existing, found while mapping the public C4US client hack against our handlers.
