### PR TITLE
docs: correct two field widths in the packet documentation

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -214,7 +214,7 @@
 | positionX | `int` | 4 | Position X of player in game |
 | positionY | `int` | 4 | Position Y of player in game |
 | Ip | `int` | 4 | Ip Address to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server). |
-| Port | `int` | 4 | Port to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server). |
+| Port | `short` | 2 | Port to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server). |
 | skillGroup | `byte` | 1 | Number which indicates the skill group of character (to be implemented). |
 | guildId | `int` | 4 | The guild id of current character |
 | guildName | `string` | 13 | The guild name of current character (ascii). |
@@ -259,7 +259,7 @@
 | Name        | Type       | Size (bytes)   | Description               |
 |-------------|------------|----------------|---------------------------|
 | header | `byte` | 1 | Packet header |
-| type | `byte` | 4 | type of fly. See in FlyEnum. |
+| type | `byte` | 1 | type of fly. See in FlyEnum. |
 | fromVirtualId | `number` | 4 | wich entity the fly starts |
 | toVirtualId | `number` | 4 | wich entity the fly ends |
 

--- a/src/core/interface/networking/packets/packet/out/CharactersInfoPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharactersInfoPacket.ts
@@ -46,7 +46,7 @@ type CharacterInfoParams = {
  *   - {int} positionX 4 Position X of player in game
  *   - {int} positionY 4 Position Y of player in game
  *   - {int} Ip 4 Ip Address to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server).
- *   - {int} Port 4 Port to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server).
+ *   - {short} Port 2 Port to server where the map the player is on is managed (for now we have only one server, but we can add remote maps to increase the quantity of players of our server).
  *   - {byte} skillGroup 1 Number which indicates the skill group of character (to be implemented).
  *   - {int} guildId 4 The guild id of current character
  *   - {string} guildName 13 The guild name of current character (ascii).

--- a/src/core/interface/networking/packets/packet/out/FlyPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/FlyPacket.ts
@@ -10,7 +10,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  * @description Used to send fly particle from entity to another.
  * @fields
  *   - {byte} header 1 Packet header
- *   - {byte} type 4 type of fly. See in FlyEnum.
+ *   - {byte} type 1 type of fly. See in FlyEnum.
  *   - {number} fromVirtualId 4 wich entity the fly starts
  *   - {number} toVirtualId 4 wich entity the fly ends
  */


### PR DESCRIPTION
Two field widths in the packet documentation disagreed with the code they document. `docs/packets.md` is generated from those docblocks, so the published protocol reference was wrong in both places.

## What was wrong

**`CharactersInfoPacket`** documented `Port` as `{int} 4`. The code writes `writeUint16LE` and the client struct has `WORD wPort`, so it is 2 bytes. With the wrong width the documented character slot summed to **65 bytes instead of 63**, and the packet no longer added up to its own declared `size: 329`. Corrected, the documented fields sum to exactly 63 per slot and `4*63 + 4*4 + 4*13 + 4 + 4 + 1 = 329`.

**`FlyPacket`** documented `type` as `{byte} 4`, which contradicts itself — a byte is 1, and the code writes `writeUint8`. Corrected to 1, the documented fields now sum to the declared `@size 10`.

## Why it is worth a PR

Someone outside the project is building a web-client bridge against a live open-mt2 server, and their commit records having had to work out that the character list packs 63 bytes per slot rather than the larger figure they had assumed. Our documentation is the only place that states a wrong size for that packet, so it is the plausible source. That is exactly the audience `docs/packets.md` exists for.

## What this is not

Documentation only. No behaviour change, no wire-format change, no test change: the two docblocks plus `docs/packets.md` regenerated with `npm run generate:doc`. The generated file is otherwise byte-identical — I checked before editing that regenerating on current master produces no diff, so the four changed lines are the whole story.

`docs/packets.md` is not run through Prettier by the project (`format` and `lint-staged` are scoped to `*.ts`), so it is left in the generator's formatting.

## Verified

`tsc` clean, 504 unit passing, `merge-tree` clean against all 22 open branches. Cut from `352eaa2f`.

## Adjacent, deliberately not in this PR

Auditing the docblocks for this turned up two out-packets whose declared buffer size exceeds what `pack()` writes, so they ship trailing zero bytes — `QuestTargetCreatePacket` (51 vs 43) and `ItemDroppedHidePacket` (21 vs 5). Those are a code issue rather than a documentation one and are filed separately as #152, which also asks whether you want a general guard for the class. Kept out of here so this stays a pure docs change.

Also noted while sweeping and not addressed: 32 of the 48 out-packets carry no `@packet` docblock at all, so roughly two-thirds of the outbound protocol is absent from `docs/packets.md`. That is real work rather than a drive-by, so I would rather offer it than smuggle it in — say the word if you want it and I will scope it properly.

