### PR TITLE
fix: flush the player save on the logout path instead of an unobserved tick

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -160,6 +160,7 @@ export default class Player extends Character {
 
     //save
     private readonly saveCharacterService: SaveCharacterService;
+    private skipSave = false;
 
     //manager
     private readonly mobManager: MobManager;
@@ -510,7 +511,22 @@ export default class Player extends Character {
         //TODO: call quest disconnect callback
         //TODO: close safebox, close mall
         //TODO: remove from pvp instance
-        await this.saveCharacterService.execute(this);
+        if (!this.skipSave) {
+            await this.saveCharacterService.execute(this);
+        }
+    }
+
+    async flushSave(): Promise<void> {
+        if (this.skipSave) return;
+        this.skipSave = true;
+
+        const results = await this.saveCharacterService.execute(this);
+        for (const result of results) {
+            if (result.status === 'rejected') {
+                const reason = result.reason instanceof Error ? result.reason.stack : result.reason;
+                this.logger.error(`[Player] logout save failed for ${this.getName()}: ${reason}`);
+            }
+        }
     }
 
     die(killer: Character) {
@@ -1194,7 +1210,6 @@ export default class Player extends Character {
                 }
                 const countDown = SECONDS_TO_LEAVE - count;
                 if (countDown <= 0) {
-                    this.area?.despawn(this);
                     switch (command) {
                         case 'QUIT':
                             this.chat({
@@ -1206,6 +1221,7 @@ export default class Player extends Character {
                             this.connection?.setState(ConnectionStateEnum.CLOSE);
                             break;
                         case 'SELECT':
+                            this.area?.despawn(this);
                             this.connection?.setState(ConnectionStateEnum.SELECT);
                             break;
                     }
@@ -2618,6 +2634,7 @@ export default class Player extends Character {
     }
 
     save(): void {
+        if (this.skipSave) return;
         this.saveCharacterService.execute(this).catch((err) => {
             this.logger.error('Failed to save character:', err);
         });

--- a/src/game/domain/service/LeaveGameService.ts
+++ b/src/game/domain/service/LeaveGameService.ts
@@ -25,6 +25,7 @@ export default class LeaveGameService {
             player.setCurrentPrivateShopOwner(null);
         }
 
+        await player.flushSave();
         this.world.despawn(player);
     }
 }

--- a/test/integration/game/logoutSaveOnLeave.test.ts
+++ b/test/integration/game/logoutSaveOnLeave.test.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+import { container } from '@/game/Container';
+
+/**
+ * Regression for issue #149: the logout save ran on an area tick after the
+ * player was already removed from the entity map, unawaited and unobservable,
+ * and the /logout countdown despawned twice so it ran twice.
+ *
+ * The load-bearing assertion is WHERE the save runs, not just that it runs:
+ * every repository update for the leaving player must be issued while the
+ * player is still in the world (the flush on the logout path), never from the
+ * despawn tick after removal. On master both /logout saves happen after
+ * removal, so `savesAfterRemoval` reads 2 and the case fails.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Bug — the logout save happens on the logout path (issue #149)', function () {
+    this.timeout(60_000);
+
+    const LEAVER = 'logoutflush_test';
+    const SEEDED_GOLD = 12038002;
+    const GOLD_DELTA = 777;
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+    let repo: any;
+    let originalUpdate: (state: unknown) => Promise<unknown>;
+    let savesWhileLive = 0;
+    let savesAfterRemoval = 0;
+
+    const db = () => container.resolve('databaseManager') as any;
+
+    const playerRow = async (name: string) => {
+        const [rows] = await db().getConnection().query('SELECT gold FROM game.player WHERE name = ?', [name]);
+        return rows[0];
+    };
+
+    const waitFor = async (predicate: () => boolean | Promise<boolean>, timeoutMs: number, stepMs = 100) => {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if (await predicate()) return true;
+            await new Promise((resolve) => setTimeout(resolve, stepMs));
+        }
+        return false;
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+
+        repo = container.resolve('playerRepository');
+        originalUpdate = repo.update.bind(repo);
+        repo.update = (state: any) => {
+            if (state?.name === LEAVER) {
+                if (harness.findPlayer(LEAVER)) savesWhileLive++;
+                else savesAfterRemoval++;
+            }
+            return originalUpdate(state);
+        };
+    });
+
+    after(async () => {
+        repo.update = originalUpdate;
+        // The /logout case leaves the socket already closed server-side, and
+        // AttackSession.close has no idempotency guard.
+        await Promise.race([session?.close(), new Promise((resolve) => setTimeout(resolve, 1_000))]);
+        await harness?.stop();
+    });
+
+    it('saves the leaving player exactly once, before removal from the world, and the data lands', async () => {
+        session = await harness.login({ username: LEAVER });
+        await session.settle(600);
+        expect(harness.findPlayer(LEAVER), 'setup: the player entered the world').to.not.equal(undefined);
+
+        session.command(`/gold ${GOLD_DELTA}`);
+        await session.settle(400);
+        expect((await playerRow(LEAVER)).gold, 'setup: nothing persisted the gold yet').to.equal(SEEDED_GOLD);
+
+        savesWhileLive = 0;
+        savesAfterRemoval = 0;
+
+        session.command('/logout');
+        const left = await waitFor(() => harness.findPlayer(LEAVER) === undefined, 20_000, 250);
+        expect(left, 'the countdown ran out and the player left the world').to.equal(true);
+
+        // Let any straggler despawn tick run before judging.
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+        expect(savesAfterRemoval, 'no save may run after the player left the world').to.equal(0);
+        expect(savesWhileLive, 'the logout path itself saved the player').to.be.greaterThanOrEqual(1);
+        expect((await playerRow(LEAVER)).gold, 'the flushed save carried the data').to.equal(SEEDED_GOLD + GOLD_DELTA);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/PlayerFlushSave.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerFlushSave.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Logger from '@/core/infra/logger/Logger';
+
+const createPlayer = (saveResults: Array<PromiseSettledResult<unknown>> = []) => {
+    const config: any = {
+        empire: { red: { startPosX: 0, startPosY: 0 } },
+        jobs: {
+            warrior: {
+                common: {
+                    st: 10,
+                    ht: 10,
+                    dx: 10,
+                    iq: 10,
+                    initialHp: 1_000,
+                    initialMp: 500,
+                    initialStamina: 30,
+                    hpPerLvl: 0,
+                    hpPerHtPoint: 0,
+                    mpPerLvl: 0,
+                    mpPerIqPoint: 0,
+                    initialAttackSpeed: 100,
+                    initialMovementSpeed: 100,
+                },
+            },
+        },
+    };
+
+    const saveCharacterService = { execute: sinon.stub().resolves(saveResults) };
+    const logger: Logger = { info: () => {}, error: sinon.spy(), debug: () => {} } as any;
+
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 1,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 1,
+            experience: 0,
+            gold: 0,
+            st: 10,
+            ht: 10,
+            dx: 10,
+            iq: 10,
+            positionX: 100_000,
+            positionY: 100_000,
+            health: 1,
+            mana: 1,
+            stamina: 30,
+            bodyPart: 0,
+            hairPart: 0,
+            name: 'leaver',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+        } as any,
+        {
+            config,
+            animationManager: { getAnimation: () => undefined } as any,
+            experienceManager: { getNeededExperience: () => 100 } as any,
+            logger,
+            saveCharacterService: saveCharacterService as any,
+            questManager: { onDespawn: () => {} } as any,
+            eventTimerManager: { removeTimer: () => {}, removeAllTimersFromOwner: () => {} } as any,
+            mobManager: {} as any,
+        },
+    );
+
+    return { player, saveCharacterService, logger };
+};
+
+describe('Player flush save (issue #149)', () => {
+    it('flushSave saves exactly once, and a second flushSave is a no-op', async () => {
+        const { player, saveCharacterService } = createPlayer();
+
+        await player.flushSave();
+        await player.flushSave();
+
+        expect(saveCharacterService.execute.callCount).to.equal(1);
+    });
+
+    it('onDespawn after flushSave does not save a second time', async () => {
+        const { player, saveCharacterService } = createPlayer();
+
+        await player.flushSave();
+        await player.onDespawn();
+
+        expect(saveCharacterService.execute.callCount).to.equal(1);
+    });
+
+    it('onDespawn without a flush still saves — a teleport despawn keeps its deferred save', async () => {
+        const { player, saveCharacterService } = createPlayer();
+
+        await player.onDespawn();
+
+        expect(saveCharacterService.execute.callCount).to.equal(1);
+    });
+
+    it('save() after flushSave is a no-op, so a stale instance cannot overwrite the row', async () => {
+        const { player, saveCharacterService } = createPlayer();
+
+        await player.flushSave();
+        player.save();
+
+        expect(saveCharacterService.execute.callCount).to.equal(1);
+    });
+
+    it('flushSave logs a rejected write instead of swallowing it', async () => {
+        const { player, logger } = createPlayer([{ status: 'rejected', reason: new Error('update failed') }]);
+
+        await player.flushSave();
+
+        const errorSpy = logger.error as sinon.SinonSpy;
+        expect(errorSpy.callCount).to.equal(1);
+        expect(String(errorSpy.firstCall.args[0])).to.include('logout save failed for leaver');
+        expect(String(errorSpy.firstCall.args[0])).to.include('update failed');
+    });
+});

--- a/test/unit/game/domain/service/LeaveGameServiceFlushSave.test.ts
+++ b/test/unit/game/domain/service/LeaveGameServiceFlushSave.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import LeaveGameService from '@/game/domain/service/LeaveGameService';
+import Player from '@/core/domain/entities/game/player/Player';
+
+describe('LeaveGameService (issue #149)', () => {
+    it('awaits the player flush save before despawning, so the caller observes a completed save', async () => {
+        const order: Array<string> = [];
+
+        const player = {
+            flushSave: async () => {
+                order.push('flush:start');
+                await new Promise((resolve) => setImmediate(resolve));
+                order.push('flush:done');
+            },
+            getCurrentPrivateShopOwner: () => null,
+        };
+
+        const world = { despawn: () => order.push('despawn') };
+        const privateShopService = { closePrivateShop: sinon.stub().resolves() };
+        const questManager = { onLogout: sinon.stub().resolves() };
+
+        const service = new LeaveGameService({
+            world: world as any,
+            privateShopService: privateShopService as any,
+            questManager: questManager as any,
+        } as any);
+
+        await service.execute(player as unknown as Player);
+
+        expect(order).to.deep.equal(['flush:start', 'flush:done', 'despawn']);
+    });
+});


### PR DESCRIPTION
Fixes #149. This is the follow-up offered in #143's description.

## The bug, mechanically

The only save on any exit route was the last line of `Player.onDespawn`, called from `Area.processDespawnQueue` as `entity.onDespawn();` with the promise discarded, one tick after `GameServer.onClose` had already resolved and torn the connection down. Nothing could observe the save or its failure — and the `/logout` countdown despawned the player twice, so the save ran twice.

## The fix

A port of the original's `FlushDelayedSave` + `m_bSkipSave` pair (`char.cpp:1353-1363`):

- `Player.flushSave()` runs the save and arms a `skipSave` gate; the saves in `onDespawn` and `save()` early-return once it is set. A failed write is logged with the stack interpolated — `SaveCharacterService` wraps its writes in `allSettled`, which never rejects, so `flushSave` inspects the results.
- `LeaveGameService` awaits `flushSave()` before `world.despawn()`, so the save completes inside the logout path and a failure reaches the existing `.catch` in `GameServer.onClose`.
- The countdown's `LOGOUT` and `QUIT` branches drop their direct `area.despawn` — the socket close already despawns through `LeaveGameService`. This is also the faithful shape: the original's `SCMD_QUIT` only sends the quit chat command and `SCMD_LOGOUT` only switches phase (`cmd_general.cpp:297-318`).

**Deliberately untouched:** `/goto` and `/phase_select` keep their deferred despawn saves. The original makes that split on purpose — `WarpSet` saves deferred (`Stop(); Save();`, `char.cpp:5250`) because the post-warp position must persist before the client reconnects. Routing `/phase_select` through the full leave path (the original does `Disconnect` then `SetPhase`, `cmd_general.cpp:310`) also has to clear `connection.player`, so it is offered separately in #149 rather than bundled here.

The failure policy on a rejected write is log-loudly-and-proceed, per the question in #149 — happy to change it if you prefer a retry.

## Verified

- 504 unit / 26 integration passing on the branch; the 23-branch combined tree (this + all 22 open PRs) builds clean and passes 651 unit.
- Fail-without-fix, run with only the src reverted to master:
  - the integration case fails with `no save may run after the player left the world: expected 2 to equal 0` — on master both `/logout` saves run after the player is removed from the world, and there are two of them. The spec classifies every repository update by whether the player was still in the world when it was issued, so it is deterministic and immune to the 120 s autosave.
  - the `LeaveGameService` unit spec fails with the despawn arriving before any save.
  - of the five `PlayerFlushSave` unit cases, **four fail only because `flushSave` does not exist**; the fifth (a teleport despawn keeps its deferred save) passes on master by design, as the regression guard for the split above.
- There is no end-to-end teleport-position spec because `/goto` cannot move a player on master until #113 lands (#88's `canTeleport` falls through) — the deferred-save guarantee is pinned at the unit level instead.

## Note on #140

This PR and #140 both touch the tail of `LeaveGameService.execute`, so whichever merges second hits a small conflict there. The combined resolution, verified in the 23-branch build (651 unit passing), keeps the original's order — quest logout before the save (`char.cpp:1340` runs before `:1353`):

```ts
await this.questManager.onLogout(player);

await player.flushSave();
this.world.despawn(player);
```

I can push that line to whichever branch is left after the first merge. #140's spec fake also gained an inert `flushSave` stub (pushed to that branch, which is also mine) so the suites stay green in either merge order.

## Note on scope

Pre-existing behaviour, on master since before #143; independent of #143 itself (no file overlap — that PR guards the despawn queue, this one moves the player save off it). The shutdown half of #149 — `World.close()`'s commented-out save loop — is left alone here and can be its own issue.
