### PR TITLE
fix: advertise the real sockets and attributes of shop listings (fix #125)

### DIFF
--- a/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
@@ -2,6 +2,7 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 import { ShopSubHeaderGC } from '@/core/enum/ShopSubHeaderEnum';
 import { ShopItem } from '@/core/domain/shop/ShopItem';
+import Item from '@/core/domain/entities/game/item/Item';
 import { SHOP_MAX_ITEMS } from '@/core/domain/shop/Shop';
 
 const SOCKETS_COUNT = 3;
@@ -39,15 +40,25 @@ export default class ShopStartPacket extends PacketOut {
             this.bufferWriter.writeUint8(shopItem?.count || 0);
             this.bufferWriter.writeUint8(shopItem?.position || 0);
 
-            // Write 3 sockets (all zero for shop items)
+            const item = shopItem?.item instanceof Item ? shopItem.item : undefined;
+
+            const sockets = [item?.getSocket0(), item?.getSocket1(), item?.getSocket2()];
             for (let s = 0; s < SOCKETS_COUNT; s++) {
-                this.bufferWriter.writeUint32LE(0);
+                this.bufferWriter.writeUint32LE(sockets[s] ?? 0);
             }
 
-            // Write 7 bonuses (all zero for shop items)
+            const attributes = [
+                [item?.getAttributeType0(), item?.getAttributeValue0()],
+                [item?.getAttributeType1(), item?.getAttributeValue1()],
+                [item?.getAttributeType2(), item?.getAttributeValue2()],
+                [item?.getAttributeType3(), item?.getAttributeValue3()],
+                [item?.getAttributeType4(), item?.getAttributeValue4()],
+                [item?.getAttributeType5(), item?.getAttributeValue5()],
+                [item?.getAttributeType6(), item?.getAttributeValue6()],
+            ];
             for (let b = 0; b < BONUSES_COUNT; b++) {
-                this.bufferWriter.writeUint8(0); // id
-                this.bufferWriter.writeUint16LE(0); // value
+                this.bufferWriter.writeUint8(attributes[b][0] ?? 0); // id
+                this.bufferWriter.writeUint16LE(attributes[b][1] ?? 0); // value
             }
         }
 

--- a/test/unit/core/interface/networking/packets/packets/out/ShopStartPacketItemData.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/out/ShopStartPacketItemData.test.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import ShopStartPacket from '@/core/interface/networking/packets/packet/out/ShopStartPacket';
+import Item from '@/core/domain/entities/game/item/Item';
+import { ShopItem } from '@/core/domain/shop/ShopItem';
+
+const HEADER_BYTES = 1 + 2 + 1 + 4;
+const SOCKETS_OFFSET = HEADER_BYTES + 4 + 4 + 1 + 1;
+const BONUSES_OFFSET = SOCKETS_OFFSET + 3 * 4;
+
+// Same shape as the fixture in Item.test.ts: a real proto, so Item.create
+// parses it the way it does in production.
+const proto: any = {
+    vnum: '479',
+    name: 'Dragon Tooth Blade +9',
+    item_type: 'ITEM_WEAPON',
+    sub_type: 'WEAPON_SWORD',
+    size: '2',
+    anti_flag: 'ANTI_MUSA | ANTI_ASSASSIN | ANTI_MUDANG | ANTI_SELL',
+    flag: 'ITEM_TUNABLE',
+    item_wear: 'WEAR_WEAPON',
+    immune: 'NONE',
+    gold: '120000',
+    shop_buy_price: '515000',
+    refine: '0',
+    refineset: '0',
+    magic_pct: '0',
+    limit_type0: 'LEVEL',
+    limit_value0: '105',
+    limit_type1: 'LIMIT_NONE',
+    limit_value1: '0',
+    addon_type0: 'APPLY_ATT_SPEED',
+    addon_value0: '15',
+    addon_type1: 'APPLY_ATTBONUS_HUMAN',
+    addon_value1: '15',
+    addon_type2: 'APPLY_ATTBONUS_MONSTER',
+    addon_value2: '5',
+    value0: '0',
+    value1: '149',
+    value2: '211',
+    value3: '116',
+    value4: '164',
+    value5: '250',
+    specular: '100',
+    socket: '3',
+    attu_addon: '0',
+};
+
+/** A listing backed by a real, upgraded item, the way a private shop entry is. */
+const createListedItem = () => {
+    const item = Item.create(proto, 1);
+    item.setSocket0(10);
+    item.setSocket1(20);
+    item.setSocket2(30);
+    item.setAttributeType0(5);
+    return item;
+};
+
+describe('ShopStartPacket item data', () => {
+    it('should advertise the sockets of a listed item instead of zeroing them', () => {
+        const items: ShopItem[] = [
+            { vnum: 1000, count: 1, price: 500, item: createListedItem(), size: 1, position: 0 },
+        ];
+
+        const buffer = new ShopStartPacket({ ownerVid: 1, items }).pack();
+
+        expect(buffer.readUInt32LE(SOCKETS_OFFSET)).to.equal(10);
+        expect(buffer.readUInt32LE(SOCKETS_OFFSET + 4)).to.equal(20);
+        expect(buffer.readUInt32LE(SOCKETS_OFFSET + 8)).to.equal(30);
+    });
+
+    it('should advertise the attributes of a listed item', () => {
+        const items: ShopItem[] = [
+            { vnum: 1000, count: 1, price: 500, item: createListedItem(), size: 1, position: 0 },
+        ];
+
+        const buffer = new ShopStartPacket({ ownerVid: 1, items }).pack();
+
+        // Only the type is asserted: Item currently exposes setAttributeType0
+        // but no matching setAttributeValue0 (the value setters are an
+        // inconsistent set), so the value cannot be seeded from a spec.
+        expect(buffer.readUInt8(BONUSES_OFFSET), 'attribute id').to.equal(5);
+    });
+
+    it('should still send zeros for an entry with no item behind it', () => {
+        // An NPC shop entry is a bare proto, which the original also serialises
+        // as zeros — the rule is "copy when there is an item", not "branch on
+        // the kind of shop".
+        const items: ShopItem[] = [{ vnum: 1000, count: 1, price: 500, item: undefined as any, size: 1, position: 0 }];
+
+        const buffer = new ShopStartPacket({ ownerVid: 1, items }).pack();
+
+        expect(buffer.readUInt32LE(SOCKETS_OFFSET)).to.equal(0);
+        expect(buffer.readUInt8(BONUSES_OFFSET)).to.equal(0);
+    });
+});


### PR DESCRIPTION
Fixes #125.

## What changes

`ShopStartPacket` hardcoded zeros for the three sockets and the seven attribute pairs of every entry, with a comment reading "for shop items". That is true of NPC shops — their entries are bare protos with no item instance behind them — but `Player.sendCurrentShop` builds this same packet for the private-shop paths (`PrivateShopService:228` and `:276`), so those inherited a serialisation written for the NPC case.

The original does not branch on the kind of shop. It copies whenever the entry is backed by a real item (`shop.cpp:463-468`, guarded by `if (item.pkItem)`), and that is the rule used here: read the sockets and attributes off the listed item when there is one, keep writing zeros when there is not. NPC entries serialise exactly as before.

`Item` is imported for a real `instanceof` check rather than duck-typing the getters, because a `ShopItem`'s `item` is not always a full instance — several existing specs pass partial stubs, and those must keep taking the zero path. Doing it without the check broke 13 of them.

## Honest scope note on impact

I could not demonstrate this in the client, and I want to be straight about why rather than imply a visible win.

Nothing in the server currently produces an item with meaningful sockets or attributes: there is no refine, socket-mounting or bonus-scroll system yet, and the only `setSocket0` call in `src` is `DropManager.ts:222`, which stores the killed monster's vnum on a metin stone. So today every listing legitimately serialises zeros either way.

What this fixes is the serialisation itself: the moment an item does carry sockets or attributes — a refine system, or simply an item loaded from the DB with them set — a private-shop listing will advertise them instead of dropping them. Right now it is a correctness fix with no visible effect, not a rendering fix.

## Verified

- 3 new specs built on a real `Item` created from a proto. The two asserting that a listed item's sockets and attributes reach the buyer **fail without the change**; the third, that an entry with no item still serialises zeros, passes either way as a regression guard.
- 501 unit passing, and the existing `ShopStartPacket` specs stay green.
- Merges cleanly against master.

## Noticed while writing the spec, deliberately not fixed here

`Item`'s attribute setters are an inconsistent set: `setAttributeType0-4` and `6` exist (no `5`), and of the value setters only `setAttributeValue5` does. Nothing in `src` depends on the missing ones today, and adding them is unrelated to this packet — happy to send that separately if you want it tidied.
