### PR TITLE
fix(shop): stop listed items being merged into, counted and consumed by quests

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1701,6 +1701,7 @@ export default class Player extends Character {
         if (existing === item) return false;
         if (existing.getWindow() !== WindowTypeEnum.INVENTORY) return false;
         if (existing.getId() !== item.getId() || !existing.isStackable()) return false;
+        if (this.isItemLockedInPrivateShop(existing)) return false;
         // Only merge into items actually present in the grid — a stale
         // map entry (ghost) would swallow the units into an empty slot.
         return this.inventory.getItem(existing.getPosition()) === existing;

--- a/src/core/domain/quests/AbstractQuest.ts
+++ b/src/core/domain/quests/AbstractQuest.ts
@@ -58,22 +58,21 @@ export abstract class AbstractQuest {
         this.itemManager = itemManager;
     }
 
+    private getCountableItems(vnum: number) {
+        return [...this.player.getInventory().getItems().values()].filter(
+            (item) => item.getId() === vnum && !this.player.isItemLockedInPrivateShop(item),
+        );
+    }
+
     protected countItem(id: number): number {
-        let count = 0;
-        const vnum = Number(id);
-        for (const item of this.player.getInventory().getItems().values()) {
-            if (item.getId() === vnum) {
-                count += item.getCount();
-            }
-        }
-        return count;
+        return this.getCountableItems(Number(id)).reduce((count, item) => count + item.getCount(), 0);
     }
 
     protected async removeItem(id: number, quantity: number = 1): Promise<boolean> {
         const vnum = Number(id);
         let needed = quantity;
         const inventory = this.player.getInventory();
-        const items = [...inventory.getItems().values()].filter((item) => item.getId() === vnum);
+        const items = this.getCountableItems(vnum);
 
         if (this.countItem(vnum) < quantity) {
             return false;

--- a/test/unit/core/domain/entities/game/player/PlayerStackMerge.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerStackMerge.test.ts
@@ -1,0 +1,155 @@
+import { expect } from 'chai';
+import BitFlag from '@/core/util/BitFlag';
+import Item from '@/core/domain/entities/game/item/Item';
+import Logger from '@/core/infra/logger/Logger';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import { ItemFlagEnum } from '@/core/enum/ItemFlagEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
+import { ItemUseSubTypeEnum } from '@/core/enum/ItemUseSubTypeEnum';
+
+const logger: Logger = { info: () => {}, error: () => {}, debug: () => {} };
+
+const POTION_VNUM = 27001;
+
+const createPlayer = () => {
+    const config: any = {
+        INVENTORY_PAGES: 2,
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: 1_000,
+                    initialMp: 500,
+                    initialStamina: 30,
+                    hpPerLvl: 0,
+                    hpPerHtPoint: 0,
+                    mpPerLvl: 0,
+                    mpPerIqPoint: 0,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: 100_000,
+            positionY: 100_000,
+            health: 1,
+            mana: 1,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'seller',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+            mobManager: {} as any,
+        },
+    );
+
+    player.setConnection({ send: () => {} } as any);
+
+    return player;
+};
+
+const createPotion = (dbId: number, count: number) =>
+    new Item({
+        id: POTION_VNUM,
+        name: 'potion',
+        type: ItemTypeEnum.ITEM_USE,
+        subType: ItemUseSubTypeEnum.USE_POTION,
+        size: 1,
+        antiFlags: new BitFlag(),
+        flags: new BitFlag(ItemFlagEnum.ITEM_STACKABLE),
+        wearFlags: new BitFlag(),
+        immuneFlags: new BitFlag(),
+        gold: 0,
+        shopPrice: 100,
+        refineId: 0,
+        refineSet: 0,
+        magicPercent: 0,
+        limits: [],
+        applies: [],
+        values: [],
+        specular: 0,
+        socket: 0,
+        addon: 0,
+        count,
+        socket0: 0,
+        socket1: 0,
+        socket2: 0,
+        attributeType0: 0,
+        attributeValue0: 0,
+        attributeType1: 0,
+        attributeValue1: 0,
+        attributeType2: 0,
+        attributeValue2: 0,
+        attributeType3: 0,
+        attributeValue3: 0,
+        attributeType4: 0,
+        attributeValue4: 0,
+        attributeType5: 0,
+        attributeValue5: 0,
+        attributeType6: 0,
+        attributeValue6: 0,
+        dbId,
+    } as any);
+
+describe('Player stack merging into a private shop listing (issue #128)', () => {
+    it('should leave a listed stack untouched and place the new units elsewhere', () => {
+        const player = createPlayer();
+        const listed = createPotion(1, 5);
+        player.getInventory().addItem(listed);
+        (player as any).privateShop = { hasItemListed: (item: Item) => item === listed };
+
+        const picked = createPotion(2, 10);
+        const result = player.addItemStacking(picked);
+
+        expect(listed.getCount()).to.be.equal(5);
+        expect(picked.getCount()).to.be.equal(10);
+        expect(result?.inserted).to.be.equal(picked);
+    });
+
+    it('should still merge into a stack that is not for sale', () => {
+        const player = createPlayer();
+        const existing = createPotion(1, 5);
+        player.getInventory().addItem(existing);
+
+        const picked = createPotion(2, 10);
+        const result = player.addItemStacking(picked);
+
+        expect(existing.getCount()).to.be.equal(15);
+        expect(picked.getCount()).to.be.equal(0);
+        expect(result?.inserted).to.be.equal(null);
+    });
+});

--- a/test/unit/core/domain/quests/AbstractQuest.test.ts
+++ b/test/unit/core/domain/quests/AbstractQuest.test.ts
@@ -225,4 +225,73 @@ describe('AbstractQuest', () => {
             expect(rearmed).to.be.equal(true);
         });
     });
+
+    describe('inventory items listed in a private shop (issue #128)', () => {
+        const POTION_VNUM = 27001;
+
+        class InventoryQuest extends AbstractQuest {
+            constructor(player: any, itemManager: any) {
+                super({ player, itemManager } as any);
+                (this as any).id = 9;
+                (this as any).name = 'InventoryQuest';
+            }
+
+            public count(vnum: number) {
+                return (this as any).countItem(vnum);
+            }
+
+            public take(vnum: number, quantity: number) {
+                return (this as any).removeItem(vnum, quantity);
+            }
+        }
+
+        const createItem = (dbId: number, count: number) => ({
+            dbId,
+            getId: () => POTION_VNUM,
+            getCount: () => count,
+            getPosition: () => dbId,
+            getSize: () => 1,
+            decreaseCount: () => {},
+        });
+
+        const buildQuest = (items: Array<any>, listed: Array<any>) => {
+            const removed: Array<any> = [];
+            const player: any = {
+                getInventory: () => ({
+                    getItems: () => new Map(items.map((item) => [item.dbId, item])),
+                    removeItem: (position: number) => removed.push(position),
+                }),
+                isItemLockedInPrivateShop: (item: any) => listed.includes(item),
+                sendItemUpdate: () => {},
+                sendItemRemoved: () => {},
+            };
+            const itemManager: any = { update: async () => {}, delete: async () => {} };
+
+            return { quest: new InventoryQuest(player, itemManager), removed };
+        };
+
+        it('should not count items that are for sale in the private shop', () => {
+            const forSale = createItem(1, 5);
+            const spare = createItem(2, 3);
+            const { quest } = buildQuest([forSale, spare], [forSale]);
+
+            expect(quest.count(POTION_VNUM)).to.be.equal(3);
+        });
+
+        it('should count everything while no private shop lists them', () => {
+            const first = createItem(1, 5);
+            const second = createItem(2, 3);
+            const { quest } = buildQuest([first, second], []);
+
+            expect(quest.count(POTION_VNUM)).to.be.equal(8);
+        });
+
+        it('should refuse to consume a quest requirement that is only met by items for sale', async () => {
+            const forSale = createItem(1, 5);
+            const { quest, removed } = buildQuest([forSale], [forSale]);
+
+            expect(await quest.take(POTION_VNUM, 5)).to.be.equal(false);
+            expect(removed).to.be.deep.equal([]);
+        });
+    });
 });


### PR DESCRIPTION
Fixes #128.

## The bug

The private-shop lock is checked by move, use, drop, sell and inventory move — five call sites — but not by the two paths that reach an item without the player acting on it directly.

**Stack merging is the one with a payoff.** `canMergeInto` never asked whether the stack it is about to grow is listed in an open private shop, and `mergeIntoExistingStacks` runs on pickup, on purchase and on quest rewards. A seller who lists 5 potions at 1000 gold and then picks up 10 more grows the listing to 15, and the buyer gets all of them for the price the listing was created at — the price is per stack.

**Quest requirements are the other.** `AbstractQuest` counted and consumed inventory items with no shop filter, so items parked in an open shop satisfied a quest while still being for sale.

## The original answers one of them and gets the other wrong

`CountSpecifyItem`, `RemoveSpecifyItem` and `RemoveSpecifyTypeItem` all skip listed items with the same predicate (`char_item.cpp:6384`, `:6414`, `:6474`). That is what the quest counting now does — **once**, through a shared `getCountableItems`, rather than as a third copy of the predicate.

Its merge loops carry exactly the bug being fixed here: neither `PickupItem` (`char_item.cpp:5835-5867`) nor `AutoGiveItem` (`:6564-6592`) consults `m_pkMyShop` before growing a stack.

It gets away with it because **its lock is far blunter**: `CanHandleItem` returns false outright while `GetMyShop()` is set (`char_item.cpp:213`), so a seller cannot touch any item at all while trading. Ours locks the listed items and leaves the rest of the inventory usable, which is the better behaviour — and the reason every path that mutates a stack has to consult the lock itself. Worth noting that `PickupItem` is not gated by `CanHandleItem` in the original either, so the hole is not purely theoretical there.

If you would rather have the original's blunt version, that is a different PR and a worse one for players; I would keep the per-item lock and close the gaps, which is what this does.

## Verified

- **503 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated to this) and **25 integration passing, 0 failing**.
- Fail-without-fix: **3 of the 5 new specs fail on master, and all 3 are behaviour proofs** — the listed stack grows from 5 to 15 (`expected 15 to equal 5`), the quest counts 8 where only 3 are countable, and `removeItem` returns `true` for a requirement met only by items that are for sale.
- The other 2 pass either way, deliberately: one proves the same scenario **does** merge when nothing is listed, so the first spec cannot pass for the wrong reason.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 11 of my other open branches.

## Note on scope

Pre-existing, and independent of my other open PRs. The five existing lock call sites are untouched — this is about the two that were missed, not a general absence of the guard. Gap 1 is the one with the duplication-shaped payoff, so if you want to split them, that is the half to take first.

## Why a stock client cannot reach the merge path, and why the guard still matters

I tried to validate the merge arm in the real client and could not, so I am recording the reason rather than leaving a silently untested claim.

While a private shop is open the retail client refuses movement, attacking and world clicks outright — `CPythonPlayer::NEW_MoveToDirection`, `NEW_Attack`, `__CanAttack` and `NEW_SetMouseSmartState` all early-return on `IsOpenPrivateShop()`. The last of those is the smart-click handler, so a stock client cannot pick an item off the ground while its own shop is up, which is exactly the setup this guard is about.

That is the same blunt lock the original server applies from the other side: `CanHandleItem` returns false while `GetMyShop()` is set (`char_item.cpp:213`).

Our lock is per-item and finer, which is the better design — but it is precisely why every mutating path has to consult it itself. Anything that does not self-restrict reaches the merge: a modified client, or a server-side path that never asks the client at all. The quest arm in this PR is the second case, and it is exercised by the specs.
