### PR TITLE
fix: stop charging click destinations to the move speed budget (fix #137)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -6,6 +6,7 @@ import InventoryEventsEnum from '../inventory/events/InventoryEventsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import PlayerApplies from './delegate/PlayerApplies';
 import { EntityStateEnum } from '@/core/enum/EntityStateEnum';
+import { MovementTypeEnum } from '@/core/enum/MovementTypeEnum';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
 import Item, { MAX_ITEM_STACK } from '../item/Item';
@@ -680,7 +681,7 @@ export default class Player extends Character {
      * the server's authoritative position and drop the move.
      * Returns true when the requested destination is acceptable.
      */
-    isMoveAllowed(x: number, y: number): boolean {
+    isMoveAllowed(x: number, y: number, movementType: MovementTypeEnum = MovementTypeEnum.WAIT): boolean {
         const max = this.horse.isRiding() ? MAX_MOVE_DISTANCE_RIDING : MAX_MOVE_DISTANCE;
 
         // Like the original, measure against the client's last accepted
@@ -695,7 +696,9 @@ export default class Player extends Character {
         const anchor = this.lastReportedPosition ?? serverPosition;
         const distance = MathUtil.calcDistance(anchor.x, anchor.y, x, y);
 
-        if (withinCap && this.isMoveRateAllowed(distance, performance.now())) {
+        const claimsPosition = movementType !== MovementTypeEnum.MOVE;
+
+        if (withinCap && (!claimsPosition || this.isMoveRateAllowed(distance, performance.now()))) {
             this.lastReportedPosition = { x, y };
             return true;
         }

--- a/src/game/app/service/CharacterMoveService.ts
+++ b/src/game/app/service/CharacterMoveService.ts
@@ -22,7 +22,7 @@ export default class CharacterMoveService {
     async execute({ player, movementType, positionX, positionY, arg, rotation, time }: CharacterMoveServiceParams) {
         // Reject teleport-hack packets (destination too far for one step); the
         // player is snapped back to their real position inside isMoveAllowed.
-        if (!player.isMoveAllowed(positionX, positionY)) {
+        if (!player.isMoveAllowed(positionX, positionY, movementType)) {
             this.logger.info(
                 `[CharacterMoveService] Rejected move for ${player.getName()} to (${positionX}, ${positionY}) — too far from (${player.getPositionX()}, ${player.getPositionY()}), type=${movementType}`,
             );

--- a/test/unit/core/domain/entities/game/player/PlayerMoveRateByType.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerMoveRateByType.test.ts
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import { MovementTypeEnum } from '@/core/enum/MovementTypeEnum';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const START_X = 100_000;
+const START_Y = 100_000;
+
+const config: any = {
+    empire: { red: { startPosX: 0, startPosY: 0 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 1000,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 0,
+                hpPerHtPoint: 0,
+                mpPerLvl: 0,
+                mpPerIqPoint: 0,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+// -accY / duration is the animation speed in units per second: a 450 u/s run.
+// Without a run animation getMoveDistancePerMs() returns null and the whole
+// rate check short-circuits, which would make these assertions vacuous.
+const animationManager: any = {
+    getAnimation: () => ({ getAccY: () => -450, getDuration: () => 1 }),
+};
+
+const createPlayer = (): Player => {
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 0,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 25,
+            experience: 0,
+            gold: 0,
+            positionX: START_X,
+            positionY: START_Y,
+            name: 'Walker',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager,
+            experienceManager: { getNeededExperience: () => 1000 } as any,
+            logger,
+            saveCharacterService: { execute: async () => {} } as any,
+            questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+            eventTimerManager: {
+                addTimer: () => {},
+                removeTimer: () => {},
+                isTimerActive: () => false,
+                clearTimersByOwner: () => {},
+                removeAllTimersFromOwner: () => {},
+            } as any,
+            mobManager: { getMobProto: () => undefined } as any,
+        },
+    );
+    player.setConnection({ send: () => {}, setState: () => {} } as any);
+    return player;
+};
+
+describe('Player move rate by movement type', () => {
+    it('should not charge click destinations, so walking never rubber-bands', () => {
+        const player = createPlayer();
+
+        // The reported bug: clicking repeatedly while walking. Each MOVE packet
+        // carries the whole remaining path, so charging them saturated the
+        // window and then refused even a single step.
+        const accepted = [];
+        for (let i = 1; i <= 10; i++) {
+            accepted.push(player.isMoveAllowed(START_X + i * 400, START_Y, MovementTypeEnum.MOVE));
+        }
+
+        expect(accepted.every(Boolean), 'every click was accepted').to.equal(true);
+    });
+
+    it('should still cap a single click beyond the per-packet limit', () => {
+        const player = createPlayer();
+
+        // Not charging the rate must not weaken the teleport cap.
+        expect(player.isMoveAllowed(START_X + 5_000, START_Y, MovementTypeEnum.MOVE)).to.equal(false);
+    });
+
+    it('should still charge position claims, so hop-by-hop teleporting is refused', () => {
+        const player = createPlayer();
+
+        // WAIT relocates the character at once, so it is a claim about where
+        // the character *is* and stays rate limited.
+        let accepted = 0;
+        for (let hop = 1; hop <= 30; hop++) {
+            if (player.isMoveAllowed(START_X + hop * 180, START_Y, MovementTypeEnum.WAIT)) accepted++;
+        }
+
+        expect(accepted, 'the hop-by-hop burst was bounded').to.be.lessThan(30);
+    });
+
+    it('should charge position claims by default, for callers that pass no type', () => {
+        const player = createPlayer();
+
+        let accepted = 0;
+        for (let hop = 1; hop <= 30; hop++) {
+            if (player.isMoveAllowed(START_X + hop * 180, START_Y)) accepted++;
+        }
+
+        expect(accepted, 'the default is the conservative, charged path').to.be.lessThan(30);
+    });
+});


### PR DESCRIPTION
Fixes #137.

## The fix

Charge the speed budget only for packets that **claim a position**:

| packet | what it does server-side | charged? |
|---|---|---|
| `MOVE` | sets a *target*; the server then interpolates towards it at the character's own speed | **no** — the interpolation already is the speed limit, and the requested path has not been walked yet |
| `WAIT` | writes the position directly (`waitInternal`), so it really relocates the character | **yes** — this is the shape a teleport takes, and it stays limited |

`isMoveAllowed` now takes the movement type, **defaulting to the charged path**, so any caller that passes none keeps the conservative behaviour. The per-packet cap is untouched and still guards both kinds.

## Why the old behaviour rubber-banded

The budget models distance travelled per second but was billed the distance to the requested destination. Every click billed a path the character had not walked, and re-clicking mid-path billed the remainder again — two clicks saturated the one-second window, after which **every** move in it was refused however small. Each refusal also nulls `lastReportedPosition`, so the next move is measured from the lagging interpolated position, which sustains the burst.

Measured in-game before the fix: **84 refusals in ~2 minutes of ordinary walking**, 29 of them under 500 units, the smallest **17** — far below the 2500 cap, so the cap was never the cause.

## An attempt I rejected

I first accumulated the server-side position delta instead (option 1 in the issue). It fixed the walking but **let the hop-by-hop teleport hack through**: between packets 34ms apart the interpolated position only advances ~15 units, so nothing was ever charged. The existing #65 specs caught it and I dropped that approach rather than weaken them.

## Verified

- 4 new unit specs. **Only the click-burst one fails on master**; the other three — the per-packet cap, hop-by-hop refusal, and the charged default — pass either way, which is the evidence that this does not weaken the existing guards.
- Both #65 rate specs stay green. 498 unit passing.
- Confirmed in the real client: walking no longer snaps back. The character also stopped dropping to the ground and standing up again — that turned out to be the client reacting to the `SYNC_POSITION` snaps rather than a separate bug, which I could only tell once the snapping stopped.

## Note on scope

Pre-existing, from the #65 rate limiting work. The original has no equivalent distance budget on movement — its speed-hack checks are combo-interval based (`input_main.cpp:1287-1317`) — so the shape here is our own design call. If you would rather keep billing `MOVE` and raise the budget instead, say so and I will swap it; I went this way because a click destination simply is not a statement about where the character is.
