### PR TITLE
fix(player): persist an emptied quick slot bar instead of restoring it on login

### DIFF
--- a/src/game/infra/database/PlayerRepository.ts
+++ b/src/game/infra/database/PlayerRepository.ts
@@ -175,9 +175,7 @@ export default class PlayerRepository implements IPlayerRepository {
                 player.id,
             ],
         );
-        if (player.quickSlot.size > 0) {
-            await this.bulkUpsertQuickSlots(player);
-        }
+        await this.bulkUpsertQuickSlots(player);
     }
 
     private async getQuickSlots(playerId: number): Promise<Map<number, { type: number; position: number }>> {
@@ -239,6 +237,11 @@ export default class PlayerRepository implements IPlayerRepository {
 
     private async bulkUpsertQuickSlots(player: PlayerState): Promise<void> {
         const { id: playerId, quickSlot: quickSlots } = player;
+
+        await this.databaseManager
+            .getConnection()
+            .query<ResultSetHeader>(`DELETE FROM game.quick_slot WHERE playerId = ?;`, [playerId]);
+
         if (quickSlots.size === 0) return;
 
         const values: (number | string)[] = [];
@@ -248,10 +251,6 @@ export default class PlayerRepository implements IPlayerRepository {
             placeholders.push('(?, ?, ?, ?)');
             values.push(playerId, slot, quickSlot.type, quickSlot.position);
         }
-
-        await this.databaseManager
-            .getConnection()
-            .query<ResultSetHeader>(`DELETE FROM game.quick_slot WHERE playerId = ?;`, [playerId]);
 
         await this.databaseManager.getConnection().query<ResultSetHeader>(
             `

--- a/test/unit/game/infra/database/PlayerRepository.test.ts
+++ b/test/unit/game/infra/database/PlayerRepository.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import PlayerRepository from '@/game/infra/database/PlayerRepository';
+import PlayerState from '@/core/domain/entities/state/player/PlayerState';
+
+const PLAYER_ID = 42;
+
+const createRepository = () => {
+    const queries: Array<string> = [];
+    const params: Array<Array<unknown>> = [];
+
+    const connection = {
+        query: sinon.stub().callsFake((sql: string, values: Array<unknown>) => {
+            queries.push(sql);
+            params.push(values);
+            return Promise.resolve([{ insertId: PLAYER_ID }]);
+        }),
+        execute: sinon.stub().resolves([{ insertId: PLAYER_ID }]),
+    };
+
+    const playerRepository = new PlayerRepository({
+        databaseManager: { getConnection: () => connection } as any,
+    });
+
+    return { playerRepository, queries, params };
+};
+
+const createPlayerState = (quickSlot: Map<number, { type: number; position: number }>) =>
+    ({ id: PLAYER_ID, quickSlot }) as unknown as PlayerState;
+
+const quickSlotQueries = (queries: Array<string>) => queries.filter((sql) => sql.includes('game.quick_slot'));
+
+describe('PlayerRepository quick slots (issue #121)', () => {
+    it('should delete the stored rows when the last quick slot is cleared', async () => {
+        const { playerRepository, queries, params } = createRepository();
+
+        await playerRepository.update(createPlayerState(new Map()));
+
+        const touched = quickSlotQueries(queries);
+
+        expect(touched).to.have.length(1);
+        expect(touched[0]).to.contain('DELETE FROM game.quick_slot');
+        expect(params[params.length - 1]).to.be.deep.equal([PLAYER_ID]);
+    });
+
+    it('should replace the stored rows when quick slots remain', async () => {
+        const { playerRepository, queries } = createRepository();
+
+        await playerRepository.update(createPlayerState(new Map([[0, { type: 1, position: 3 }]])));
+
+        const touched = quickSlotQueries(queries);
+
+        expect(touched).to.have.length(2);
+        expect(touched[0]).to.contain('DELETE FROM game.quick_slot');
+        expect(touched[1]).to.contain('INSERT INTO game.quick_slot');
+    });
+
+    it('should not touch the table while creating a character with no quick slots', async () => {
+        const { playerRepository, queries } = createRepository();
+
+        await playerRepository.create(createPlayerState(new Map()));
+
+        expect(quickSlotQueries(queries)).to.have.length(0);
+    });
+});


### PR DESCRIPTION
Fixes #121.

## The bug

`bulkUpsertQuickSlots` is the only writer of `game.quick_slot` and the only thing that issues the `DELETE`, and it was skipped whenever the map was empty — guarded once inside the method and again at both call sites.

Removing *some* quick slots worked, because the map was still non-empty and the `DELETE` cleared the old rows before the `INSERT`. Removing the **last** one lost the change entirely, and every deleted row came back on the next login.

## The fix

The `DELETE` runs before the empty check and only the `INSERT` is skipped, so a save always leaves the table matching what the player has. The `update` call site loses its guard as well — two copies of the same condition, one of which was wrong, is what produced this.

**The `create` call site keeps its guard on purpose.** A brand-new character has no rows to delete, and `player.id` there is not yet the inserted id — `CreateCharacterService` calls `setId` only *after* `create()` returns — so running the method unconditionally would write rows under the wrong id the day a new character starts out with quick slots.

## The alternative I offered, and why I did not take it

The issue offered a "quick slots changed" flag to avoid a `DELETE` per save for players who never touch the bar. Not worth it: `quick_slot`'s primary key is `(playerId, slot)`, so the delete is an indexed point lookup, and the flag adds state that can go stale — a worse trade than one cheap query every 120 seconds.

The original does not have the problem at all, because quickslots live in a **fixed array on the character row** (`char.cpp:1229-1230`) and are written with every save. Our separate table is the reason the empty case needs handling at all. Matching the original's storage would mean a schema migration on a live database, which is your call and not a bug fix, so this stays inside the shape we have.

## Verified

- **501 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated to this) and **25 integration passing, 0 failing**.
- Fail-without-fix: the emptied-bar spec fails on master with `expected [] to have a length of 1` — nothing touches `game.quick_slot` at all when the map is empty. The other two pass either way and cover the paths this must not change: slots that remain are still delete-then-insert, and character creation still issues no quick-slot query.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 19 of my other open branches.

## Note on scope

Pre-existing, and independent of my other open PRs. Purely user-facing — no duplication or security angle, just a setting that would not stay cleared. The three quick-slot handlers (add/remove/swap) are correct and untouched: they mutate an in-memory `Map` and validate their inputs.