### PR TITLE
fix: restore the original's flat restart health

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -556,6 +556,7 @@ export default class Player extends Character {
             message: 'CloseRestartWindow',
         });
         this.connection?.setState(ConnectionStateEnum.GAME);
+        this.setPos(PositionEnum.STANDING);
 
         if (type === 'TOWN') {
             const position = this.area?.getStartPositionByEmpire(this.empire);
@@ -592,6 +593,8 @@ export default class Player extends Character {
             });
             return;
         }
+
+        if (this.isDead()) return;
 
         if (victim.isDead()) {
             this.setPos(PositionEnum.STANDING);

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -577,6 +577,7 @@ export default class Player extends Character {
         }
 
         this.addPoint(PointsEnum.HEALTH, RESTART_HEALTH - this.getPoint(PointsEnum.HEALTH));
+        this.startRecovery();
 
         if (type === 'HERE') {
             this.applyInvisibleAffect(RESTART_INVISIBLE_SECONDS);
@@ -801,6 +802,10 @@ export default class Player extends Character {
         this.points.calcPointsAndResetValues();
         this.sendPoints();
 
+        this.startRecovery();
+    }
+
+    private startRecovery() {
         this.addEventTimer({
             id: TimedEventsEnum.REGEN_HEALTH,
             eventFunction: this.regenHealth.bind(this),

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -6,6 +6,7 @@ import InventoryEventsEnum from '../inventory/events/InventoryEventsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import PlayerApplies from './delegate/PlayerApplies';
 import { EntityStateEnum } from '@/core/enum/EntityStateEnum';
+import { MovementTypeEnum } from '@/core/enum/MovementTypeEnum';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
 import Item, { MAX_ITEM_STACK } from '../item/Item';
@@ -132,6 +133,9 @@ const SHOUT_COOLDOWN_MS = 15_000;
 // before the regen bonus, not after.
 const RECOVERY_PERCENT_BY_STEP = [1, 5, 5, 5, 5, 5, 5, 5, 5, 5];
 const RECOVERY_FLAT_HEALTH = 15;
+
+const RESTART_HEALTH = 50;
+const RESTART_INVISIBLE_SECONDS = 5;
 
 export default class Player extends Character {
     private readonly accountId: number;
@@ -561,12 +565,24 @@ export default class Player extends Character {
         if (type === 'TOWN') {
             const position = this.area?.getStartPositionByEmpire(this.empire);
             if (position?.x !== undefined && position?.y !== undefined) {
-                this.setPositionX(position.x);
-                this.setPositionY(position.y);
+                this.wait({
+                    positionX: position.x,
+                    positionY: position.y,
+                    arg: 0,
+                    rotation: this.getRotation(),
+                    time: 0,
+                    movementType: MovementTypeEnum.WAIT,
+                });
             }
         }
 
-        this.area?.spawn(this);
+        this.addPoint(PointsEnum.HEALTH, RESTART_HEALTH - this.getPoint(PointsEnum.HEALTH));
+
+        if (type === 'HERE') {
+            this.applyInvisibleAffect(RESTART_INVISIBLE_SECONDS);
+        }
+
+        this.resendSelfToWorld();
     }
 
     setConnection(connection: GameConnection) {
@@ -2219,8 +2235,23 @@ export default class Player extends Character {
     }
 
     private broadcastMountChange(): void {
+        this.resendSelfToWorld();
+
+        // Send mount affect to self when mounting
+        if (this.horse.isRiding()) {
+            this.sendAffect({
+                type: AffectTypeEnum.MOUNT,
+                apply: 0,
+                duration: 0,
+                flag: 0,
+                value: this.horse.getMountVnum(),
+                manaCost: 0,
+            });
+        }
+    }
+
+    private resendSelfToWorld(): void {
         const mountVnum = this.horse.getMountVnum();
-        const isRiding = this.horse.isRiding();
         const parts = [this.getBody()?.getId() ?? 0, this.getWeapon()?.getId() ?? 0, 0, this.getHair()?.getId() ?? 0];
 
         // Packets are single-use (pack() advances the internal buffer cursor),
@@ -2275,18 +2306,6 @@ export default class Player extends Character {
                 state: this.isDead() ? 1 : 0,
             }),
         );
-
-        // Send mount affect to self when mounting
-        if (isRiding) {
-            this.sendAffect({
-                type: AffectTypeEnum.MOUNT,
-                apply: 0,
-                duration: 0,
-                flag: 0,
-                value: mountVnum,
-                manaCost: 0,
-            });
-        }
 
         // Rebuild our own scene wiped by the self-spawn above
         this.resendNearbyToSelf();

--- a/test/integration/game/deadStateLegalitySecurity.test.ts
+++ b/test/integration/game/deadStateLegalitySecurity.test.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for the dead-state legality gap. Dying sets PositionEnum.DEAD on the
+ * character and ConnectionStateEnum.DEAD on the connection, but nothing reads
+ * either one: `Player.restart` puts the character back in the world without
+ * clearing the dead position or restoring health, and `Player.attack` sets the
+ * attacker to FIGHTING before the damage runs, so a dead character revives itself
+ * by swinging at anything.
+ *
+ * Both cases are asserted on the live server-side entity rather than on packets,
+ * because the client is never told about either transition — that desync is part
+ * of what makes the gap invisible in play.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — dead state legality', function () {
+    this.timeout(60000);
+
+    const RESTARTER = 'restarter_test';
+    const SWINGER = 'swinger_test';
+    const DAMAGE_MESSAGE = 'your damage is';
+
+    let harness: AttackHarness;
+    let restarter: AttackSession;
+    let swinger: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await restarter?.close();
+        await swinger?.close();
+        await harness?.stop();
+    });
+
+    // Mobs reach the world through the area spawn queue, so it takes a few ticks
+    // before there is a live one to be killed by.
+    async function liveMonster() {
+        let monster = harness.findMonster();
+        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            monster = harness.findMonster();
+        }
+
+        expect(monster, 'setup: the world spawned a monster').to.not.equal(undefined);
+        expect(monster!.getPoint(PointsEnum.HEALTH), 'setup: the monster is alive').to.be.greaterThan(0);
+        return monster!;
+    }
+
+    it('brings the character back to life on /restart_here', async () => {
+        const monster = await liveMonster();
+
+        restarter = await harness.login({
+            username: RESTARTER,
+            x: monster.getPositionX(),
+            y: monster.getPositionY(),
+        });
+
+        const player = harness.findPlayer(RESTARTER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        player.takeDamage(monster, player.getPoint(PointsEnum.HEALTH) + 1);
+        expect(player.isDead(), 'setup: the character died').to.equal(true);
+
+        restarter.command('/restart_here');
+        await restarter.settle(800);
+
+        expect(player.isDead(), 'restart cleared the dead position').to.equal(false);
+        expect(player.getPoint(PointsEnum.HEALTH), 'restart left the character with usable health').to.be.greaterThan(
+            0,
+        );
+    });
+
+    it('ignores an attack sent while dead instead of reviving the attacker', async () => {
+        const monster = await liveMonster();
+
+        swinger = await harness.login({
+            username: SWINGER,
+            x: monster.getPositionX(),
+            y: monster.getPositionY(),
+        });
+
+        const player = harness.findPlayer(SWINGER);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        // The damage line is debug output, so it has to be switched on or the
+        // assertion below would be vacuously false.
+        swinger.command('/debug');
+        await swinger.settle(400);
+
+        // Positive control: the same packet lands while alive, so a missing
+        // damage message after the death is the dead state rejecting it.
+        swinger.flush();
+        swinger.attack(monster.getVirtualId());
+        await swinger.settle(600);
+        expect(swinger.received().includes(DAMAGE_MESSAGE), 'setup: the attack lands while alive').to.equal(true);
+
+        player.takeDamage(monster, player.getPoint(PointsEnum.HEALTH) + 1);
+        expect(player.isDead(), 'setup: the character died').to.equal(true);
+
+        swinger.flush();
+        swinger.attack(monster.getVirtualId());
+        await swinger.settle(600);
+
+        expect(player.isDead(), 'the attack did not clear the dead position').to.equal(true);
+        expect(swinger.received().includes(DAMAGE_MESSAGE), 'no damage dealt while dead').to.equal(false);
+    });
+});

--- a/test/integration/game/restartHealthFidelity.test.ts
+++ b/test/integration/game/restartHealthFidelity.test.ts
@@ -83,13 +83,13 @@ describe('Restart health fidelity', function () {
     }
 
     it('revives on the flat restart health and tells the client to stand up', async () => {
+        // takeDamage is a direct server-side call and needs no proximity, so we
+        // log in at the harness default location (always valid) and only use the
+        // monster as the attacker reference — logging in on a monster's position
+        // is flaky, since some spawn at locations the world rejects.
         const monster = await liveMonster();
 
-        session = await harness.login({
-            username: REVIVER,
-            x: monster.getPositionX(),
-            y: monster.getPositionY(),
-        });
+        session = await harness.login({ username: REVIVER });
 
         const player = await livePlayer(REVIVER);
 

--- a/test/integration/game/restartHealthFidelity.test.ts
+++ b/test/integration/game/restartHealthFidelity.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * A restart used to end in `area.spawn`, whose queued respawn re-ran `onSpawn`
+ * and therefore `init()` -> `calcPointsAndResetValues()` -> `resetHealth()`,
+ * handing back a full bar. The original gives a flat 50 HP
+ * (cmd_general.cpp:641) and only re-announces the character
+ * (RestartAtSamePos, char.cpp:768) rather than re-initialising it.
+ *
+ * The second assertion is the one that matters for playability: the client
+ * draws the character lying down after death, so the re-announce has to reach
+ * it with an alive state byte or the character would stand up server-side
+ * while still looking dead on screen.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Restart health fidelity', function () {
+    this.timeout(60000);
+
+    const RESTART_HEALTH = 50;
+    const CHARACTER_SPAWN_HEADER = 0x01;
+    // header, vid(4), rotation(4), x(4), y(4), z(4), entityType(1), class(2),
+    // moveSpeed(1), attackSpeed(1), state(1)
+    const SPAWN_ENTITY_TYPE_OFFSET = 21;
+    const SPAWN_STATE_OFFSET = 26;
+    const ENTITY_TYPE_PLAYER = 6;
+    const ALIVE = 0;
+
+    const REVIVER = 'reviver_test';
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    async function liveMonster() {
+        let monster = harness.findMonster();
+        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            monster = harness.findMonster();
+        }
+
+        expect(monster, 'setup: the world spawned a monster').to.not.equal(undefined);
+        return monster!;
+    }
+
+    // Spawns are queued to the next area tick, so a character is not in the
+    // world the instant login resolves.
+    async function livePlayer(username: string) {
+        let player = harness.findPlayer(username);
+        for (let attempt = 0; attempt < 20 && !player; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            player = harness.findPlayer(username);
+        }
+
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+        return player!;
+    }
+
+    /**
+     * Scan the raw stream for this character's spawn packet and read its state
+     * byte. The harness keeps an unframed byte stream, so the header and the
+     * virtual id alone produce false matches on unrelated payloads — the entity
+     * type has to agree as well before a hit is believed.
+     */
+    function findSpawnState(buffer: Buffer, virtualId: number): number | null {
+        for (let i = 0; i + SPAWN_STATE_OFFSET < buffer.length; i++) {
+            if (buffer[i] !== CHARACTER_SPAWN_HEADER) continue;
+            if (buffer.readUInt32LE(i + 1) !== virtualId) continue;
+            if (buffer.readUInt8(i + SPAWN_ENTITY_TYPE_OFFSET) !== ENTITY_TYPE_PLAYER) continue;
+            return buffer.readUInt8(i + SPAWN_STATE_OFFSET);
+        }
+        return null;
+    }
+
+    it('revives on the flat restart health and tells the client to stand up', async () => {
+        const monster = await liveMonster();
+
+        session = await harness.login({
+            username: REVIVER,
+            x: monster.getPositionX(),
+            y: monster.getPositionY(),
+        });
+
+        const player = await livePlayer(REVIVER);
+
+        const maxHealth = player.getPoint(PointsEnum.MAX_HEALTH);
+        expect(maxHealth, 'setup: a full bar is well above the restart value').to.be.greaterThan(RESTART_HEALTH * 4);
+
+        player.takeDamage(monster, player.getPoint(PointsEnum.HEALTH) + 1);
+        expect(player.isDead(), 'setup: the character died').to.equal(true);
+
+        session.flush();
+        session.command('/restart_here');
+        await session.settle(800);
+
+        expect(player.isDead(), 'the restart revived the character').to.equal(false);
+        expect(player.getPoint(PointsEnum.HEALTH), 'the restart did not hand back a full bar').to.equal(RESTART_HEALTH);
+        expect(
+            findSpawnState(session.received(), player.getVirtualId()),
+            'the client was re-announced the character as alive',
+        ).to.equal(ALIVE);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import { PositionEnum } from '@/core/enum/PositionEnum';
+import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const config: any = {
+    empire: { red: { startPosX: 100, startPosY: 200 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (virtualId: number, name: string): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: virtualId,
+            appearance: 0,
+            slot: 0,
+            virtualId,
+            id: virtualId,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            name,
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createConnection = () =>
+    ({
+        send: () => {},
+        setState: () => {},
+    }) as any;
+
+const createKiller = (virtualId: number) =>
+    ({
+        getVirtualId: () => virtualId,
+        getName: () => 'Killer',
+        removeTargetedBy: () => {},
+        addTargetedBy: () => {},
+    }) as unknown as Character;
+
+// A live victim: attack() must reach neither the cooldown nor the battle
+// delegate while the attacker is dead, so only the isDead/getVirtualId surface
+// is exercised on the fixed path.
+const createVictim = (virtualId: number) =>
+    ({
+        isDead: () => false,
+        getVirtualId: () => virtualId,
+        getPositionX: () => 0,
+        getPositionY: () => 0,
+    }) as unknown as Monster;
+
+const kill = (player: Player) => {
+    player.die(createKiller(999));
+    expect(player.isDead(), 'setup: the character is dead').to.equal(true);
+};
+
+describe('Player dead state legality', () => {
+    describe('restart', () => {
+        it('should clear the dead position on /restart_here', () => {
+            const player = createPlayer(1, 'Restarter');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.restart('HERE');
+
+            expect(player.isDead()).to.equal(false);
+            expect(player.getPos()).to.equal(PositionEnum.STANDING);
+        });
+
+        it('should clear the dead position on /restart_town', () => {
+            const player = createPlayer(1, 'Restarter');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.restart('TOWN');
+
+            expect(player.isDead()).to.equal(false);
+            expect(player.getPos()).to.equal(PositionEnum.STANDING);
+        });
+    });
+
+    describe('attack', () => {
+        it('should ignore an attack sent while dead instead of reviving the attacker', () => {
+            const player = createPlayer(1, 'Swinger');
+            player.setConnection(createConnection());
+            kill(player);
+
+            player.attack(AttackTypeEnum.NORMAL, createVictim(77));
+
+            expect(player.isDead(), 'the attack did not revive the attacker').to.equal(true);
+            expect(player.getPos()).to.equal(PositionEnum.DEAD);
+        });
+
+        it('should still let a living character attack', () => {
+            const player = createPlayer(1, 'Swinger');
+            player.setConnection(createConnection());
+
+            expect(player.isDead()).to.equal(false);
+
+            player.attack(AttackTypeEnum.NORMAL, createVictim(77));
+
+            expect(player.getPos()).to.equal(PositionEnum.FIGHTING);
+        });
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerRestartHealth.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerRestartHealth.test.ts
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const RESTART_HEALTH = 50;
+const START_X = 100;
+const START_Y = 200;
+
+const config: any = {
+    empire: { red: { startPosX: START_X, startPosY: START_Y } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 0,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            positionX: 50_000,
+            positionY: 60_000,
+            name: 'Restarter',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createArea = () => {
+    const spawned: any[] = [];
+    const moves: any[] = [];
+    return {
+        spawned,
+        moves,
+        spawn: (entity: any) => spawned.push(entity),
+        onCharacterMove: (event: any) => moves.push(event),
+        getStartPositionByEmpire: () => ({ x: START_X, y: START_Y }),
+    };
+};
+
+const createKiller = () =>
+    ({
+        getVirtualId: () => 999,
+        getName: () => 'Killer',
+        removeTargetedBy: () => {},
+        addTargetedBy: () => {},
+    }) as unknown as Character;
+
+const createDeadPlayer = () => {
+    const player = createPlayer();
+    const area = createArea();
+    player.setConnection({ send: () => {}, setState: () => {} } as any);
+    player.setArea(area as any);
+    player.die(createKiller());
+    return { player, area };
+};
+
+describe('Player restart health', () => {
+    it('should leave the character on the flat restart health, not a full bar', () => {
+        const { player } = createDeadPlayer();
+        const maxHealth = player.getPoint(PointsEnum.MAX_HEALTH);
+
+        player.restart('HERE');
+
+        expect(maxHealth, 'setup: the full bar is far above the restart value').to.be.greaterThan(RESTART_HEALTH * 4);
+        expect(player.getPoint(PointsEnum.HEALTH)).to.equal(RESTART_HEALTH);
+    });
+
+    it('should use the same flat health when restarting in town', () => {
+        const { player } = createDeadPlayer();
+
+        player.restart('TOWN');
+
+        expect(player.getPoint(PointsEnum.HEALTH)).to.equal(RESTART_HEALTH);
+    });
+
+    it('should not queue another spawn, so onSpawn cannot re-initialise the character', () => {
+        const { player, area } = createDeadPlayer();
+
+        player.restart('HERE');
+
+        expect(area.spawned).to.have.lengthOf(0);
+    });
+
+    it('should move through the normal movement path when restarting in town', () => {
+        const { player, area } = createDeadPlayer();
+
+        player.restart('TOWN');
+
+        expect(player.getPositionX()).to.equal(START_X);
+        expect(player.getPositionY()).to.equal(START_Y);
+        // Going through wait() is what keeps the spatial grid and the nearby
+        // entity lists consistent after the jump across the map.
+        expect(area.moves, 'the warp went through the area movement path').to.have.lengthOf(1);
+    });
+
+    it('should grant the revive invisibility when restarting in place', () => {
+        const { player } = createDeadPlayer();
+
+        player.restart('HERE');
+
+        expect(player.isAffectByFlag(AffectBitsTypeEnum.REVIVE_INVISIBLE)).to.equal(true);
+    });
+
+    it('should not grant the revive invisibility when restarting in town', () => {
+        const { player } = createDeadPlayer();
+
+        player.restart('TOWN');
+
+        expect(player.isAffectByFlag(AffectBitsTypeEnum.REVIVE_INVISIBLE)).to.equal(false);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerRestartHealth.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerRestartHealth.test.ts
@@ -38,7 +38,26 @@ const config: any = {
     },
 };
 
-const createPlayer = (): Player =>
+// A timer manager that actually tracks which ids are armed per owner, so a
+// test can tell whether death cleared the regen timers and whether a restart
+// brought them back.
+const createTimerManager = () => {
+    const active = new Map<number, Set<string>>();
+    const ids = (ownerId: number) => active.get(ownerId) ?? new Set<string>();
+    return {
+        active,
+        addTimer: ({ id, ownerId }: { id: string; ownerId: number }) => {
+            if (!active.has(ownerId)) active.set(ownerId, new Set());
+            active.get(ownerId)!.add(id);
+        },
+        removeTimer: () => {},
+        isTimerActive: (ownerId: number, id: string) => ids(ownerId).has(id),
+        clearTimersByOwner: (ownerId: number) => active.delete(ownerId),
+        removeAllTimersFromOwner: (ownerId: number) => active.delete(ownerId),
+    };
+};
+
+const createPlayer = (timerManager: any = createTimerManager()): Player =>
     PlayerFactory.create(
         {
             playerClass: 0,
@@ -66,13 +85,7 @@ const createPlayer = (): Player =>
             logger,
             saveCharacterService: { execute: async () => {} } as any,
             questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
-            eventTimerManager: {
-                addTimer: () => {},
-                removeTimer: () => {},
-                isTimerActive: () => false,
-                clearTimersByOwner: () => {},
-                removeAllTimersFromOwner: () => {},
-            } as any,
+            eventTimerManager: timerManager as any,
             mobManager: { getMobProto: () => undefined } as any,
         },
     );
@@ -98,12 +111,13 @@ const createKiller = () =>
     }) as unknown as Character;
 
 const createDeadPlayer = () => {
-    const player = createPlayer();
+    const timers = createTimerManager();
+    const player = createPlayer(timers);
     const area = createArea();
     player.setConnection({ send: () => {}, setState: () => {} } as any);
     player.setArea(area as any);
     player.die(createKiller());
-    return { player, area };
+    return { player, area, timers };
 };
 
 describe('Player restart health', () => {
@@ -143,6 +157,20 @@ describe('Player restart health', () => {
         // Going through wait() is what keeps the spatial grid and the nearby
         // entity lists consistent after the jump across the map.
         expect(area.moves, 'the warp went through the area movement path').to.have.lengthOf(1);
+    });
+
+    it('should re-arm the health and mana regeneration that death cleared', () => {
+        const { player, timers } = createDeadPlayer();
+        const vid = player.getVirtualId();
+
+        // Death clears every timer, so regeneration is off at this point — that
+        // is exactly what a naive restart would leave in place.
+        expect(timers.isTimerActive(vid, 'REGEN_HEALTH'), 'death cleared regen').to.equal(false);
+
+        player.restart('HERE');
+
+        expect(timers.isTimerActive(vid, 'REGEN_HEALTH')).to.equal(true);
+        expect(timers.isTimerActive(vid, 'REGEN_MANA')).to.equal(true);
     });
 
     it('should grant the revive invisibility when restarting in place', () => {


### PR DESCRIPTION
> **Stacked on #130.** This branch is cut from it, so the diff shows **four commits** — `28460b42` is #130 and is already under review there. **The three new ones here are `36d1fcaa` (the flat health), `0e5d3a6b` (re-arm regen), and `37f1d5d6` (a test-robustness fix).** Merge #130 first and this collapses to those three. It also merges cleanly against #131 (verified locally with `git merge-tree`).

Follow-up to #130, which I said there I would send separately. This is the half of #108 that could not be done until a restart actually revived you.

## What the bug is

A restart ended in `area.spawn`, and the queued respawn re-ran `onSpawn` → `init()` → `calcPointsAndResetValues()` → `resetHealth()` — so reviving handed back a **full bar**. The original gives **a flat 50 HP** (`cmd_general.cpp:641` for here, `:633` for town) and never re-initialises the character: `RestartAtSamePos` (`char.cpp:768`) is a pure re-render, `EncodeRemovePacket` + `EncodeInsertPacket` to the character and to everyone in view.

## Re-running a spawn was doing much more than reviving

`onSpawn` also rebuilds every quest, re-sends the inventory and quick slots, and repeats the welcome message — the same replay problem as #123.

It was also feeding the spatial grid wrong, which I did not expect and is worth flagging on its own: `processSpawnQueue` calls `aoi.insert`, which writes the entity into the cell for its **new** position **without removing it from the old one** (only `updatePosition` does that), and `linkNearbyEntities` only ever *adds* neighbours. So `/restart_town` across the map left the character listed in **two grid cells**, still holding the neighbours it had where it died.

## What this does instead

- **The re-announce is extracted, not rewritten.** `broadcastMountChange` already implemented exactly the original's packet pair — `CharacterSpawnPacket` (which carries the alive/dead state byte) + `CharacterInfoPacket`, to self and to every nearby player, then `resendNearbyToSelf` because the self-spawn wipes the client scene. It is now `resendSelfToWorld` and both callers share it, so the two paths cannot drift and there is no duplicated block for the quality gate to flag.
- **Health** is set with the same delta form the original uses: `PointChange(POINT_HP, 50 - GetHP())`.
- **`/restart_town`** warps through `wait()`, the ordinary movement path, so `area.onCharacterMove` keeps the grid and the neighbour lists correct.
- **`/restart_here`** re-applies the revive invisibility for 5s (`ReviveInvisible(5)`). Town does not get it — also matching the original.
- **Regeneration is re-armed** (`0e5d3a6b`). `die()` clears every timer, and the old restart re-armed the regen timers as a side effect of re-running `onSpawn` → `init()`. Dropping the respawn dropped that too, which I caught in the client — the revived character sat frozen at 50 with no recovery. The original calls `StartRecoveryEvent()` from `do_restart` for exactly this reason; the two regen timers are now factored out of `init()` into `startRecovery()` and both paths call it.

## The one behavioural change outside restart

The mount affect is now sent *after* the re-announce instead of in the middle of it. It is a packet to the mounting player about their own character, so its ordering against unrelated nearby-entity packets should not matter, and the horse specs covering that path stay green. Flagging it because it is the only thing here that touches #33's code.

## Verified

- **7 new unit specs.** On the parent commit, 5 fail by assertion (both restart flavours handing back 1000 instead of 50, a spawn still being queued, town not going through the movement path, no revive invisibility) and one covers the regen re-arm (regen off after death, back on after the restart). All fail without their respective change.
- **1 new integration spec** against the real server: the character revives on **exactly 50**, and the client is re-announced with an **alive state byte** (the part unit tests cannot show — the client draws you lying down until told otherwise).
- 509 unit passing; integration **28 passing, 0 failing**.
- **Confirmed in the real client** end to end: died to monsters, `/restart_here`, the character stands up on 50 HP and the `[HP REGEN]` log resumes on its 3s cycle. No repeated welcome message.

## Still not done

`DeathPenalty` remains the `//TODO` in `die()`, so the original's `DeathPenalty(0)` for here and `DeathPenalty(1)` for town are still missing.
