### PR TITLE
fix: match the original monster melee damage and defense formulas (fix #133)

### DIFF
--- a/src/core/domain/entities/game/mob/delegate/MobPoints.ts
+++ b/src/core/domain/entities/game/mob/delegate/MobPoints.ts
@@ -64,9 +64,7 @@ export class MobPoints extends Points {
     }
 
     private calcDefense() {
-        this.defense = Math.floor(
-            this.getPoint(PointsEnum.LEVEL) * 3 + this.getPoint(PointsEnum.HT) * 4 + Number(this.mobProto.def),
-        );
+        this.defense = this.getPoint(PointsEnum.LEVEL) + this.getPoint(PointsEnum.HT) + Number(this.mobProto.def);
     }
 
     private calcAttack() {

--- a/src/core/domain/entities/game/mob/delegate/MobPoints.ts
+++ b/src/core/domain/entities/game/mob/delegate/MobPoints.ts
@@ -1,6 +1,5 @@
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import { Points } from '../../shared/Points';
-import MathUtil from '@/core/domain/util/MathUtil';
 import { MobsProto } from '@/game/infra/config/GameConfig';
 
 export class MobPoints extends Points {
@@ -71,10 +70,7 @@ export class MobPoints extends Points {
     }
 
     private calcAttack() {
-        this.attack =
-            (MathUtil.getRandomInt(Number(this.mobProto.damage_min), Number(this.mobProto.damage_max)) +
-                Math.floor(this.getPoint(PointsEnum.LEVEL) * 3 + this.getPoint(PointsEnum.ST) * 4)) *
-            Number(this.mobProto.dam_multiply);
+        this.attack = this.getPoint(PointsEnum.LEVEL) * 2 + this.getPoint(PointsEnum.ST) * 2;
     }
 
     private calcHealth() {

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -76,8 +76,13 @@ export default class MonsterBattle {
         }
 
         const attackRating = this.calcAttackRating(victim);
-        const baseMonsterAttack = this.attacker.getAttack();
-        const attack = Math.floor(baseMonsterAttack * attackRating);
+        const level = this.attacker.getLevel();
+
+        const rolledDamage = MathUtil.getRandomInt(this.attacker.getDamageMin(), this.attacker.getDamageMax()) * 2;
+        let attack = this.attacker.getAttack() + rolledDamage - level * 2;
+        attack = Math.floor(attack * attackRating);
+        attack += level * 2;
+        attack = Math.floor(attack * this.attacker.getDamMultiply());
 
         this.applyAttackEffect(victim);
 

--- a/test/unit/core/domain/entities/game/mob/MonsterMeleeDamage.test.ts
+++ b/test/unit/core/domain/entities/game/mob/MonsterMeleeDamage.test.ts
@@ -44,6 +44,27 @@ describe('Monster melee damage', () => {
         });
     });
 
+    describe('MobPoints defense grade', () => {
+        // Chief Orc (vnum 691): level 50, ht 63, def 57 in mobs.json.
+        const chiefOrcProto: any = { ...wildDogProto, level: 50, ht: 63, st: 40, def: 57, max_hp: 5000 };
+
+        it('should be level + ht + def, matching the original ComputeBattlePoints', () => {
+            const points = new MobPoints(wildDogProto);
+            points.calcPoints();
+
+            // 1 + 3 + 4 = 8. The old formula was level*3 + ht*4 + def = 19.
+            expect(points.getPoint(PointsEnum.DEFENSE)).to.equal(8);
+        });
+
+        it('should not scale the level and ht terms, which suppressed player damage on real mobs', () => {
+            const points = new MobPoints(chiefOrcProto);
+            points.calcPoints();
+
+            // 50 + 63 + 57 = 170, against 50*3 + 63*4 + 57 = 459 before.
+            expect(points.getPoint(PointsEnum.DEFENSE)).to.equal(170);
+        });
+    });
+
     describe('MonsterBattle.meleeAttack', () => {
         // attackRating 90 on both sides gives a clean fAR of exactly 0.7:
         // (90+210)/300 - ((90*2+5)/(90+95))*0.3 = 1 - 0.3 = 0.7

--- a/test/unit/core/domain/entities/game/mob/MonsterMeleeDamage.test.ts
+++ b/test/unit/core/domain/entities/game/mob/MonsterMeleeDamage.test.ts
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { MobPoints } from '@/core/domain/entities/game/mob/delegate/MobPoints';
+import MonsterBattle from '@/core/domain/entities/game/mob/delegate/battle/MonsterBattle';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+// Wild Dog (vnum 101): the worked example from the issue.
+const wildDogProto: any = {
+    move_speed: 100,
+    attack_speed: 100,
+    dx: 6,
+    ht: 3,
+    iq: 3,
+    st: 3,
+    level: 1,
+    max_hp: 100,
+    def: 4,
+    damage_min: 22,
+    damage_max: 22,
+    dam_multiply: 1,
+};
+
+describe('Monster melee damage', () => {
+    describe('MobPoints attack grade', () => {
+        it('should be level*2 + st*2, matching the original ComputeBattlePoints', () => {
+            const points = new MobPoints(wildDogProto);
+            points.calcPoints();
+
+            // 1*2 + 3*2 = 8. The old formula folded the damage roll and
+            // level*3 + st*4 in here, which is what this pins against.
+            expect(points.getPoint(PointsEnum.ATTACK_GRADE)).to.equal(8);
+        });
+
+        it('should not fold the damage roll into the grade (grade is deterministic)', () => {
+            const a = new MobPoints(wildDogProto);
+            const b = new MobPoints(wildDogProto);
+            a.calcPoints();
+            b.calcPoints();
+
+            expect(a.getPoint(PointsEnum.ATTACK_GRADE)).to.equal(b.getPoint(PointsEnum.ATTACK_GRADE));
+        });
+    });
+
+    describe('MonsterBattle.meleeAttack', () => {
+        // attackRating 90 on both sides gives a clean fAR of exactly 0.7:
+        // (90+210)/300 - ((90*2+5)/(90+95))*0.3 = 1 - 0.3 = 0.7
+        const createAttacker = (overrides: any = {}) =>
+            ({
+                getBattleType: () => BattleTypeEnum.MELEE,
+                getAttackRange: () => 100,
+                getPositionX: () => 0,
+                getPositionY: () => 0,
+                getAttackRating: () => 90,
+                getLevel: () => 1,
+                getDamageMin: () => 22,
+                getDamageMax: () => 22,
+                getAttack: () => 8, // grade = level*2 + st*2
+                getDamMultiply: () => 1,
+                getEnchant: () => 0,
+                isImmuneByFlag: () => false,
+                isDeathBlower: () => false,
+                takeDamage: () => {},
+                ...overrides,
+            }) as any;
+
+        const createVictim = () => {
+            let received: number | null = null;
+            return {
+                received: () => received,
+                victim: {
+                    getPositionX: () => 0,
+                    getPositionY: () => 0,
+                    getAttackRating: () => 90,
+                    getDefense: () => 0,
+                    getPoint: () => 0,
+                    isAffectByFlag: () => false,
+                    debugChat: () => {},
+                    sendDamageReceived: () => {},
+                    takeDamage: (_attacker: any, damage: number) => {
+                        received = damage;
+                    },
+                } as any,
+            };
+        };
+
+        it('rolls the damage per hit and doubles it, matching CalcMeleeDamage', () => {
+            // grade 8 + roll(22*2=44) - level*2(2) = 50; *0.7 = 35; +2 = 37; *1 = 37
+            const battle = new MonsterBattle(createAttacker(), logger);
+            const { victim, received } = createVictim();
+
+            battle.execute(AttackTypeEnum.NORMAL, victim);
+
+            expect(received()).to.equal(37);
+        });
+
+        it('applies the mob damage multiply on top', () => {
+            // same 37, then *2 = 74
+            const battle = new MonsterBattle(createAttacker({ getDamMultiply: () => 2 }), logger);
+            const { victim, received } = createVictim();
+
+            battle.execute(AttackTypeEnum.NORMAL, victim);
+
+            expect(received()).to.equal(74);
+        });
+
+        it('subtracts the victim defense from the doubled-roll attack', () => {
+            const battle = new MonsterBattle(createAttacker(), logger);
+            let received: number | null = null;
+            const victim: any = {
+                getPositionX: () => 0,
+                getPositionY: () => 0,
+                getAttackRating: () => 90,
+                getDefense: () => 10,
+                getPoint: () => 0,
+                isAffectByFlag: () => false,
+                debugChat: () => {},
+                sendDamageReceived: () => {},
+                takeDamage: (_a: any, damage: number) => {
+                    received = damage;
+                },
+            };
+
+            battle.execute(AttackTypeEnum.NORMAL, victim);
+
+            // 37 - 10 = 27
+            expect(received).to.equal(27);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #133.

## What changes

All three legs of the monster melee exchange now mirror the original's `CalcMeleeDamage` (`battle.cpp:442-486`) and `ComputeBattlePoints` (`char.cpp:2192-2194`):

- **`MobPoints.calcAttack`** — the attack grade is now just `level*2 + st*2`. It used to fold the damage roll and a non-original `level*3 + st*4` into the grade, rolled **once at spawn**, so a mob's hit was both wrong and fixed for its whole life.
- **`MonsterBattle.meleeAttack`** — per hit: `roll = rand(min,max) * 2` (the original doubles it), `atk = grade + roll - level*2`, `atk = floor(atk * rating) + level*2` (the level term stays **outside** the rating multiply, as the original comments at `battle.cpp:454`), `atk = floor(atk * dam_multiply)`, `damage = max(0, atk - defense)`.
- **`MobPoints.calcDefense`** — now `level + ht + def`, matching `char.cpp:2194` (`// lev + con`). It used to compute `level*3 + ht*4 + def`, with nothing in the original behind either factor.

`calcAttackRating` matches `CalcAttackRating` exactly and is untouched. `getAttack()` and `getDefense()` have one reader each, so neither semantic change has other callers.

## Numbers

Attack grade — Wild Dog (vnum 101: level 1, st 3, damage 20-24) hitting a same-level victim, attack **before** defense:

| | attack |
|---|---|
| original | ~33-39 |
| before this PR | ~23-26 (≈0.69x) |

Defense grade, from `mobs.json`:

| mob | level / ht / def | before | original |
|---|---|---|---|
| Wild Dog (101) | 1 / 5 / 4 | 27 | 10 |
| Lykos (191) | 30 / 30 / 35 | 245 | 95 |
| Chief Orc (691) | 50 / 63 / 57 | 459 | 170 |

The ratio holds at roughly 2.6-2.7x across the level range. That value is subtracted straight from the player's attack in `PlayerBattleAgainstMobStrategy`, so **player melee damage has been well below the original on every mob** — the mirror image of the attack bug, and the reason fixing only the attack side would have left the exchange lopsided the other way.

It also leaks into penetrate: `calculatePenetrateDamage` adds the victim's defense back as bonus damage, so an inflated defense made penetrate hits proportionally too strong.

## Verified

- 7 unit specs pinning the worked examples: the attack grade is 8, a hit lands 37 with a clean 0.7 rating (90 vs 90 → `fAR = 0.7` exactly), the damage multiply doubles it, defense subtracts on top; the defense grade is 8 for the Wild Dog proto and 170 for a Chief Orc.
- **Fail-without-fix confirmed for both halves.** Restoring the old attack formula fails 4 of the 5 attack specs (the grade reads 37, a hit lands 5); restoring the old defense formula fails both new defense specs (19 vs 8, 459 vs 170). Nothing else in the suite depended on either value.
- 752 unit passing, 0 failing.
- Rebased onto current `master` — the branch was 90 commits behind and `MonsterBattle.ts` had been refactored into `resolveAttack` since; the fix now sits on top of that refactor rather than beside it.
- The attack half was felt in the real client on a level-1 naked character: the same wolves that could barely dent the regen now hurt. The defense half is arithmetic-only so far and has not had a client run.

## Note on scope

Pre-existing, unrelated to my open PRs. Melee only — RANGE/MAGIC monster damage is separately unimplemented (#50/#51).

The attack half was found while testing #132 in the client. The defense half came out of a systematic diff of the whole combat/points axis (`PlayerPoints`, `PlayerBattleAgainstMobStrategy`, `MonsterBattle`, `MobPoints`) against the 40250 source, which turned up a number of other divergences — happy to file those separately rather than grow this PR.