### PR TITLE
fix(net): close the guild-mark connection instead of holding it open

### DIFF
--- a/src/core/enum/PacketHeaderEnum.ts
+++ b/src/core/enum/PacketHeaderEnum.ts
@@ -20,6 +20,7 @@ export default {
     SKILL_LEVEL: 0x4c,
     CHARACTER_DETAILS: 0x71,
     CLIENT_VERSION: 0xf1,
+    MARK_LOGIN: 0x64,
     CHARACTER_UPDATE: 0x13,
     ENTER_GAME: 0x0a,
     GAME_TIME: 0x6a,

--- a/src/core/interface/networking/packets/Packets.ts
+++ b/src/core/interface/networking/packets/Packets.ts
@@ -58,6 +58,8 @@ import QuickSlotSwapRequestPacket from './packet/in/quickSlotSwap/QuickSlotSwapR
 import QuickSlotSwapRequestPacketHandler from './packet/in/quickSlotSwap/QuickSlotSwapRequestPacketHandler';
 import QuickSlotRemoveRequestPacket from './packet/in/quickSlotRemove/QuickSlotRemoveRequestPacket';
 import QuickSlotRemoveRequestPacketHandler from './packet/in/quickSlotRemove/QuickSlotRemoveRequestPacketHandler';
+import MarkLoginPacket from './packet/in/markLogin/MarkLoginPacket';
+import MarkLoginPacketHandler from './packet/in/markLogin/MarkLoginPacketHandler';
 
 const LOGIN_PHASES: ReadonlySet<ConnectionStateEnum> = new Set([
     ConnectionStateEnum.HANDSHAKE,
@@ -300,6 +302,14 @@ const packets: Map<number, PacketMapValue<any>> = new Map<number, PacketMapValue
             createPacket: (params = {}) => new QuickSlotRemoveRequestPacket(params),
             createHandler: (params) => new QuickSlotRemoveRequestPacketHandler(params),
             phases: GAME_PHASES,
+        },
+    ],
+    [
+        PacketHeaderEnum.MARK_LOGIN,
+        {
+            createPacket: () => new MarkLoginPacket(),
+            createHandler: (params) => new MarkLoginPacketHandler(params),
+            phases: LOGIN_PHASES,
         },
     ],
 ]);

--- a/src/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacket.ts
@@ -1,0 +1,19 @@
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import PacketIn from '../PacketIn';
+
+const MARK_LOGIN_SIZE = 9;
+
+export default class MarkLoginPacket extends PacketIn {
+    constructor() {
+        super({
+            header: PacketHeaderEnum.MARK_LOGIN,
+            name: 'MarkLoginPacket',
+            size: MARK_LOGIN_SIZE,
+            sequenced: false,
+        });
+    }
+
+    unpack() {
+        return this;
+    }
+}

--- a/src/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacketHandler.ts
@@ -1,0 +1,20 @@
+import Connection from '@/core/interface/networking/Connection';
+import Logger from '@/core/infra/logger/Logger';
+import PacketHandler from '../../PacketHandler';
+import MarkLoginPacket from './MarkLoginPacket';
+
+export default class MarkLoginPacketHandler extends PacketHandler<MarkLoginPacket> {
+    private readonly logger: Logger;
+
+    constructor({ logger }: { logger: Logger }) {
+        super();
+        this.logger = logger;
+    }
+
+    async execute(connection: Connection) {
+        this.logger.info(
+            `[MarkLoginPacketHandler] Guild mark login requested but this is not a mark server, closing connection: ID: ${connection.getId()}`,
+        );
+        connection.close();
+    }
+}

--- a/test/integration/game/markLoginConnection.test.ts
+++ b/test/integration/game/markLoginConnection.test.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import { createConnection, Socket } from 'node:net';
+import { container } from '@/game/Container';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import BufferReader from '@/core/interface/networking/buffer/BufferReader';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import AttackHarness from '../../support/AttackSession';
+
+/**
+ * Regression for issue #146: the client's guild-mark downloader opens a second
+ * connection to this port, handshakes and sends MARK_LOGIN. We are not a mark
+ * server, so the connection has to be released instead of sitting there forever.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Guild-mark connection (issue #146)', function () {
+    this.timeout(60000);
+
+    // The literal header, not the enum, so this spec runs identically on a tree
+    // that does not know MARK_LOGIN yet.
+    const MARK_LOGIN_HEADER = 100;
+    const MARK_LOGIN_HANDLE = 0x0badf00d;
+    const MARK_LOGIN_RANDOM_KEY = 0x12345678;
+
+    let harness: AttackHarness;
+    let socket: Socket;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        socket?.destroy();
+        await harness?.stop();
+    });
+
+    /** A raw connection that mimics CGuildMarkDownloader: handshake, then MARK_LOGIN. */
+    const markConnection = () => {
+        const host = container.resolve<any>('config').SERVER_ADDRESS as string;
+        const port = Number(container.resolve<any>('config').SERVER_PORT);
+
+        let buffer = Buffer.alloc(0);
+        let closed = false;
+
+        const client = createConnection({ host, port });
+        client.on('data', (chunk) => (buffer = Buffer.concat([buffer, chunk])));
+        client.on('close', () => (closed = true));
+
+        const next = (length: number) =>
+            new Promise<Buffer>((resolve) => {
+                const tick = () => {
+                    if (buffer.byteLength >= length) {
+                        const out = buffer.subarray(0, length);
+                        buffer = buffer.subarray(length);
+                        return resolve(out);
+                    }
+                    setTimeout(tick, 20);
+                };
+                tick();
+            });
+
+        const closedWithin = async (ms: number) => {
+            for (let waited = 0; waited < ms && !closed; waited += 50) {
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+            return closed;
+        };
+
+        return { client, next, closedWithin };
+    };
+
+    it('should close a connection that asks to log in as a guild mark client', async () => {
+        const { client, next, closedWithin } = markConnection();
+        socket = client;
+
+        await next(2);
+        const handshake = await next(13);
+        const reader = new BufferReader();
+        reader.setBuffer(handshake);
+        const id = reader.readUInt32LE();
+        const time = reader.readUInt32LE();
+        const delta = reader.readUInt32LE();
+
+        client.write(
+            new BufferWriter(PacketHeaderEnum.HANDSHAKE, 13)
+                .writeUint32LE(id)
+                .writeUint32LE(time)
+                .writeUint32LE(delta)
+                .getBuffer(),
+        );
+
+        client.write(
+            new BufferWriter(MARK_LOGIN_HEADER, 9)
+                .writeUint32LE(MARK_LOGIN_HANDLE)
+                .writeUint32LE(MARK_LOGIN_RANDOM_KEY)
+                .getBuffer(),
+        );
+
+        expect(await closedWithin(5_000), 'the mark connection was released').to.equal(true);
+        expect(await harness.isServerAlive(), 'the server stayed up').to.equal(true);
+    });
+});

--- a/test/unit/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacket.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import MarkLoginPacket from '@/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacket';
+import MarkLoginPacketHandler from '@/core/interface/networking/packets/packet/in/markLogin/MarkLoginPacketHandler';
+import { makePackets } from '@/core/interface/networking/packets/Packets';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+const MARK_LOGIN_HEADER = 100;
+const MARK_LOGIN_BYTES = 9;
+
+describe('MarkLogin (issue #146)', () => {
+    it('should frame at the exact wire size, with no sequence byte', () => {
+        const packet = new MarkLoginPacket();
+
+        expect(PacketHeaderEnum.MARK_LOGIN).to.be.equal(MARK_LOGIN_HEADER);
+        expect(packet.getFrameLength(Buffer.alloc(MARK_LOGIN_BYTES))).to.be.equal(MARK_LOGIN_BYTES);
+    });
+
+    it('should be registered so the header is no longer unknown', () => {
+        const builder = makePackets().get(MARK_LOGIN_HEADER);
+
+        expect(builder).to.not.be.equal(undefined);
+        expect(builder!.createPacket()).to.be.instanceOf(MarkLoginPacket);
+        expect(builder!.createHandler({ logger: { info: () => {} } })).to.be.instanceOf(MarkLoginPacketHandler);
+    });
+
+    it('should close the connection, because this server is not a mark server', async () => {
+        const logger: any = { info: sinon.spy(), error: () => {}, debug: () => {} };
+        const connection: any = { getId: () => 'connection-1', close: sinon.spy() };
+
+        await new MarkLoginPacketHandler({ logger }).execute(connection, new MarkLoginPacket());
+
+        expect(connection.close.calledOnce).to.be.equal(true);
+        expect(logger.info.calledOnce).to.be.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #146.

## The bug

The client opens a **second TCP connection** to this port to download guild marks: `__DownloadMark` connects `CGuildMarkDownloader` — a `CNetworkStream` of its own — to whatever `SetMarkServer` was given, which in a normal serverinfo is the game host and port. On that socket it does its own handshake and immediately sends `TPacketCGMarkLogin`: header **100**, nine bytes, no sequence byte (`Packet.h:440-445`; `packet_info.cpp:136` registers it `bSeq=false`).

We did not know header 100, so `extractFrame` took the unknown-header branch: logged, emptied the buffer, returned — **and left the socket open**. Nothing else released it either: keepalive pings it and the mark client answers `CG_PONG` (`GuildMarkDownloader.cpp:245-259`), so the missed-pong timeout never fires, while the downloader blocks waiting for a `GC_MARK_IDXLIST` we never send.

Measured on a running server: **two established sockets for one character in game**, the extra one idle for 22 minutes, both from the same client pid.

## The fix

The original refuses it explicitly rather than ignoring it — `CInputHandshake` handles the header in the handshake phase and closes when the process is not a mark server (`input.cpp:606-619`):

```cpp
if (!guild_mark_server) {
    sys_err("Guild Mark login requested but i'm not a mark server!");
    d->SetPhase(PHASE_CLOSE);
    return 0;
}
```

So header 100 becomes a registered packet whose handler logs and closes. The socket goes away at its first packet instead of lasting the session.

**Registering it rather than adding it to `UnimplementedPackets` is deliberate.** Skipping the frame would silence the log line and leave the connection leaking, and the downloader would then send `MARK_CRCLIST` (101) and `MARK_IDXLIST` (104), which are equally unknown. The connection has to end, not be tolerated.

The packet declares `sequenced: false`, which is what makes it frame at exactly nine bytes — the same per-header opt-out the original expresses as `bSeq=false`, and the reason the log line always read `discarding 9 buffered byte(s)`.

## ⚠️ One line is needed if #145 lands first

`merge-tree` reports **0 conflicts against all 21 of my other open branches**, but that is not the whole story here: #145 makes `phases` a **required** field on `PacketMapValue`, so the two together do not compile until the new entry declares one. I built them together to be sure, and the fix is one line:

```ts
[
    PacketHeaderEnum.MARK_LOGIN,
    {
        createPacket: () => new MarkLoginPacket(),
        createHandler: (params) => new MarkLoginPacketHandler(params),
        phases: LOGIN_PHASES,   // <- only when #145 is in
    },
],
```

`LOGIN_PHASES` is right because the mark client sends this straight after its handshake. **With that line the combined tree compiles and 507 unit specs pass**, including #145's "every registered packet declares a phase". Merge in either order and tell me which — I will push the line rather than leave you to it.

## Verified

- **501 unit passing** (the 2 failures are an untracked slot-audit spec of mine, unrelated) and **26 integration passing, 0 failing**.
- Fail-without-fix: the integration spec is a behaviour proof and fails on master with `the mark connection was released`, reproducing the real client's sequence byte for byte — the same run logs the familiar `[IN][PACKET] Unknown header packet: 100, discarding 9 buffered byte(s)`. It uses the literal header rather than the enum so it runs identically on a tree that does not know `MARK_LOGIN`.
- The three unit specs cover the wire size, the registration, and the close.

## Note on scope

Pre-existing. Not related to #92 / PR #95, which were about losing packets queued *behind* an unknown header — that does not happen here, the buffer holds the 9-byte packet alone. This is about the socket.

It also does not make guild marks work, and is not meant to: if you ever want a real mark server, this handler is where it starts and the close becomes the "not configured as one" branch.