### PR TITLE
fix: dismount before dying so the corpse leaves the horse (fix #135)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -514,6 +514,8 @@ export default class Player extends Character {
     }
 
     die(killer: Character) {
+        this.stopRiding(true);
+
         super.die(killer);
 
         //TODO: death penalty

--- a/test/unit/core/domain/entities/game/player/PlayerDismountOnDeath.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerDismountOnDeath.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const config: any = {
+    empire: { red: { startPosX: 100, startPosY: 200 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createPlayer = (horseLevel = 11): Player =>
+    PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 0,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            name: 'Rider',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+            horseLevel,
+            horseHealth: 200,
+            horseStamina: 100,
+            horseName: 'Pony',
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+
+const createKiller = () =>
+    ({
+        getVirtualId: () => 999,
+        getName: () => 'Killer',
+        removeTargetedBy: () => {},
+        addTargetedBy: () => {},
+    }) as unknown as Character;
+
+const createConnection = () => ({ send: () => {}, setState: () => {} }) as any;
+
+describe('Player dismount on death', () => {
+    it('should dismount a riding character when it dies', () => {
+        const player = createPlayer();
+        player.setConnection(createConnection());
+
+        expect(player.startRiding(), 'setup: the character mounted').to.equal(true);
+        expect(player.isHorseRiding()).to.equal(true);
+
+        player.die(createKiller());
+
+        expect(player.isHorseRiding(), 'the corpse is no longer on the horse').to.equal(false);
+        expect(player.getMountVnum(), 'the mount is cleared so re-renders carry no horse').to.equal(0);
+    });
+
+    it('should clear the mount of a rental ride too', () => {
+        const player = createPlayer(0);
+        player.setConnection(createConnection());
+
+        expect(player.startTemporaryRiding(20115, 60_000), 'setup: the character mounted a rental').to.equal(true);
+        expect(player.isHorseRiding()).to.equal(true);
+
+        player.die(createKiller());
+
+        expect(player.isHorseRiding()).to.equal(false);
+        expect(player.getMountVnum()).to.equal(0);
+    });
+
+    it('should still die normally when not mounted', () => {
+        const player = createPlayer();
+        player.setConnection(createConnection());
+
+        expect(player.isHorseRiding()).to.equal(false);
+
+        player.die(createKiller());
+
+        expect(player.isDead()).to.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #135.

## What the bug is

A character killed while riding stayed mounted. The riding flag and `mountVnum` survived death, so every render of the character — including the death broadcast itself — still carried the mount, and the corpse was drawn lying flat on the horse's back, floating along as it moved.

`Player.die` handled timers, connection state, death packets, targets and the kill message, but never touched `PlayerHorse`.

## What the original does

It force-dismounts as the **first** thing `CHARACTER::Dead` does (`char_battle.cpp:1203-1216`), before any death state is applied — so the dismount broadcast goes out while the character is still standing and the death packets follow it. This PR keeps that order: `stopRiding(true)` sits above `super.die(killer)`.

`stopRiding(true)` covers both of the original's arms: `PlayerHorse.stopRiding` delegates a rental mount to `stopTemporaryRiding`, which clears `mountVnum` and its expiry timer. `forced = true` is exactly what that flag already exists for — dismounts the player did not ask for — so the mount-change cooldown cannot refuse it and the horse cannot outlive its rider.

The `src` diff is one line.

## Why it surfaced now

A gap in the horse riding feature (#33, mine) that has been there since the merge. It only became visible because monsters dealt a fraction of their intended damage until #134 — dying while mounted was rare enough not to be noticed.

## Verified

- 3 new unit specs, **2 failing on master**: a dead rider is still riding, and a rental mount is still set. The third is a regression guard that an unmounted character still dies normally.
- 501 unit passing.
- Reproduced and confirmed fixed in the real client on a grade-3 horse.

## Note on scope

Independent of my other open PRs; it merges cleanly against master. Death still leaves `DeathPenalty` unimplemented (the `//TODO` in `die()`), which is unchanged here.
