### PR TITLE
fix(quest): clear the pending NPC chat menu when the player leaves

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -524,7 +524,7 @@ export default class Player extends Character {
         //TODO: logout from party
         //TODO: logout from guild
         //TODO: save affect
-        //TODO: call quest disconnect callback
+        this.questManager.onDespawn(this);
         //TODO: close safebox, close mall
         //TODO: remove from pvp instance
         if (!this.skipSave) {

--- a/src/core/domain/quests/QuestManager.ts
+++ b/src/core/domain/quests/QuestManager.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import Logger from '@/core/infra/logger/Logger';
 import { AbstractQuest } from './AbstractQuest';
-import { getQuestMeta, MetaTask, QuestStatusEnum } from './decorators/QuestDecorator';
+import { getQuestMeta, MetaTask, QuestStatusEnum, StateExecutionContextBase } from './decorators/QuestDecorator';
 
 type TaskTarget = number | number[] | undefined;
 import { QuestEventEnum } from '@/core/enum/QuestEventEnum';
@@ -257,6 +257,19 @@ export class QuestManager {
         }
     }
 
+    private async dispatchStateEvent(player: Player, context: StateExecutionContextBase) {
+        const questMap = this.getQuestsForEvent(context.eventType);
+        for (const [questId, states] of questMap) {
+            const quest = player.getQuest(questId);
+            if (!quest) continue;
+            const current = quest.getCurrentState()?.name;
+            if (!current) continue;
+            if (states.has(current)) {
+                await quest.runState(context);
+            }
+        }
+    }
+
     async onLogin(player: Player) {
         if (player.isQuestRunning()) {
             this.logger.info(
@@ -265,16 +278,16 @@ export class QuestManager {
             return;
         }
 
-        const questMap = this.getQuestsForEvent(QuestEventEnum.LOGIN);
-        for (const [questId, states] of questMap) {
-            const quest = player.getQuest(questId);
-            if (!quest) continue;
-            const current = quest.getCurrentState()?.name;
-            if (!current) continue;
-            if (states.has(current)) {
-                await quest.runState({ eventType: QuestEventEnum.LOGIN });
-            }
-        }
+        await this.dispatchStateEvent(player, { eventType: QuestEventEnum.LOGIN });
+    }
+
+    onDespawn(player: Player) {
+        this.pendingChatOptions.delete(player.getId());
+    }
+
+    async onLogout(player: Player) {
+        this.onDespawn(player);
+        await this.dispatchStateEvent(player, { eventType: QuestEventEnum.LOGOUT });
     }
 
     async onLevelUp(player: Player) {
@@ -285,22 +298,14 @@ export class QuestManager {
             return;
         }
 
-        const questMap = this.getQuestsForEvent(QuestEventEnum.LEVELUP);
-        for (const [questId, states] of questMap) {
-            const quest = player.getQuest(questId);
-            if (!quest) continue;
-            const current = quest.getCurrentState()?.name;
-            if (!current) continue;
-            if (states.has(current)) {
-                await quest.runState({ eventType: QuestEventEnum.LEVELUP });
-            }
-        }
+        await this.dispatchStateEvent(player, { eventType: QuestEventEnum.LEVELUP });
     }
 
     onAnswer(player: Player, answer: number) {
         const chatOptions = this.pendingChatOptions.get(player.getId());
-        if (chatOptions) {
-            this.pendingChatOptions.delete(player.getId());
+        this.pendingChatOptions.delete(player.getId());
+
+        if (chatOptions && !this.hasSuspendedQuest(player)) {
             const option = chatOptions[answer];
             if (!option) {
                 player.sendQuestScript(QuestSkinEnum.NO_WINDOW, '[DONE]');
@@ -352,6 +357,12 @@ export class QuestManager {
 
             this.logger.error(`[QUEST_MANAGER] No active quest paused or awaiting select, playerId: ${player.getId()}`);
         }
+    }
+
+    private hasSuspendedQuest(player: Player): boolean {
+        return Boolean(
+            player.getQuestByStatus(QuestStatusEnum.SELECT) ?? player.getQuestByStatus(QuestStatusEnum.PAUSE),
+        );
     }
 
     async onClick(player: Player, npc: NPC) {
@@ -444,15 +455,9 @@ export class QuestManager {
             return;
         }
 
-        const questMap = this.getQuestsForEvent(QuestEventEnum.KILL);
-        for (const [questId, states] of questMap) {
-            const quest = killer.getQuest(questId);
-            if (!quest) continue;
-            const current = quest.getCurrentState()?.name;
-            if (!current) continue;
-            if (states.has(current)) {
-                await quest.runState({ eventType: QuestEventEnum.KILL, victim: new VictimQuest({ victim }) });
-            }
-        }
+        await this.dispatchStateEvent(killer, {
+            eventType: QuestEventEnum.KILL,
+            victim: new VictimQuest({ victim }),
+        });
     }
 }

--- a/src/game/domain/service/LeaveGameService.ts
+++ b/src/game/domain/service/LeaveGameService.ts
@@ -1,14 +1,25 @@
 import Player from '@/core/domain/entities/game/player/Player';
 import World from '@/core/domain/World';
+import { QuestManager } from '@/core/domain/quests/QuestManager';
 import PrivateShopService from '@/game/app/service/PrivateShopService';
 
 export default class LeaveGameService {
     private readonly world: World;
     private readonly privateShopService: PrivateShopService;
+    private readonly questManager: QuestManager;
 
-    constructor({ world, privateShopService }: { world: World; privateShopService: PrivateShopService }) {
+    constructor({
+        world,
+        privateShopService,
+        questManager,
+    }: {
+        world: World;
+        privateShopService: PrivateShopService;
+        questManager: QuestManager;
+    }) {
         this.world = world;
         this.privateShopService = privateShopService;
+        this.questManager = questManager;
     }
 
     async execute(player: Player) {
@@ -25,7 +36,10 @@ export default class LeaveGameService {
             player.setCurrentPrivateShopOwner(null);
         }
 
+        await this.questManager.onLogout(player);
+
         await player.flushSave();
+
         this.world.despawn(player);
     }
 }

--- a/test/integration/game/questMenuLogout.test.ts
+++ b/test/integration/game/questMenuLogout.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import { container } from '@/game/Container';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for issue #120: an NPC chat menu that the player never answers is
+ * recorded against the persistent character id, so without a logout hook it
+ * survives the disconnect and diverts the next session's first quest answer.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Quest chat menu left open at disconnect (issue #120)', function () {
+    this.timeout(60000);
+
+    const USERNAME = 'quest_menu_test';
+    const HORSE_TRAINER_NPC_VNUM = 20349;
+    const CLOSE_WINDOW_ANSWER = 254;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    // Spawns are queued to the next area tick, so the entity is not in the world
+    // yet when login() resolves.
+    async function livePlayer(name: string) {
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const player = harness.findPlayer(name);
+            if (player) return player;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        return undefined;
+    }
+
+    it('drops the menu when the connection goes away', async () => {
+        const questManager = container.resolve<any>('questManager');
+        const pendingChatOptions = questManager.pendingChatOptions;
+
+        session = await harness.login({ username: USERNAME });
+        const player = await livePlayer(USERNAME);
+
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        // The welcome quest suspends on login and blocks every NPC interaction
+        // until the player closes it: first the [NEXT] page, then the select.
+        questManager.onAnswer(player, CLOSE_WINDOW_ANSWER);
+        await session.settle(200);
+        questManager.onAnswer(player, CLOSE_WINDOW_ANSWER);
+        await session.settle(200);
+
+        expect(player.isQuestRunning(), 'setup: no quest is holding the player anymore').to.equal(false);
+
+        const opened = await questManager.onClick(player, {
+            isNPC: () => true,
+            getId: () => HORSE_TRAINER_NPC_VNUM,
+        });
+
+        expect(opened, 'setup: the horse trainer chat menu opened').to.equal(true);
+        expect(pendingChatOptions.has(player.getId()), 'setup: the open menu was recorded').to.equal(true);
+
+        await session.close();
+
+        for (let attempt = 0; attempt < 20 && pendingChatOptions.has(player.getId()); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        expect(pendingChatOptions.has(player.getId()), 'the menu did not outlive the connection').to.equal(false);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerBackToSelect.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerBackToSelect.test.ts
@@ -26,6 +26,7 @@ describe('Player.backToSelect (World.players cleanup)', () => {
         const leaveGameService = new LeaveGameService({
             world,
             privateShopService: { closePrivateShop: sinon.stub().resolves() },
+            questManager: { onLogout: sinon.stub().resolves() },
         } as never);
 
         const player: Record<string, unknown> = {

--- a/test/unit/core/domain/quests/QuestManager.test.ts
+++ b/test/unit/core/domain/quests/QuestManager.test.ts
@@ -7,15 +7,42 @@ import { QuestEventEnum } from '@/core/enum/QuestEventEnum';
 const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
 
 const CLOSE_WINDOW_ANSWER = 254;
+const NPC_VNUM = 20349;
+const QUEST_ID = 7;
+const STATE_NAME = 'START';
+
+const createMenuPlayer = (quest: any, questsByStatus: Partial<Record<QuestStatusEnum, any>>) =>
+    ({
+        getId: () => 1,
+        isQuestRunning: () => false,
+        getQuest: (id: number) => (id === QUEST_ID ? quest : null),
+        getQuestByStatus: (status: QuestStatusEnum) => questsByStatus[status] ?? null,
+        sendQuestScript: sinon.spy(),
+    }) as any;
+
+const openChatMenu = (questManager: QuestManager, player: any) => {
+    (questManager as any).registerChatTask(QUEST_ID, STATE_NAME, {
+        when: QuestEventEnum.CHAT,
+        target: NPC_VNUM,
+        chat: 'Train a Horse',
+        handlerName: 'onChat',
+    });
+
+    return questManager.onClick(player, { isNPC: () => true, getId: () => NPC_VNUM } as any);
+};
+
+const createMenuQuest = () => ({ getCurrentState: () => ({ name: STATE_NAME }), run: sinon.spy() });
+
+const createDialogQuest = () => ({ unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() });
 
 describe('QuestManager', () => {
+    let questManager: QuestManager;
+
+    beforeEach(() => {
+        questManager = new QuestManager({ logger, shopManager: {} as any } as any);
+    });
+
     describe('onAnswer', () => {
-        let questManager: QuestManager;
-
-        beforeEach(() => {
-            questManager = new QuestManager({ logger, shopManager: {} as any });
-        });
-
         const createPlayer = (questsByStatus: Partial<Record<QuestStatusEnum, any>>) =>
             ({
                 getId: () => 1,
@@ -23,7 +50,7 @@ describe('QuestManager', () => {
             }) as any;
 
         it('should unselect the quest awaiting select for valid answers', () => {
-            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            const quest = createDialogQuest();
             questManager.onAnswer(createPlayer({ [QuestStatusEnum.SELECT]: quest }), 1);
 
             expect(quest.unselect.calledOnceWith(1)).to.be.equal(true);
@@ -31,14 +58,14 @@ describe('QuestManager', () => {
         });
 
         it('should unpause a paused quest when the next button is pressed', () => {
-            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            const quest = createDialogQuest();
             questManager.onAnswer(createPlayer({ [QuestStatusEnum.PAUSE]: quest }), CLOSE_WINDOW_ANSWER);
 
             expect(quest.unpause.calledOnce).to.be.equal(true);
         });
 
         it('should cancel a quest stuck awaiting select when the window is closed', () => {
-            const quest = { unselect: sinon.spy(), cancel: sinon.spy(), unpause: sinon.spy() };
+            const quest = createDialogQuest();
             questManager.onAnswer(createPlayer({ [QuestStatusEnum.SELECT]: quest }), CLOSE_WINDOW_ANSWER);
 
             expect(quest.cancel.calledOnce).to.be.equal(true);
@@ -47,6 +74,79 @@ describe('QuestManager', () => {
 
         it('should not throw when there is no active quest', () => {
             expect(() => questManager.onAnswer(createPlayer({}), CLOSE_WINDOW_ANSWER)).to.not.throw();
+        });
+
+        it('should route the answer to the chat menu the player just opened', async () => {
+            const menuQuest = createMenuQuest();
+            const player = createMenuPlayer(menuQuest, {});
+
+            expect(await openChatMenu(questManager, player), 'setup: the chat menu opened').to.be.equal(true);
+
+            questManager.onAnswer(player, 0);
+
+            expect(menuQuest.run.calledOnce).to.be.equal(true);
+        });
+
+        it('should not let a chat menu outrank a quest that is awaiting an answer', async () => {
+            const menuQuest = createMenuQuest();
+            const questsByStatus: Partial<Record<QuestStatusEnum, any>> = {};
+            const player = createMenuPlayer(menuQuest, questsByStatus);
+
+            expect(await openChatMenu(questManager, player), 'setup: the chat menu opened').to.be.equal(true);
+
+            const dialogQuest = createDialogQuest();
+            questsByStatus[QuestStatusEnum.SELECT] = dialogQuest;
+
+            questManager.onAnswer(player, 1);
+
+            expect(dialogQuest.unselect.calledOnceWith(1)).to.be.equal(true);
+            expect(menuQuest.run.called).to.be.equal(false);
+        });
+    });
+
+    describe('onDespawn', () => {
+        it('should drop a chat menu the player left unanswered', async () => {
+            const menuQuest = createMenuQuest();
+            const player = createMenuPlayer(menuQuest, {});
+
+            expect(await openChatMenu(questManager, player), 'setup: the chat menu opened').to.be.equal(true);
+
+            questManager.onDespawn(player);
+            questManager.onAnswer(player, 0);
+
+            expect(menuQuest.run.called).to.be.equal(false);
+        });
+    });
+
+    describe('onLogout', () => {
+        it('should dispatch the logout event to a quest subscribed in its current state', async () => {
+            const quest = { getCurrentState: () => ({ name: STATE_NAME }), runState: sinon.stub().resolves() };
+            (questManager as any).addQuestToEvent(QuestEventEnum.LOGOUT, QUEST_ID, STATE_NAME);
+
+            await questManager.onLogout(createMenuPlayer(quest, {}));
+
+            expect(quest.runState.calledOnceWith({ eventType: QuestEventEnum.LOGOUT })).to.be.equal(true);
+        });
+
+        it('should not dispatch the logout event to a quest that already left that state', async () => {
+            const quest = { getCurrentState: () => ({ name: 'DONE' }), runState: sinon.stub().resolves() };
+            (questManager as any).addQuestToEvent(QuestEventEnum.LOGOUT, QUEST_ID, STATE_NAME);
+
+            await questManager.onLogout(createMenuPlayer(quest, {}));
+
+            expect(quest.runState.called).to.be.equal(false);
+        });
+
+        it('should drop a chat menu the player left unanswered', async () => {
+            const menuQuest = createMenuQuest();
+            const player = createMenuPlayer(menuQuest, {});
+
+            expect(await openChatMenu(questManager, player), 'setup: the chat menu opened').to.be.equal(true);
+
+            await questManager.onLogout(player);
+            questManager.onAnswer(player, 0);
+
+            expect(menuQuest.run.called).to.be.equal(false);
         });
     });
 

--- a/test/unit/game/domain/service/LeaveGameService.test.ts
+++ b/test/unit/game/domain/service/LeaveGameService.test.ts
@@ -1,0 +1,47 @@
+import LeaveGameService from '@/game/domain/service/LeaveGameService';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('LeaveGameService', function () {
+    let world: any;
+    let privateShopService: any;
+    let questManager: any;
+    let playerMock: any;
+    let leaveGameService: LeaveGameService;
+
+    beforeEach(function () {
+        world = { despawn: sinon.spy() };
+        privateShopService = { closePrivateShop: sinon.stub().resolves() };
+        questManager = { onLogout: sinon.stub().resolves() };
+        playerMock = {
+            getCurrentPrivateShopOwner: () => null,
+            setCurrentPrivateShopOwner: sinon.spy(),
+            flushSave: sinon.stub().resolves(),
+        };
+
+        leaveGameService = new LeaveGameService({ world, privateShopService, questManager });
+    });
+
+    describe('execute', function () {
+        it('should run the quest logout hook for the player who is leaving', async function () {
+            await leaveGameService.execute(playerMock);
+
+            expect(questManager.onLogout.calledOnceWith(playerMock)).to.be.equal(true);
+        });
+
+        it('should run the quest logout hook before the player leaves the world', async function () {
+            await leaveGameService.execute(playerMock);
+
+            expect(questManager.onLogout.calledBefore(world.despawn)).to.be.equal(true);
+        });
+
+        it('should run the quest logout hook before the save is flushed', async function () {
+            await leaveGameService.execute(playerMock);
+
+            expect(
+                questManager.onLogout.calledBefore(playerMock.flushSave),
+                'a LOGOUT quest handler that changes player state must be persisted, not dropped',
+            ).to.be.equal(true);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #120.

## The bug

`QuestManager.pendingChatOptions` is written when an NPC chat menu opens (`QuestManager.ts:382`) and deleted in exactly one place: when the player answers it (`:303`). The map is keyed by `player.getId()`, the persistent character row id, and `QuestManager` had no logout path at all, so a menu left unanswered when the connection drops stays in the map for the lifetime of the process and consumes the **first quest answer of the next session** — the chat branch is checked before the `answer <= 250` branch and returns unconditionally. Either the previous session's handler runs, built around an `NpcQuest` wrapping an NPC captured before the relog, or the answer is swallowed with `[DONE]` while the quest genuinely awaiting a `SELECT` stays suspended.

## The fix

The original splits this in two, and `CHARACTER::Disconnect` calls both: `CQuestManager::LogoutPC` dispatches `QUEST_LOGOUT_EVENT` (`questmanager.cpp:405`, `questnpc.cpp:389`), and `CQuestManager::DisconnectPC` erases the per-character entry from `m_mapPC` (`questmanager.cpp:903`). This mirrors that split:

- **`onDespawn(player)`** drops the map entry, called from `Player.onDespawn`, where `//TODO: call quest disconnect callback` already sat. That is the one point every exit from the world goes through: a dropped connection, `/logout`, `/quit`, and the back-to-select countdown, which despawns the character directly and never reaches `LeaveGameService`.
- **`onLogout(player)`** additionally dispatches `LOGOUT` to the quests subscribed in their current state, called from `LeaveGameService`, where the player really leaves the game. Dispatching the event from `onDespawn` instead would fire a logout on every `/goto`, since a teleport despawns and respawns the same character.

`onAnswer` also stops letting the chat branch outrank a suspended quest: it takes that branch only when nothing is awaiting a `SELECT` or a `PAUSE`, so a stale entry cannot steal a live dialog even if one survives by some other route.

`QuestEventEnum.LOGOUT` was already registered as a task event (`:115`) and typed in `QuestDecorator` with nothing dispatching it — a half-finished port, and that missing dispatcher is why the map had no lifecycle. It stays correct-but-inert today, because quests are not persisted and a logout handler can only touch state that is about to be discarded; I wired it anyway, since leaving a registered event without a dispatcher is what produced this bug.

The dispatch loop was identical in `onLogin`, `onLevelUp` and `onKill`, and `LOGOUT` would have been a fourth copy, so it is now one private `dispatchStateEvent`. No behaviour change there: the KILL victim facade is built once per dispatch instead of once per quest, which no caller can observe.

## Verified

- **506 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated to this) and **26 integration passing, 0 failing**.
- Fail-without-fix: **7 of the new specs fail on master, but only 2 of those are behaviour proofs** — the unit case where a stale menu steals a live dialog's answer, and the integration case that opens a real horse-trainer menu, drops the connection, and finds the entry still in the map. The other 5 fail only because `onDespawn`/`onLogout` do not exist there. One further spec (a menu answered normally) passes either way, as a regression guard.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 9 of my other open branches.

## Note on scope

Pre-existing, and independent of my other open PRs. One thing I deliberately left alone, which is worth its own issue if you agree: **the back-to-select countdown bypasses `LeaveGameService` entirely** (`Player.ts` despawns the character and only flips the connection state), so a player going back to character select never has their private shop closed either — the duplication case that service's own comment describes. The quest menu is covered here because `Player.onDespawn` catches that path, but the rest of the leave-game teardown is not.