### PR TITLE
fix(net): gate packet dispatch on the connection phase

### DIFF
--- a/src/auth/interface/server/AuthServer.ts
+++ b/src/auth/interface/server/AuthServer.ts
@@ -17,6 +17,8 @@ export default class AuthServer extends Server {
             return;
         }
 
+        if (!this.isAllowedInPhase(connection, header, packetBuilder)) return;
+
         const { createPacket, createHandler } = packetBuilder;
         const packet = createPacket({});
         const handler = createHandler(this.container);

--- a/src/core/interface/networking/Connection.ts
+++ b/src/core/interface/networking/Connection.ts
@@ -63,6 +63,10 @@ export default abstract class Connection {
         return this.lastHandshake;
     }
 
+    getState() {
+        return this.state;
+    }
+
     setState(value: ConnectionStateEnum) {
         this.state = value;
         this.updateState();

--- a/src/core/interface/networking/packets/Packets.ts
+++ b/src/core/interface/networking/packets/Packets.ts
@@ -1,4 +1,5 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { ConnectionStateEnum } from '@/core/enum/ConnectionStateEnum';
 import EmpirePacket from './packet/bidirectional/empire/EmpirePacket';
 import EmpirePacketHandler from './packet/bidirectional/empire/EmpirePacketHandler';
 import HandshakePacket from './packet/bidirectional/handshake/HandshakePacket';
@@ -58,9 +59,22 @@ import QuickSlotSwapRequestPacketHandler from './packet/in/quickSlotSwap/QuickSl
 import QuickSlotRemoveRequestPacket from './packet/in/quickSlotRemove/QuickSlotRemoveRequestPacket';
 import QuickSlotRemoveRequestPacketHandler from './packet/in/quickSlotRemove/QuickSlotRemoveRequestPacketHandler';
 
+const LOGIN_PHASES: ReadonlySet<ConnectionStateEnum> = new Set([
+    ConnectionStateEnum.HANDSHAKE,
+    ConnectionStateEnum.AUTH,
+    ConnectionStateEnum.LOGIN,
+    ConnectionStateEnum.SELECT,
+    ConnectionStateEnum.LOADING,
+]);
+
+const GAME_PHASES: ReadonlySet<ConnectionStateEnum> = new Set([ConnectionStateEnum.GAME, ConnectionStateEnum.DEAD]);
+
+const EVERY_PHASE: ReadonlySet<ConnectionStateEnum> = new Set([...LOGIN_PHASES, ...GAME_PHASES]);
+
 export type PacketMapValue<T extends Packet> = {
     createPacket: (params?: any) => T;
     createHandler: (container: any) => PacketHandler<T>;
+    phases: ReadonlySet<ConnectionStateEnum>;
 };
 
 const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue<any>>([
@@ -69,6 +83,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new HandshakePacket(params),
             createHandler: (params) => new HandshakePacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -76,6 +91,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new LoginRequestPacket(params),
             createHandler: (params) => new LoginRequestPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -83,6 +99,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: () => new ServerStatusRequestPacket(),
             createHandler: (params) => new ServerStatusRequestPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -90,6 +107,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new AuthTokenPacket(params),
             createHandler: (params) => new AuthTokenPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -97,6 +115,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new EmpirePacket(params),
             createHandler: (params) => new EmpirePacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -104,6 +123,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new CreateCharacterPacket(params),
             createHandler: (params) => new CreateCharacterPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -111,6 +131,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new DeleteCharacterPacket(params),
             createHandler: (params) => new DeleteCharacterPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -118,6 +139,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new SelectCharacterPacket(params),
             createHandler: (params) => new SelectCharacterPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -125,6 +147,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ClientVersionPacket(params),
             createHandler: (params) => new ClientVersionPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -132,6 +155,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: () => new EnterGamePacket(),
             createHandler: (params) => new EnterGamePacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
     [
@@ -139,6 +163,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new CharacterMovePacket(params),
             createHandler: (params) => new CharacterMovePacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -146,6 +171,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ChatInPacket(params),
             createHandler: (params) => new ChatInPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -153,6 +179,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ItemUsePacket(params),
             createHandler: (params) => new ItemUsePacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -160,6 +187,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ItemMovePacket(params),
             createHandler: (params) => new ItemMovePacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -167,6 +195,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ItemDropPacket(params),
             createHandler: (params) => new ItemDropPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -174,6 +203,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new ItemPickupPacket(params),
             createHandler: (params) => new ItemPickupPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -181,6 +211,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new AttackPacket(params),
             createHandler: (params) => new AttackPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -188,6 +219,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new TargetPacket(params),
             createHandler: (params) => new TargetPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -195,6 +227,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new InternalPingPacket(params),
             createHandler: (params) => new InternalPingPacketHandler(params),
+            phases: EVERY_PHASE,
         },
     ],
     [
@@ -202,6 +235,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: () => new PongPacket(),
             createHandler: () => new PongPacketHandler(),
+            phases: EVERY_PHASE,
         },
     ],
     [
@@ -209,6 +243,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new OnClickPacket(params),
             createHandler: (params) => new OnClickPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -216,6 +251,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new QuestAnswerPacket(params),
             createHandler: (params) => new QuestAnswerPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -223,6 +259,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new QuestButtonPacket(params),
             createHandler: (params) => new QuestButtonPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -230,6 +267,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: () => new ShopPacket(),
             createHandler: (params) => new ShopPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -237,6 +275,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: () => new MyShopPacket(),
             createHandler: (params) => new MyShopPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -244,6 +283,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new QuickSlotAddRequestPacket(params),
             createHandler: (params) => new QuickSlotAddRequestPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -251,6 +291,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new QuickSlotSwapRequestPacket(params),
             createHandler: (params) => new QuickSlotSwapRequestPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
     [
@@ -258,6 +299,7 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
         {
             createPacket: (params = {}) => new QuickSlotRemoveRequestPacket(params),
             createHandler: (params) => new QuickSlotRemoveRequestPacketHandler(params),
+            phases: GAME_PHASES,
         },
     ],
 ]);

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -44,6 +44,15 @@ export default abstract class Server {
     abstract createConnection(socket: Socket): Connection;
     abstract onData(connection: Connection, data: Buffer): Promise<void>;
 
+    protected isAllowedInPhase(connection: Connection, header: number, packetBuilder: PacketMapValue<any>): boolean {
+        if (packetBuilder.phases.has(connection.getState())) return true;
+
+        this.logger.info(
+            `[IN][PACKET] Header ${header} is not allowed in state ${connection.getState()} from connection: ID: ${connection.getId()}, ignoring`,
+        );
+        return false;
+    }
+
     /**
      * Unpacks a packet, closing the connection instead of letting a malformed
      * packet throw. A packet lying about its size makes unpack() read past the

--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -47,6 +47,8 @@ export default class GameServer extends Server {
             return;
         }
 
+        if (!this.isAllowedInPhase(connection, header, packetBuilder)) return;
+
         const { createPacket, createHandler } = packetBuilder;
         const packet = createPacket({});
         const handler = createHandler(this.container);

--- a/test/integration/game/loginPacketReplaySecurity.test.ts
+++ b/test/integration/game/loginPacketReplaySecurity.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { container } from '@/game/Container';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for issue #123: ENTER_GAME and SELECT_CHARACTER belong to the login
+ * phase. Replaying them from inside the game re-runs onSpawn (a free full heal,
+ * renewable mob immunity, a quest reset) and builds a second live Player for the
+ * same database row.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Security — login packets replayed from inside the game (issue #123)', function () {
+    this.timeout(60000);
+
+    const HEALED = 'replay_heal_test';
+    const DOUBLED = 'replay_select_test';
+
+    let harness: AttackHarness;
+    let healSession: AttackSession;
+    let selectSession: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await healSession?.close();
+        await selectSession?.close();
+        await harness?.stop();
+    });
+
+    // Spawns are queued to the next area tick, so the entity is not in the world
+    // yet when login() resolves.
+    async function livePlayer(name: string) {
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const player = harness.findPlayer(name);
+            if (player) return player;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        return undefined;
+    }
+
+    const livePlayerCount = (name: string) =>
+        [...container.resolve<any>('entityManager').entities.values()].filter(
+            (entity: any) => entity?.getName?.() === name,
+        ).length;
+
+    it('should not let a replayed ENTER_GAME heal the character', async () => {
+        healSession = await harness.login({ username: HEALED });
+        const player = await livePlayer(HEALED);
+
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        player.addPoint(PointsEnum.HEALTH, -5_000);
+        const damaged = player.getPoint(PointsEnum.HEALTH);
+
+        expect(damaged, 'setup: the character is hurt').to.be.lessThan(player.getPoint(PointsEnum.MAX_HEALTH));
+
+        healSession.sendSequenced(new BufferWriter(PacketHeaderEnum.ENTER_GAME, 1).getBuffer());
+        await healSession.settle(800);
+
+        expect(player.getPoint(PointsEnum.HEALTH), 'the replay did not refill the health bar').to.be.lessThan(
+            player.getPoint(PointsEnum.MAX_HEALTH),
+        );
+        expect(await harness.isServerAlive(), 'the server stayed up').to.equal(true);
+    });
+
+    it('should not let a replayed SELECT_CHARACTER put a second character in the world', async () => {
+        selectSession = await harness.login({ username: DOUBLED });
+        const player = await livePlayer(DOUBLED);
+
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+        expect(livePlayerCount(DOUBLED), 'setup: exactly one live character').to.equal(1);
+
+        selectSession.sendSequenced(new BufferWriter(PacketHeaderEnum.SELECT_CHARACTER, 2).writeUint8(0).getBuffer());
+        await selectSession.settle(600);
+        selectSession.sendSequenced(new BufferWriter(PacketHeaderEnum.ENTER_GAME, 1).getBuffer());
+        await selectSession.settle(800);
+
+        expect(livePlayerCount(DOUBLED), 'still exactly one live character').to.equal(1);
+    });
+});

--- a/test/unit/core/interface/networking/packets/Packets.test.ts
+++ b/test/unit/core/interface/networking/packets/Packets.test.ts
@@ -20,6 +20,7 @@ import SelectCharacterPacketHandler from '@/core/interface/networking/packets/pa
 import ServerStatusRequestPacket from '@/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacket';
 import ServerStatusRequestPacketHandler from '@/core/interface/networking/packets/packet/in/serverStatus/ServerStatusRequestPacketHandler';
 import { makePackets, PacketMapValue } from '@/core/interface/networking/packets/Packets';
+import { ConnectionStateEnum } from '@/core/enum/ConnectionStateEnum';
 import { expect } from 'chai';
 
 describe('PacketHandlerMap', function () {
@@ -107,5 +108,78 @@ describe('PacketHandlerMap', function () {
         if (!handlerFactory) throw new Error('Expected handlerFactory to be defined');
         expect(handlerFactory.createPacket({})).to.be.instanceOf(CharacterMovePacket);
         expect(handlerFactory.createHandler({})).to.be.instanceOf(CharacterMovePacketHandler);
+    });
+
+    describe('phase gate (issue #123)', function () {
+        const LOGIN_ONLY = [
+            PacketHeaderEnum.TOKEN,
+            PacketHeaderEnum.EMPIRE,
+            PacketHeaderEnum.CREATE_CHARACTER,
+            PacketHeaderEnum.DELETE_CHARACTER,
+            PacketHeaderEnum.SELECT_CHARACTER,
+            PacketHeaderEnum.ENTER_GAME,
+        ];
+
+        const GAME_ONLY = [
+            PacketHeaderEnum.ATTACK,
+            PacketHeaderEnum.CHAT_IN,
+            PacketHeaderEnum.ITEM_USE,
+            PacketHeaderEnum.ITEM_MOVE,
+            PacketHeaderEnum.ITEM_DROP,
+            PacketHeaderEnum.ITEM_PICKUP,
+            PacketHeaderEnum.ON_CLICK,
+            PacketHeaderEnum.SHOP_IN,
+            PacketHeaderEnum.PLAYER_SHOP_IN,
+        ];
+
+        const phasesOf = (header: number) => packetHandlerMap.get(header)!.phases;
+
+        it('should give every registered packet a phase it is reachable in', function () {
+            for (const [header, packet] of packetHandlerMap) {
+                expect(packet.phases, `header ${header} declares its phases`).to.not.be.equal(undefined);
+                expect(packet.phases.size, `header ${header} is reachable somewhere`).to.be.greaterThan(0);
+            }
+        });
+
+        it('should keep login packets out of the game phases', function () {
+            for (const header of LOGIN_ONLY) {
+                expect(phasesOf(header).has(ConnectionStateEnum.GAME), `header ${header} in GAME`).to.be.equal(false);
+                expect(phasesOf(header).has(ConnectionStateEnum.DEAD), `header ${header} in DEAD`).to.be.equal(false);
+            }
+        });
+
+        it('should keep gameplay packets out of the login phases', function () {
+            for (const header of GAME_ONLY) {
+                expect(phasesOf(header).has(ConnectionStateEnum.SELECT), `header ${header} in SELECT`).to.be.equal(
+                    false,
+                );
+                expect(phasesOf(header).has(ConnectionStateEnum.LOADING), `header ${header} in LOADING`).to.be.equal(
+                    false,
+                );
+            }
+        });
+
+        it('should let keepalive through in every phase', function () {
+            for (const header of [PacketHeaderEnum.PONG, PacketHeaderEnum.INTERNAL_PING]) {
+                expect(phasesOf(header).has(ConnectionStateEnum.SELECT), `header ${header} in SELECT`).to.be.equal(
+                    true,
+                );
+                expect(phasesOf(header).has(ConnectionStateEnum.GAME), `header ${header} in GAME`).to.be.equal(true);
+            }
+        });
+
+        it('should keep movement out of the phases where the character is not in the world yet', function () {
+            const move = phasesOf(PacketHeaderEnum.CHARACTER_MOVE);
+
+            expect(move.has(ConnectionStateEnum.GAME), 'move in GAME').to.be.equal(true);
+            expect(move.has(ConnectionStateEnum.SELECT), 'move in SELECT').to.be.equal(false);
+            expect(move.has(ConnectionStateEnum.LOADING), 'move in LOADING').to.be.equal(false);
+        });
+
+        it('should dispatch nothing on a closing connection', function () {
+            for (const [header, packet] of packetHandlerMap) {
+                expect(packet.phases.has(ConnectionStateEnum.CLOSE), `header ${header} in CLOSE`).to.be.equal(false);
+            }
+        });
     });
 });


### PR DESCRIPTION
Fixes #123.

## The bug

`ENTER_GAME` and `SELECT_CHARACTER` are login-phase packets, but nothing stopped a client sending them again from inside the game. Neither handler checked the phase, `Packets.ts` was a flat header map with no phase information, and `Connection` had `setState` but no `getState` — so no handler could have checked even if it wanted to.

Replaying `ENTER_GAME` re-runs `onSpawn`: a **full heal**, a fresh `REVIVE_INVISIBLE` that **no monster will attack through**, and a **reset of every quest** to its initial state. Poll it every three seconds and the immunity never lapses. Replaying `SELECT_CHARACTER` builds a **second `Player` for the same database row**, with its own virtual id and its own `Item` instances, and the autosave loop then writes both.

## You asked which shape — the original settles it

It does not check for this, it makes it unrepresentable. `DESC::SetPhase` **swaps the whole input processor** (`desc.cpp:539-587`), so once the descriptor is in `PHASE_GAME` the login handlers are not reachable at all. `CInputLogin` owns LOGIN, CHARACTER_SELECT/CREATE/DELETE, ENTERGAME, EMPIRE, CLIENT_VERSION, MOVE and PONG; `CInputMain` owns the gameplay set (`input_login.cpp:1018-1096`).

So this ports the partition — **without** splitting the map into four. Every entry declares the phases it is reachable in, and both servers consult it before dispatch:

- `LOGIN_PHASES` = handshake, auth, login, select, loading — the states `CInputLogin` covers.
- `GAME_PHASES` = game, dead — the states `CInputMain` covers.
- `CHARACTER_MOVE`, `PONG` and `INTERNAL_PING` are in both, exactly as the original has them in both processors.

`phases` is a **required** field on `PacketMapValue`, so a new packet cannot be registered without deciding where it belongs. That is the part I would argue is better than four hand-maintained maps: those can drift apart, one table cannot.

Two things fall out beyond the reported bug: nothing is dispatched on a connection in `CLOSE` (the same class as #91, one level up), and the refusal is a **logged no-op rather than a disconnect**, because the frame has already been consumed by the framing layer and a stale packet arriving during a phase change is not proof of a malicious client.

The one assignment I would flip first if it misbehaves is `CLIENT_VERSION`, kept login-only because that is where `CInputLogin` has it. The refusal logs the header and the state, so a client test surfaces it immediately.

## Verified

- **503 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated) and **27 integration passing, 0 failing** — the whole login handshake still works, which is the regression this had to not break.
- Fail-without-fix: **both new integration specs are behaviour proofs and both fail on master** — the replayed `ENTER_GAME` refills the health bar, and the replayed `SELECT_CHARACTER` leaves two live characters with the same name in the world. The five unit specs assert the table itself and only exercise the new field.
- `merge-tree`: 0 conflicts against `60947b2b` and against all 20 of my other open branches; the combined build of all of them is green.

## Note on scope

Pre-existing. #87 reaches the same *effects* (heal, escape, refreshable invisibility) through the command path rather than the packet path, and #105 is the same account on two connections — neither is closed by this. If you want the per-handler guards as well as the gate, say so and I will add them, but with dispatch partitioned they would be unreachable code.