### PR TITLE
fix(area): isolate spawn and despawn failures so one entity cannot kill the server

### DIFF
--- a/src/core/domain/Area.ts
+++ b/src/core/domain/Area.ts
@@ -1,4 +1,5 @@
 import Queue from '../util/Queue';
+import Logger from '../infra/logger/Logger';
 import GameEntity from './entities/game/GameEntity';
 import Player from './entities/game/player/Player';
 import MathUtil from './util/MathUtil';
@@ -25,6 +26,7 @@ export default class Area {
     private readonly height: number;
     private readonly aka?: string;
     private readonly goto?: AtlasInfoGoto;
+    private readonly logger: Logger;
 
     private readonly entitiesToSpawn = new Queue<GameEntity>(SIZE_QUEUE);
     private readonly entitiesToDespawn = new Queue<GameEntity>(SIZE_QUEUE);
@@ -53,9 +55,11 @@ export default class Area {
         {
             spawnManager,
             entityManager,
+            logger,
         }: {
             spawnManager: SpawnManager;
             entityManager: EntityManager;
+            logger: Logger;
         },
     ) {
         this.name = name;
@@ -65,6 +69,7 @@ export default class Area {
         this.height = height;
         this.aka = aka;
         this.goto = goto;
+        this.logger = logger;
         this.aoi = new SpatialGrid(CHAR_VIEW_SIZE * 2);
 
         this.spawnManager = spawnManager;
@@ -235,7 +240,7 @@ export default class Area {
     private processSpawnQueue() {
         for (const entity of this.entitiesToSpawn.dequeueIterator()) {
             if (!entity) continue;
-            entity.onSpawn();
+            this.runIsolated(entity, 'spawn', () => entity.onSpawn());
             this.aoi.insert(entity);
             this.linkNearbyEntities(entity);
             this.entityManager.addEntity(entity);
@@ -267,7 +272,7 @@ export default class Area {
             this.unlinkNearbyEntities(entity);
             this.entityManager.removeEntity(entity);
             this.aoi.remove(entity);
-            entity.onDespawn();
+            this.runIsolated(entity, 'despawn', () => entity.onDespawn());
         }
     }
 
@@ -289,5 +294,18 @@ export default class Area {
                 otherEntity.removeNearbyEntity(entity);
             }
         }
+    }
+    private runIsolated(entity: GameEntity, phase: string, run: () => Promise<void> | void) {
+        try {
+            Promise.resolve(run()).catch((error) => this.logLifecycleFailure(entity, phase, error));
+        } catch (error) {
+            this.logLifecycleFailure(entity, phase, error);
+        }
+    }
+
+    private logLifecycleFailure(entity: GameEntity, phase: string, error: unknown) {
+        this.logger.error(
+            `[AREA] Failed to ${phase} entity ${entity.getVirtualId()} on ${this.name}: ${(error as Error)?.stack ?? error}`,
+        );
     }
 }

--- a/src/core/domain/World.ts
+++ b/src/core/domain/World.ts
@@ -141,6 +141,7 @@ export default class World {
                 {
                     spawnManager: this.spawnManager,
                     entityManager: this.entityManager,
+                    logger: this.logger,
                 },
             );
             await area.load();

--- a/test/unit/core/domain/AreaLifecycle.test.ts
+++ b/test/unit/core/domain/AreaLifecycle.test.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import Area from '@/core/domain/Area';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+const createArea = () => {
+    const logged: Array<string> = [];
+    const spawned: Array<number> = [];
+    const removed: Array<number> = [];
+
+    const area = new Area(
+        { name: 'test_area', positionX: 0, positionY: 0, width: 1, height: 1 },
+        {
+            spawnManager: {} as any,
+            entityManager: {
+                addEntity: (entity: any) => spawned.push(entity.getVirtualId()),
+                removeEntity: (entity: any) => removed.push(entity.getVirtualId()),
+            } as any,
+            logger: {
+                info: () => {},
+                debug: () => {},
+                error: (message: string) => logged.push(message),
+            } as any,
+        },
+    );
+
+    return { area, logged, spawned, removed };
+};
+
+const createEntity = (
+    virtualId: number,
+    hooks: { onSpawn?: () => Promise<void> | void; onDespawn?: () => Promise<void> | void } = {},
+) => {
+    const areas: Array<any> = [];
+    let cell: any = null;
+    return {
+        areas,
+        getVirtualId: () => virtualId,
+        getPositionX: () => 1_000,
+        getPositionY: () => 1_000,
+        getTargetPosition: () => ({ x: 1_000, y: 1_000 }),
+        getEntityType: () => EntityTypeEnum.MONSTER,
+        setCell: (value: any) => (cell = value),
+        getCell: () => cell,
+        setArea: (area: any) => areas.push(area),
+        addNearbyEntity: () => {},
+        removeNearbyEntity: () => {},
+        onSpawn: hooks.onSpawn ?? (() => {}),
+        onDespawn: hooks.onDespawn ?? (() => {}),
+    } as any;
+};
+
+describe('Area lifecycle queues (issue #124)', () => {
+    const rejections: Array<unknown> = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+
+    beforeEach(() => {
+        rejections.length = 0;
+        process.on('unhandledRejection', onRejection);
+    });
+
+    afterEach(() => {
+        process.off('unhandledRejection', onRejection);
+    });
+
+    it('should keep a rejected onSpawn from escaping the tick', async () => {
+        const { area, logged } = createArea();
+
+        area.spawn(createEntity(1, { onSpawn: () => Promise.reject(new Error('quest boom')) }));
+        area.tick();
+        await flush();
+
+        expect(rejections).to.have.length(0);
+        expect(logged.some((message) => message.includes('quest boom'))).to.be.equal(true);
+    });
+
+    it('should keep a rejected onDespawn from escaping the tick', async () => {
+        const { area, logged } = createArea();
+        const entity = createEntity(1, { onDespawn: () => Promise.reject(new Error('save boom')) });
+
+        area.spawn(entity);
+        area.tick();
+        area.despawn(entity);
+        area.tick();
+        await flush();
+
+        expect(rejections).to.have.length(0);
+        expect(logged.some((message) => message.includes('save boom'))).to.be.equal(true);
+    });
+
+    it('should keep draining the spawn queue when one entity throws synchronously', () => {
+        const { area, spawned } = createArea();
+
+        area.spawn(
+            createEntity(1, {
+                onSpawn: () => {
+                    throw new Error('boom');
+                },
+            }),
+        );
+        area.spawn(createEntity(2));
+
+        area.tick();
+
+        expect(spawned).to.be.deep.equal([1, 2]);
+    });
+
+    it('should still place a healthy entity in the world', () => {
+        const { area, spawned } = createArea();
+        const entity = createEntity(1);
+
+        area.spawn(entity);
+        area.tick();
+
+        expect(spawned).to.be.deep.equal([1]);
+        expect(entity.areas).to.be.deep.equal([area]);
+    });
+});


### PR DESCRIPTION
Fixes #124.

## The bug

`Area.processSpawnQueue` called `entity.onSpawn()` without awaiting it and without a catch. `Player.onSpawn` is async and ends in `questManager.addQuests`, which constructs every quest class and awaits an initial `setState` for each — so anything that throws in a quest constructor rejects a promise nobody holds, and `game/main.ts` turns an `unhandledRejection` into `process.exit(1)`. One player spawning at a bad moment drops every connected player.

`processDespawnQueue` has the same shape eighteen lines below, and that one is worse: `Player.onDespawn` ends in a **database write**, so it fails on a connection blip rather than only on a programming error.

Neither is covered by what we already have. `GameServer.onData`'s catch wraps packet handlers, but the spawn is queued and runs on a later area tick, long after that promise settled. The `World.tick` guard in #114 is a synchronous `try/catch` around `area.tick()`, and these rejections surface after the stack has unwound, so it never sees them.

## The fix

Both call sites go through `runIsolated`, which catches the synchronous throw **and** the rejection.

The synchronous half matters on its own: `onSpawn` is declared `Promise<void> | void` and `Monster`, `NPC` and `Stone` implement it synchronously, so a throw there aborted the whole queue for that tick and left every entity behind the failing one unspawned. A bare `.catch()` would not have covered that — and would itself have thrown on the synchronous implementations, which return `undefined`.

**The failing entity is left in the world rather than unwound.** `onSpawn` is called before the aoi/entityManager registration and was never awaited, so nothing downstream ever depended on it having finished; a player whose quests failed to load is better off in the world with a logged error than silently dropped. Say the word if you would rather they be despawned.

`Area` had no logger, so it takes one from `World`, which already has it. The stack is interpolated into the message because `WinstonLoggerAdapter` only preserves it when the `Error` is the first argument.

## Where the original stands

It has no equivalent of this defect — its spawn path is synchronous, so there is nothing to port.

It is **ahead of us on the despawn half**, though: `CHARACTER::Disconnect` persists the character inline (`char.cpp:1353-1358`) before destroying it, while ours defers the save to an area tick that nobody observes — `GameServer.onClose` has already resolved by then, so there is no point in the shutdown path where a player is known to be persisted. This PR stops that save from taking the process down; moving it onto the logout path so it can be observed is a larger change and a separate one. Happy to take it next if you want it.

## Verified

- **502 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated to this) and **25 integration passing, 0 failing**.
- Fail-without-fix: **3 of the 4 new specs fail on master, and all 3 are behaviour proofs** — the spawn rejection and the despawn rejection both reach the process-level `unhandledRejection` listener, and the synchronous throw propagates out of `tick()`. The fourth passes either way, proving a healthy spawn still reaches the entity manager.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 12 of my other open branches. #96 needed care — it adds a field in the same place and its own `Area.test.ts` — so my field, import and spec file are placed to avoid it, and I built the two together: 547 unit passing, both Area spec files coexisting.

## Note on scope

Pre-existing. Same defect class as #73 and #81, one level below the handler layer; #114 does not close it, which is why this is separate.