### PR TITLE
fix(quest): key quest targets by player so they stop overwriting each other

### DIFF
--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -490,14 +490,19 @@ export abstract class AbstractQuest {
 
     protected sendTarget({ virtualId, vnum, name }: { virtualId?: number; vnum?: number; name: string }) {
         if (vnum) {
-            return this.questTargetManager.sendTargetByVnum({ player: this.player, vnum, name });
+            return this.questTargetManager.sendTargetByVnum({ player: this.player, questId: this.id, vnum, name });
         }
         if (virtualId) {
-            return this.questTargetManager.sendTargetByVirtualId({ player: this.player, virtualId, name });
+            return this.questTargetManager.sendTargetByVirtualId({
+                player: this.player,
+                questId: this.id,
+                virtualId,
+                name,
+            });
         }
     }
 
     protected removeTarget({ name }: { name: string }) {
-        return this.questTargetManager.removeTarget({ player: this.player, targetName: name });
+        return this.questTargetManager.removeTarget({ player: this.player, questId: this.id, targetName: name });
     }
 }

--- a/src/core/domain/quests/QuestTargetManager.ts
+++ b/src/core/domain/quests/QuestTargetManager.ts
@@ -5,22 +5,33 @@ import { EntityManager } from '../manager/EntityManager';
 
 export class QuestTargetManager {
     private readonly entityManager: EntityManager;
-    private readonly targets: Map<string, number> = new Map();
+    private readonly targetsByPlayer: Map<number, Map<string, number>> = new Map();
     private nextTargetId: number = 0;
 
     constructor({ entityManager }: { entityManager: EntityManager }) {
         this.entityManager = entityManager;
     }
 
-    removeTarget({ player, targetName }: { player: Player; targetName: string }) {
-        const targetId = this.targets.get(targetName);
+    removeTarget({ player, questId, targetName }: { player: Player; questId: number; targetName: string }) {
+        const targets = this.targetsByPlayer.get(player.getId());
+
+        if (!targets) return;
+
+        const key = QuestTargetManager.createKey(questId, targetName);
+        const targetId = targets.get(key);
 
         if (!targetId) return;
+
+        targets.delete(key);
+
+        if (targets.size === 0) {
+            this.targetsByPlayer.delete(player.getId());
+        }
 
         player.sendQuestTargetRemove({ id: targetId });
     }
 
-    sendTargetByVnum({ player, vnum, name }: { player: Player; vnum: number; name: string }) {
+    sendTargetByVnum({ player, questId, vnum, name }: { player: Player; questId: number; vnum: number; name: string }) {
         const targetsVirtualId = this.entityManager.getEntityByVnum(vnum);
 
         if (targetsVirtualId.length <= 0) return;
@@ -31,32 +42,59 @@ export class QuestTargetManager {
 
         if (!target) return;
 
-        const targetId = ++this.nextTargetId;
-
-        this.targets.set(name, targetId);
-
         player.sendQuestTarget({
-            id: targetId,
+            id: this.createTarget({ player, questId, name }),
             targetName: name,
             targetVirtualId: target.getVirtualId(),
             type: QuestTargetTypeEnum.VIRTUAL_ID,
         });
     }
 
-    sendTargetByVirtualId({ player, virtualId, name }: { player: Player; virtualId: number; name: string }) {
+    sendTargetByVirtualId({
+        player,
+        questId,
+        virtualId,
+        name,
+    }: {
+        player: Player;
+        questId: number;
+        virtualId: number;
+        name: string;
+    }) {
         const target = this.entityManager.getEntity(virtualId);
 
         if (!target) return;
 
-        const targetId = ++this.nextTargetId;
-
-        this.targets.set(name, targetId);
-
         player.sendQuestTarget({
-            id: targetId,
+            id: this.createTarget({ player, questId, name }),
             targetName: name,
             targetVirtualId: target.getVirtualId(),
             type: QuestTargetTypeEnum.VIRTUAL_ID,
         });
+    }
+
+    private createTarget({ player, questId, name }: { player: Player; questId: number; name: string }): number {
+        let targets = this.targetsByPlayer.get(player.getId());
+
+        if (!targets) {
+            targets = new Map<string, number>();
+            this.targetsByPlayer.set(player.getId(), targets);
+        }
+
+        const key = QuestTargetManager.createKey(questId, name);
+        const previousTargetId = targets.get(key);
+
+        if (previousTargetId) {
+            player.sendQuestTargetRemove({ id: previousTargetId });
+        }
+
+        const targetId = ++this.nextTargetId;
+        targets.set(key, targetId);
+
+        return targetId;
+    }
+
+    private static createKey(questId: number, name: string): string {
+        return `${questId}:${name}`;
     }
 }

--- a/test/unit/core/domain/quests/QuestTargetManager.test.ts
+++ b/test/unit/core/domain/quests/QuestTargetManager.test.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { QuestTargetManager } from '@/core/domain/quests/QuestTargetManager';
+
+const TARGET_NAME = 'skill_teacher';
+const QUEST_ID = 4;
+const TARGET_VIRTUAL_ID = 91;
+
+const createPlayer = (id: number) =>
+    ({
+        getId: () => id,
+        getArea: () => 'area',
+        sendQuestTarget: sinon.spy(),
+        sendQuestTargetRemove: sinon.spy(),
+    }) as any;
+
+const entityManager: any = {
+    getEntity: () => ({ getVirtualId: () => TARGET_VIRTUAL_ID, getArea: () => 'area' }),
+    getEntityByVnum: () => [TARGET_VIRTUAL_ID],
+};
+
+describe('QuestTargetManager', () => {
+    let questTargetManager: QuestTargetManager;
+
+    beforeEach(() => {
+        questTargetManager = new QuestTargetManager({ entityManager });
+    });
+
+    const sendTarget = (player: any, questId: number = QUEST_ID, name: string = TARGET_NAME) =>
+        questTargetManager.sendTargetByVirtualId({ player, questId, virtualId: TARGET_VIRTUAL_ID, name });
+
+    const removeTarget = (player: any, questId: number = QUEST_ID, name: string = TARGET_NAME) =>
+        questTargetManager.removeTarget({ player, questId, targetName: name });
+
+    const sentTargetId = (player: any) => player.sendQuestTarget.lastCall.args[0].id;
+
+    it('should remove the marker the player was given, not the one another player got last', () => {
+        const first = createPlayer(1);
+        const second = createPlayer(2);
+
+        sendTarget(first);
+        sendTarget(second);
+
+        const firstTargetId = sentTargetId(first);
+        removeTarget(first);
+
+        expect(first.sendQuestTargetRemove.calledOnceWith({ id: firstTargetId })).to.be.equal(true);
+    });
+
+    it('should leave the other players markers alone', () => {
+        const first = createPlayer(1);
+        const second = createPlayer(2);
+
+        sendTarget(first);
+        sendTarget(second);
+
+        const secondTargetId = sentTargetId(second);
+        removeTarget(first);
+        removeTarget(second);
+
+        expect(second.sendQuestTargetRemove.calledOnceWith({ id: secondTargetId })).to.be.equal(true);
+    });
+
+    it('should forget a target once it is removed', () => {
+        const player = createPlayer(1);
+
+        sendTarget(player);
+        removeTarget(player);
+        removeTarget(player);
+
+        expect(player.sendQuestTargetRemove.calledOnce).to.be.equal(true);
+    });
+
+    it('should keep targets of different quests apart even under the same name', () => {
+        const player = createPlayer(1);
+
+        sendTarget(player, QUEST_ID);
+        const firstTargetId = sentTargetId(player);
+        sendTarget(player, QUEST_ID + 1);
+
+        removeTarget(player, QUEST_ID);
+
+        expect(player.sendQuestTargetRemove.calledOnceWith({ id: firstTargetId })).to.be.equal(true);
+    });
+
+    it('should replace a target sent twice instead of leaving the old marker drawn', () => {
+        const player = createPlayer(1);
+
+        sendTarget(player);
+        const firstTargetId = sentTargetId(player);
+        sendTarget(player);
+
+        expect(player.sendQuestTargetRemove.calledOnceWith({ id: firstTargetId })).to.be.equal(true);
+        expect(sentTargetId(player)).to.not.be.equal(firstTargetId);
+    });
+
+    it('should do nothing when removing a target the player never had', () => {
+        const player = createPlayer(1);
+
+        expect(() => removeTarget(player)).to.not.throw();
+        expect(player.sendQuestTargetRemove.called).to.be.equal(false);
+    });
+
+    it('should send the target by vnum with the resolved virtual id', () => {
+        const player = createPlayer(1);
+
+        questTargetManager.sendTargetByVnum({ player, questId: QUEST_ID, vnum: 20345, name: TARGET_NAME });
+
+        expect(player.sendQuestTarget.calledOnce).to.be.equal(true);
+        expect(player.sendQuestTarget.lastCall.args[0].targetVirtualId).to.be.equal(TARGET_VIRTUAL_ID);
+    });
+});


### PR DESCRIPTION
Fixes #127.

## The bug

`QuestTargetManager` kept every quest marker in one server-wide map keyed by the target's **name**, with no player in the key — and quest scripts use a fixed name constant. `SkillQuest` declares `TARGET_NAME = 'skill_teacher'` at module level and uses it for both the send (`:160`) and the remove (`:202`).

So with two players on the skill quest: A gets id 1, B overwrites the entry with id 2, and when A finishes, `removeTarget` looks the name up and hands A **B's** id. A's own marker is never removed and stays on screen for the rest of the session. `removeTarget` also never deleted the entry, so the map only grew and kept serving the stale id to whoever asked next.

## The fix

The original settles the shape. `CTargetManager` stores targets in `std::map<DWORD /*PID*/, std::list<LPEVENT>>` and keys every operation by player id, quest index and name — `CreateTarget(dwPID, dwQuestIndex, szTargetName, ...)` and `DeleteTarget(dwPID, dwQuestIndex, szTargetName)` (`target.h:56-57`, `target.cpp:134` / `:240`). `DeleteTarget` matches on the quest index **and** the name, sends the delete packet, and erases the entry.

So the map becomes `Map<playerId, Map<questId:name, targetId>>`, `removeTarget` deletes what it just removed, and a player's map is dropped once its last target goes. The quest id comes from the quest instance itself, so the two facade methods on `AbstractQuest` are the only call sites that change.

Two things ride along, both from the same passage of the original:

- **The quest index is part of the key**, not just the player. Two quests using the same marker name for one player would otherwise collide — the same bug one level down.
- **Sending the same target twice now removes the old marker first.** `CreateTarget` does this explicitly ("same target will be replaced", `target.cpp:175-201`); ours silently replaced the map entry and left the old marker drawn on the client forever.

`nextTargetId` stays a global counter, like the original's `m_iID` — the id only has to be unique per client.

## What I deliberately left out

The original also has **`CTargetManager::Logout(dwPID)`**, which drops the player's whole list and is called from `CHARACTER::Disconnect` (`char.cpp:1373`). The natural home for that here is the despawn hook #140 adds, and wiring it in this PR would make this one depend on that one. With `removeTarget` now deleting, what is left is bounded: one entry per marker a player abandons without finishing the quest. Happy to add it to whichever of the two lands second.

## Verified

- **505 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated to this) and **25 integration passing, 0 failing**.
- Fail-without-fix: **4 of the 7 new specs fail on master, and all 4 are behaviour proofs** — they exercise master's own code, since the extra `questId` argument is simply ignored there. The other 3 pass either way, as regression guards.
- No integration spec here: the defect is pure in-memory bookkeeping, and asserting it end to end would mean scanning an unframed byte stream for a remove packet — the kind of test that passes for the wrong reason. Say the word if you want one anyway.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 10 of my other open branches, #140 included.

## Note on scope

Pre-existing, and independent of my other open PRs. Only reachable through `SkillQuest` today, which is the one quest that uses markers — the blast radius grows with every quest that adds one, which is why it is worth doing while there is a single caller.