### PR TITLE
docs: document the remaining 35 out-packets and fix four wrong entries

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -17,6 +17,7 @@
 | header | `byte` | 1 | Packet header |
 | type | `int` | 4 | Apply type number. See in AffectTypeEnum |
 | apply | `byte` | 1 | Describe which point is affected by this affect. See in PointEnum |
+| value | `int` | 4 | The amount applied to the affected point |
 | flag | `int` | 4 | The bit flag of applies. See in AffectBitsTypeEnum |
 | duration | `int` | 4 | The duration in seconds of an affect |
 | manaCost | `int` | 4 | The mana cost of an affect |
@@ -179,7 +180,7 @@
 | Name        | Type       | Size (bytes)   | Description               |
 |-------------|------------|----------------|---------------------------|
 | header | `byte` | 1 | Packet header. |
-| points | `int[255]` | 4 | In this array we send the value of each point. |
+| points | `int[255]` | 1020 | In this array we send the value of each point. |
 
 ---
 
@@ -223,6 +224,161 @@
 
 ---
 
+### CharacterSpawnPacket
+
+**Type:** Out
+
+**Header:** 0x01
+
+**Size:** 35 bytes
+
+**Description:** Is used to spawn a character (player, mob, npc) on the client of nearby players. The affect flag is repeated 2x.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| vid | `int` | 4 | Character identification in game |
+| rotation | `float` | 4 | Rotation of character in degrees |
+| positionX | `int` | 4 | Position X of character in game |
+| positionY | `int` | 4 | Position Y of character in game |
+| positionZ | `int` | 4 | Position Z of character in game |
+| entityType | `byte` | 1 | Kind of entity being spawned (See in EntityTypeEnum) |
+| playerClass | `short` | 2 | Class of player, or vnum of the mob/npc |
+| movementSpeed | `byte` | 1 | Movement speed of character |
+| attackSpeed | `byte` | 1 | Attack speed of character |
+| state | `byte` | 1 | State flag of character |
+| affects | `int[2]` | 8 | Affect flags of character |
+
+---
+
+### CharacterUpdatePacket
+
+**Type:** Out
+
+**Header:** 0x13
+
+**Size:** 35 bytes
+
+**Description:** Is used to send the updated state of an already spawned character to nearby players. The equipment part is repeated 4x and the affect flag 2x.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| vid | `int` | 4 | Character identification in game |
+| parts | `short[4]` | 8 | Equipment parts (armor, weapon, head, hair) |
+| moveSpeed | `byte` | 1 | Movement speed of character |
+| attackSpeed | `byte` | 1 | Attack speed of character |
+| state | `byte` | 1 | State flag of character |
+| affects | `int[2]` | 8 | Affect flags of character |
+| guildId | `int` | 4 | Id of guild |
+| rankPoints | `short` | 2 | Rank points |
+| pkMode | `byte` | 1 | If pk is enable |
+| mountVnum | `int` | 4 | Vnum of mount |
+
+---
+
+### ChatOutPacket
+
+**Type:** Out
+
+**Header:** 0x04
+
+**Size:** 9 + message.length + 1 bytes
+
+**Description:** Is used to send a chat message to the client. This is a dynamic size packet: the 9 byte head is fixed and the message field grows with the text, so the documented sizes below are for an empty message.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| size | `short` | 2 | Total size of the packet in bytes |
+| messageType | `byte` | 1 | Kind of message being sent (See in ChatMessageTypeEnum) |
+| vid | `int` | 4 | Character identification in game of the sender |
+| empireId | `byte` | 1 | Id of empire |
+| message | `string` | 1 | Null terminated ascii message, message.length + 1 bytes wide (1 when empty) |
+
+---
+
+### ConnectionStatePacket
+
+**Type:** Out
+
+**Header:** 0xfd
+
+**Size:** 2 bytes
+
+**Description:** Is used to tell the client which phase the connection moved to. See in ConnectionStateEnum.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| state | `byte` | 1 | New phase of the connection |
+
+---
+
+### CreateCharacterFailurePacket
+
+**Type:** Out
+
+**Header:** 0x09
+
+**Size:** 2 bytes
+
+**Description:** Sent when the character creation request is refused, the client shows the matching error message on the select screen.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| reason | `byte` | 1 | Number which indicates why the creation failed (See CreateCharacterFailureReasonEnum). |
+
+---
+
+### CreateCharacterSuccessPacket
+
+**Type:** Out
+
+**Header:** 0x08
+
+**Size:** 65 bytes
+
+**Description:** Sent when the character creation succeeds, it carries the slot plus the same character block used by the characters list (one character only, not repeated).
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| slot | `byte` | 1 | Account character slot the new character was created on (0 to 3). |
+| id | `int` | 4 | Character identification in server. |
+| name | `string` | 25 | Name of character (ascii). |
+| playerClass | `byte` | 1 | Number which indicates the player class (See the number of each class in JobEnum). |
+| level | `byte` | 1 | Number which indicates the player level. |
+| playTime | `int` | 4 | Time the player played with this character in minutes. |
+| st | `byte` | 1 | Number which indicates the st point quantity (strength). |
+| ht | `byte` | 1 | Number which indicates the ht point quantity (vitality). |
+| dx | `byte` | 1 | Number which indicates the dx point quantity (dexterity). |
+| iq | `byte` | 1 | Number which indicates the iq point quantity (intelligence). |
+| bodyPart | `short` | 2 | Number which indicates the id of the body part. |
+| nameChange | `byte` | 1 | Number which indicates if that character need to change name (0 or 1). |
+| hairPart | `short` | 2 | Number which indicates the id of the hair part. |
+| unknown | `int` | 4 | filled with 0. |
+| positionX | `int` | 4 | Position X of player in game |
+| positionY | `int` | 4 | Position Y of player in game |
+| ip | `int` | 4 | Ip address of the server which manages the map the player is on. |
+| port | `short` | 2 | Port of the server which manages the map the player is on. |
+| skillGroup | `byte` | 1 | Number which indicates the skill group of character (to be implemented). |
+
+---
+
 ### DamagePacket
 
 **Type:** Out
@@ -241,6 +397,43 @@
 | virtualId | `number` | 4 | virtualId of the affected entity |
 | damageFlags | `byte` | 1 | indicates the flags of damage like: critical, pierced etc //TODO |
 | damage | `number` | 4 | the damage number |
+
+---
+
+### DeleteCharacterFailurePacket
+
+**Type:** Out
+
+**Header:** 0x0b
+
+**Size:** 1 bytes
+
+**Description:** Sent when the character deletion is refused, header only packet (GC_PLAYER_DELETE_WRONG_SOCIAL_ID), the client shows the wrong private code message.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+
+---
+
+### DeleteCharacterSuccessPacket
+
+**Type:** Out
+
+**Header:** 0x0a
+
+**Size:** 2 bytes
+
+**Description:** Tells the client the character in the given slot was deleted so it can clear the slot on the select screen.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| slot | `byte` | 1 | Account character slot that was cleared (0 to 3). |
 
 ---
 
@@ -287,11 +480,30 @@
 
 ---
 
+### GameTimePacket
+
+**Type:** Out
+
+**Header:** 0x6a
+
+**Size:** 5 bytes
+
+**Description:** Sends the current server time so the client can sync its own clock. Matches the client struct TPacketGCTime.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| time | `int` | 4 | Server time as a unix timestamp in seconds (client time_t) |
+
+---
+
 ### InternalPongPacket
 
 **Type:** Out
 
-**Header:** 253
+**Header:** 0xef
 
 **Size:** 5 bytes
 
@@ -303,6 +515,519 @@
 |-------------|------------|----------------|---------------------------|
 | header | `byte` | 1 | Packet header |
 | time | `int` | 4 | The time sent by client |
+
+---
+
+### ItemDroppedHidePacket
+
+**Type:** Out
+
+**Header:** 0x1b
+
+**Size:** 21 bytes
+
+**Description:** Tells the client to remove a dropped item from the ground. Only the 5 bytes listed below are written by pack(); the declared size of 21 makes the buffer 16 bytes longer than the payload, and those trailing bytes are sent as zeros. The client reads 5 bytes (TPacketGCItemGroundDel).
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| virtualId | `int` | 4 | Virtual id of the ground item to remove |
+
+---
+
+### ItemDroppedPacket
+
+**Type:** Out
+
+**Header:** 0x1a
+
+**Size:** 21 bytes
+
+**Description:** Tells the client to spawn a dropped item on the ground at the given position.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| positionX | `int` | 4 | Position X of the item on the ground |
+| positionY | `int` | 4 | Position Y of the item on the ground |
+| positionZ | `int` | 4 | Position Z of the item on the ground, always 0 |
+| virtualId | `int` | 4 | Virtual id assigned to the ground item |
+| id | `int` | 4 | Item vnum (prototype id) used to render the item |
+
+---
+
+### ItemPacket
+
+**Type:** Out
+
+**Header:** 0x15
+
+**Size:** 54 bytes
+
+**Description:** Sets an item into a client window cell (inventory, equipment, ...). The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| window | `byte` | 1 | Window the cell belongs to (See WindowTypeEnum) |
+| position | `short` | 2 | Cell position inside the window |
+| id | `int` | 4 | Item vnum (prototype id) |
+| count | `byte` | 1 | Stack size of the item |
+| flags | `int` | 4 | Item flags, currently always sent as 0 |
+| antiFlags | `int` | 4 | Item anti flags, currently always sent as 0 |
+| highlight | `int` | 4 | Non zero highlights the cell in the client, currently always sent as 0 |
+| sockets | `int[3]` | 12 | Metin socket values, 3 slots of 4 bytes |
+| bonusId | `byte` | 1 | Attribute type of the bonus slot, repeated 7x |
+| bonusValue | `short` | 2 | Attribute value of the bonus slot, repeated 7x |
+
+---
+
+### ItemUsePacket
+
+**Type:** Out
+
+**Header:** 0x0b
+
+**Size:** 4 bytes
+
+**Description:** Sends the use of an item at a given window cell.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| window | `byte` | 1 | Window the cell belongs to (See WindowTypeEnum) |
+| position | `short` | 2 | Cell position inside the window |
+
+---
+
+### LoginFailedPacket
+
+**Type:** Out
+
+**Header:** 0x07
+
+**Size:** 10 bytes
+
+**Description:** Sent when the credentials are refused, the status text is the key the client uses to pick the error message (See LoginStatusEnum).
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| status | `string` | 9 | Status text, null terminated and zero padded, max 8 ascii characters (ex: WRONGPWD, ALREADY). |
+
+---
+
+### LoginSuccessPacket
+
+**Type:** Out
+
+**Header:** 0x96
+
+**Size:** 6 bytes
+
+**Description:** Sent when the credentials are accepted, it carries the login key the client sends back on the game connection.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| key | `int` | 4 | Login key generated for this authentication, the client echoes it on the token packet. |
+| result | `byte` | 1 | Number which indicates the authentication result (1 means success, 0 makes the client show a key failure). |
+
+---
+
+### PingPacket
+
+**Type:** Out
+
+**Header:** 0x2c
+
+**Size:** 1 bytes
+
+**Description:** Keepalive ping (GC_PING, header 44) sent periodically to every connection; the client answers with CG_PONG (header 254). Header-only packet, matches the client struct TPacketGCPing.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+
+---
+
+### QuestInfoPacket
+
+**Type:** Out
+
+**Header:** 0x51
+
+**Size:** 105 bytes
+
+**Description:** Used to send the state of a quest to the client quest window. The 6 byte head is always written, every field after the flag byte is optional and is only written when its bit is set in the flag, so the packet on the wire is between 6 and 105 bytes. The widths below are the maximum case, with every optional field present.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| size | `short` | 2 | Total size in bytes of this packet |
+| id | `short` | 2 | Index of the quest this info belongs to |
+| flags | `byte` | 1 | Bitmask telling which of the optional fields below follow. See QuestFlagEnum. |
+| wasStarted | `byte` | 1 | Optional (ISBEGIN). 1 when the quest begins, 0 when it ends. |
+| title | `string` | 31 | Optional (TITLE). Quest title (ascii). |
+| clockName | `string` | 17 | Optional (CLOCK_NAME). Label of the quest clock (ascii). |
+| clockValue | `int` | 4 | Optional (CLOCK_VALUE). Value shown in the quest clock. |
+| counterName | `string` | 17 | Optional (COUNTER_NAME). Label of the quest counter (ascii). |
+| counterValue | `int` | 4 | Optional (COUNTER_VALUE). Value shown in the quest counter. |
+| iconFile | `string` | 25 | Optional (ICON_FILE). File name of the quest icon (ascii). |
+
+---
+
+### QuestScriptPacket
+
+**Type:** Out
+
+**Header:** 0x2d
+
+**Size:** 6 + srcSize bytes
+
+**Description:** Used to send a quest script (the text and buttons of a quest dialog) to the client. The size is dynamic: a fixed 6 byte head followed by srcSize raw script bytes, so the packet is 6 + srcSize bytes. The script is not zero terminated on the wire, the client appends the terminator itself.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| size | `short` | 2 | Total size in bytes of this packet (6 + srcSize) |
+| skin | `byte` | 1 | Quest dialog skin the client should render with |
+| srcSize | `short` | 2 | Length in bytes of the script that follows |
+| src | `string` | 0 | Quest script source. Variable length, srcSize bytes, so no fixed width applies. |
+
+---
+
+### QuestTargetCreatePacket
+
+**Type:** Out
+
+**Header:** 0x7d
+
+**Size:** 51 bytes
+
+**Description:** Used to create a quest target on the client minimap and, when the target is a character, the target effect in the world. pack() writes only the 43 bytes listed below, while the buffer is declared as 51 bytes, so 8 trailing zero bytes follow the type field.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| id | `int` | 4 | Identifier of the target, reused later to update or remove it |
+| targetName | `string` | 33 | Name of the target (ascii) |
+| targetVirtualId | `int` | 4 | Virtual id of the entity the target is attached to |
+| type | `byte` | 1 | Kind of target: 0 none, 1 location, 2 character |
+
+---
+
+### QuestTargetRemovePacket
+
+**Type:** Out
+
+**Header:** 0x7c
+
+**Size:** 5 bytes
+
+**Description:** Used to remove a quest target from the client minimap and drop its target effect.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| id | `int` | 4 | Identifier of the target to remove, the same one sent in QuestTargetCreatePacket |
+
+---
+
+### QuickSlotAddResponsePacket
+
+**Type:** Out
+
+**Header:** 0x1c
+
+**Size:** 4 bytes
+
+**Description:** Used to confirm to the client that a quick slot was filled.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| slot | `byte` | 1 | Quick slot position that was filled |
+| type | `byte` | 1 | Kind of entry placed in the slot. See QuickSlotTypeEnum. |
+| position | `byte` | 1 | Position of the item or skill inside its own container |
+
+---
+
+### QuickSlotRemoveResponsePacket
+
+**Type:** Out
+
+**Header:** 0x1d
+
+**Size:** 2 bytes
+
+**Description:** Used to confirm to the client that a quick slot was cleared.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| slot | `byte` | 1 | Quick slot position that was cleared |
+
+---
+
+### QuickSlotSwapResponsePacket
+
+**Type:** Out
+
+**Header:** 0x1e
+
+**Size:** 3 bytes
+
+**Description:** Used to confirm to the client that the content of two quick slots was swapped.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| slotA | `byte` | 1 | First quick slot position of the swap |
+| slotB | `byte` | 1 | Second quick slot position of the swap |
+
+---
+
+### RemoveCharacterPacket
+
+**Type:** Out
+
+**Header:** 0x02
+
+**Size:** 5 bytes
+
+**Description:** Is used to despawn a character (player, mob, npc) from the client of nearby players.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| vid | `int` | 4 | Character identification in game |
+
+---
+
+### ServerStatusPacket
+
+**Type:** Out
+
+**Header:** 0xd2
+
+**Size:** 9 bytes
+
+**Description:** Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the declared size of 9 only fits the default single channel.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| size | `int` | 4 | Value produced by calcSize(), 6 + 3 per channel. See notes, the client reads this as a channel count |
+| port | `short` | 2 | Channel port. Repeated once per channel entry |
+| status | `byte` | 1 | Channel status flag, 1 means online. Repeated once per channel entry |
+| isSuccess | `byte` | 1 | Trailing success flag written after the channel entries. The client never reads it |
+
+---
+
+### SetItemOwnershipPacket
+
+**Type:** Out
+
+**Header:** 0x1f
+
+**Size:** 30 bytes
+
+**Description:** Marks a dropped ground item as owned by a player, so only that player may loot it while the ownership lasts. Matches the client struct TPacketGCItemOwnership.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| virtualId | `int` | 4 | Virtual id of the ground item the ownership applies to |
+| ownerName | `string` | 25 | Name of the owning player (ascii, null terminated), empty clears the ownership |
+
+---
+
+### SetSkillGroupPacket
+
+**Type:** Out
+
+**Header:** 0x70
+
+**Size:** 2 bytes
+
+**Description:** Tells the client which skill group (skill tree branch) the character has chosen. Matches the client struct TPacketGCChangeSkillGroup.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| skillGroup | `byte` | 1 | Selected skill group, 0 means no group chosen yet |
+
+---
+
+### ShopEndPacket
+
+**Type:** Out
+
+**Header:** 0x26
+
+**Size:** 4 bytes
+
+**Description:** Is used to tell the client to close the shop window. Matches TPacketGCShop with subheader SHOP_SUBHEADER_GC_END (1).
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header. |
+| size | `short` | 2 | Total packet size in bytes, including the header. |
+| subheader | `byte` | 1 | Shop subheader, always END (1). See ShopSubHeaderGC. |
+
+---
+
+### ShopResultPacket
+
+**Type:** Out
+
+**Header:** 0x26
+
+**Size:** 4 bytes
+
+**Description:** Is used to send the outcome of a shop operation to the client. Matches TPacketGCShop, the subheader carries the result code.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header. |
+| size | `short` | 2 | Total packet size in bytes, including the header. |
+| subheader | `byte` | 1 | Result code: OK (4), NOT_ENOUGH_MONEY (5), INVENTORY_FULL (7), INVALID_POS (8), SOLD_OUT (9). See ShopSubHeaderGC. |
+
+---
+
+### ShopSignPacket
+
+**Type:** Out
+
+**Header:** 0x27
+
+**Size:** 38 bytes
+
+**Description:** Is used to show or hide the private shop sign above a player. An empty sign string tells the client the shop is closed. Matches SPacketGCShopSign.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header. |
+| ownerVid | `int` | 4 | Virtual id of the player owning the private shop. |
+| sign | `string` | 33 | Shop sign text (ascii), at most 32 chars plus a null terminator. |
+
+---
+
+### ShopStartPacket
+
+**Type:** Out
+
+**Header:** 0x26
+
+**Size:** 1728 bytes
+
+**Description:** Is used to open the shop window with its full item grid (we need to repeat the item block 40x, empty slots are sent zeroed). Matches TPacketGCShop + owner vid + TPacketGCShopStart.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header. |
+| size | `short` | 2 | Total packet size in bytes, including the header. |
+| subheader | `byte` | 1 | Shop subheader, always START (0). See ShopSubHeaderGC. |
+| ownerVid | `int` | 4 | Virtual id of the shop owner (npc or player). |
+| vnum | `int` | 4 | Item vnum of this shop slot, 0 when the slot is empty. |
+| price | `int` | 4 | Price of the item in yang. |
+| count | `byte` | 1 | Item stack count. |
+| displayPos | `byte` | 1 | Slot position of the item inside the shop grid. |
+| sockets | `int[3]` | 12 | Three socket values, always 0 for shop items. |
+| bonuses | `bonus[7]` | 21 | Seven attribute slots, each one a {byte} id plus a {short} value, always 0 for shop items. |
+
+---
+
+### ShopUpdateItemPacket
+
+**Type:** Out
+
+**Header:** 0x26
+
+**Size:** 48 bytes
+
+**Description:** Is used to refresh a single slot of an already open shop window. Matches TPacketGCShop + TPacketGCShopUpdateItem.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header. |
+| size | `short` | 2 | Total packet size in bytes, including the header. |
+| subheader | `byte` | 1 | Shop subheader, always UPDATE_ITEM (2). See ShopSubHeaderGC. |
+| pos | `byte` | 1 | Slot position being updated. |
+| vnum | `int` | 4 | Item vnum of the slot, 0 when the slot became empty. |
+| price | `int` | 4 | Price of the item in yang. |
+| count | `byte` | 1 | Item stack count. |
+| displayPos | `byte` | 1 | Slot position of the item inside the shop grid, same value as pos. |
+| sockets | `int[3]` | 12 | Three socket values, always 0 for shop items. |
+| bonuses | `bonus[7]` | 21 | Seven attribute slots, each one a {byte} id plus a {short} value, always 0 for shop items. |
+
+---
+
+### SkillLevelPacket
+
+**Type:** Out
+
+**Header:** 0x4c
+
+**Size:** 1531 bytes
+
+**Description:** Sends the level of every skill slot to the client; the 6 byte skill entry (masterType, level, nextReadTime) repeats SKILL_MAX_NUM = 255 times, so 1 + 255 * 6 = 1531 bytes. Matches the client struct TPacketGCSkillLevelNew with TPlayerSkill entries.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| masterType | `byte` | 1 | Mastery stage of the skill, always 0 here. Repeated 255 times as part of the skill entry |
+| level | `byte` | 1 | Current level of the skill, clamped to 0-255. Repeated 255 times as part of the skill entry |
+| nextReadTime | `int` | 4 | Timestamp when the skill book may be read again, always 0 here. Repeated 255 times as part of the skill entry |
 
 ---
 
@@ -367,7 +1092,7 @@
 
 ---
 
-### TargetUpdatedPacket
+### TargetUpdatePacket
 
 **Type:** Out
 
@@ -384,6 +1109,52 @@
 | header | `byte` | 1 | Packet header |
 | virtualId | `number` | 4 | virtualId of the target entity |
 | healthPercentage | `byte` | 1 | indicates the percent of target entity health |
+
+---
+
+### TeleportPacket
+
+**Type:** Out
+
+**Header:** 0x41
+
+**Size:** 15 bytes
+
+**Description:** Is used to warp the player to another position, reconnecting it to the game server that owns the destination.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| positionX | `int` | 4 | Destination position X in game |
+| positionY | `int` | 4 | Destination position Y in game |
+| address | `int` | 4 | Address of the destination game server |
+| port | `short` | 2 | Port of the destination game server |
+
+---
+
+### UpdateItemPacket
+
+**Type:** Out
+
+**Header:** 0x19
+
+**Size:** 38 bytes
+
+**Description:** Updates the stack count, sockets and bonuses of an item already set in a client window cell. The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
+
+**Fields:**
+
+| Name        | Type       | Size (bytes)   | Description               |
+|-------------|------------|----------------|---------------------------|
+| header | `byte` | 1 | Packet header |
+| window | `byte` | 1 | Window the cell belongs to (See WindowTypeEnum) |
+| position | `short` | 2 | Cell position inside the window |
+| count | `byte` | 1 | New stack size of the item |
+| sockets | `int[3]` | 12 | Metin socket values, 3 slots of 4 bytes |
+| bonusId | `byte` | 1 | Attribute type of the bonus slot, repeated 7x |
+| bonusValue | `short` | 2 | Attribute value of the bonus slot, repeated 7x |
 
 ---
 

--- a/src/core/interface/networking/packets/packet/out/AffectAddPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/AffectAddPacket.ts
@@ -12,6 +12,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  *   - {byte} header 1 Packet header
  *   - {int} type 4 Apply type number. See in AffectTypeEnum
  *   - {byte} apply 1 Describe which point is affected by this affect. See in PointEnum
+ *   - {int} value 4 The amount applied to the affected point
  *   - {int} flag 4 The bit flag of applies. See in AffectBitsTypeEnum
  *   - {int} duration 4 The duration in seconds of an affect
  *   - {int} manaCost 4 The mana cost of an affect

--- a/src/core/interface/networking/packets/packet/out/CharacterPointsPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharacterPointsPacket.ts
@@ -10,7 +10,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  * @description Is used to send update of all the points (attributes) of a character to the client. See all points in PointsEnum.
  * @fields
  *   - {byte} header 1 Packet header.
- *   - {int[255]} points 4 In this array we send the value of each point.
+ *   - {int[255]} points 1020 In this array we send the value of each point.
  */
 
 export default class CharacterPointsPacket extends PacketOut {

--- a/src/core/interface/networking/packets/packet/out/CharacterSpawnPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharacterSpawnPacket.ts
@@ -1,6 +1,28 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name CharacterSpawnPacket
+ * @header 0x01
+ * @size 35
+ * @description Is used to spawn a character (player, mob, npc) on the client of nearby players. The affect flag is repeated 2x.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} vid 4 Character identification in game
+ *   - {float} rotation 4 Rotation of character in degrees
+ *   - {int} positionX 4 Position X of character in game
+ *   - {int} positionY 4 Position Y of character in game
+ *   - {int} positionZ 4 Position Z of character in game
+ *   - {byte} entityType 1 Kind of entity being spawned (See in EntityTypeEnum)
+ *   - {short} playerClass 2 Class of player, or vnum of the mob/npc
+ *   - {byte} movementSpeed 1 Movement speed of character
+ *   - {byte} attackSpeed 1 Attack speed of character
+ *   - {byte} state 1 State flag of character
+ *   - {int[2]} affects 8 Affect flags of character
+ */
+
 export default class CharacterSpawnPacket extends PacketOut {
     private readonly vid: number;
     private readonly rotation: number = 0;

--- a/src/core/interface/networking/packets/packet/out/CharacterUpdatePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharacterUpdatePacket.ts
@@ -1,6 +1,27 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name CharacterUpdatePacket
+ * @header 0x13
+ * @size 35
+ * @description Is used to send the updated state of an already spawned character to nearby players. The equipment part is repeated 4x and the affect flag 2x.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} vid 4 Character identification in game
+ *   - {short[4]} parts 8 Equipment parts (armor, weapon, head, hair)
+ *   - {byte} moveSpeed 1 Movement speed of character
+ *   - {byte} attackSpeed 1 Attack speed of character
+ *   - {byte} state 1 State flag of character
+ *   - {int[2]} affects 8 Affect flags of character
+ *   - {int} guildId 4 Id of guild
+ *   - {short} rankPoints 2 Rank points
+ *   - {byte} pkMode 1 If pk is enable
+ *   - {int} mountVnum 4 Vnum of mount
+ */
+
 export default class CharacterUpdatePacket extends PacketOut {
     private readonly vid: number;
     private readonly parts: Array<number> = new Array(4).fill(0);

--- a/src/core/interface/networking/packets/packet/out/ChatOutPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ChatOutPacket.ts
@@ -1,6 +1,22 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name ChatOutPacket
+ * @header 0x04
+ * @size 9 + message.length + 1
+ * @description Is used to send a chat message to the client. This is a dynamic size packet: the 9 byte head is fixed and the message field grows with the text, so the documented sizes below are for an empty message.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {short} size 2 Total size of the packet in bytes
+ *   - {byte} messageType 1 Kind of message being sent (See in ChatMessageTypeEnum)
+ *   - {int} vid 4 Character identification in game of the sender
+ *   - {byte} empireId 1 Id of empire
+ *   - {string} message 1 Null terminated ascii message, message.length + 1 bytes wide (1 when empty)
+ */
+
 export default class ChatOutPacket extends PacketOut {
     private readonly messageType: number;
     private readonly message: string;

--- a/src/core/interface/networking/packets/packet/out/ConnectionStatePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ConnectionStatePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name ConnectionStatePacket
+ * @header 0xfd
+ * @size 2
+ * @description Is used to tell the client which phase the connection moved to. See in ConnectionStateEnum.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} state 1 New phase of the connection
+ */
+
 export default class ConnectionStatePacket extends PacketOut {
     private readonly state: number;
 

--- a/src/core/interface/networking/packets/packet/out/CreateCharacterFailurePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CreateCharacterFailurePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name CreateCharacterFailurePacket
+ * @header 0x09
+ * @size 2
+ * @description Sent when the character creation request is refused, the client shows the matching error message on the select screen.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} reason 1 Number which indicates why the creation failed (See CreateCharacterFailureReasonEnum).
+ */
+
 export default class CreateCharacterFailurePacket extends PacketOut {
     private readonly reason: number;
 

--- a/src/core/interface/networking/packets/packet/out/CreateCharacterSuccessPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CreateCharacterSuccessPacket.ts
@@ -41,6 +41,36 @@ const defaultCharacterInfo: CharacterParams = {
     skillGroup: 0,
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name CreateCharacterSuccessPacket
+ * @header 0x08
+ * @size 65
+ * @description Sent when the character creation succeeds, it carries the slot plus the same character block used by the characters list (one character only, not repeated).
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} slot 1 Account character slot the new character was created on (0 to 3).
+ *   - {int} id 4 Character identification in server.
+ *   - {string} name 25 Name of character (ascii).
+ *   - {byte} playerClass 1 Number which indicates the player class (See the number of each class in JobEnum).
+ *   - {byte} level 1 Number which indicates the player level.
+ *   - {int} playTime 4 Time the player played with this character in minutes.
+ *   - {byte} st 1 Number which indicates the st point quantity (strength).
+ *   - {byte} ht 1 Number which indicates the ht point quantity (vitality).
+ *   - {byte} dx 1 Number which indicates the dx point quantity (dexterity).
+ *   - {byte} iq 1 Number which indicates the iq point quantity (intelligence).
+ *   - {short} bodyPart 2 Number which indicates the id of the body part.
+ *   - {byte} nameChange 1 Number which indicates if that character need to change name (0 or 1).
+ *   - {short} hairPart 2 Number which indicates the id of the hair part.
+ *   - {int} unknown 4 filled with 0.
+ *   - {int} positionX 4 Position X of player in game
+ *   - {int} positionY 4 Position Y of player in game
+ *   - {int} ip 4 Ip address of the server which manages the map the player is on.
+ *   - {short} port 2 Port of the server which manages the map the player is on.
+ *   - {byte} skillGroup 1 Number which indicates the skill group of character (to be implemented).
+ */
+
 export default class CreateCharacterSuccessPacket extends PacketOut {
     private readonly slot: number;
     private readonly character: CharacterParams;

--- a/src/core/interface/networking/packets/packet/out/DeleteCharacterFailurePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/DeleteCharacterFailurePacket.ts
@@ -2,9 +2,16 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
 /**
- * GC_CHARACTER_DELETE_WRONG_SOCIAL_ID (header 11) — header-only packet; the
- * client shows the "wrong private code" message.
+ * @packet
+ * @type Out
+ * @name DeleteCharacterFailurePacket
+ * @header 0x0b
+ * @size 1
+ * @description Sent when the character deletion is refused, header only packet (GC_PLAYER_DELETE_WRONG_SOCIAL_ID), the client shows the wrong private code message.
+ * @fields
+ *   - {byte} header 1 Packet header
  */
+
 export default class DeleteCharacterFailurePacket extends PacketOut {
     constructor() {
         super({

--- a/src/core/interface/networking/packets/packet/out/DeleteCharacterSuccessPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/DeleteCharacterSuccessPacket.ts
@@ -2,9 +2,17 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
 /**
- * GC_CHARACTER_DELETE_SUCCESS (header 10) — tells the client the character
- * in the given slot was deleted so it can clear the slot on screen.
+ * @packet
+ * @type Out
+ * @name DeleteCharacterSuccessPacket
+ * @header 0x0a
+ * @size 2
+ * @description Tells the client the character in the given slot was deleted so it can clear the slot on the select screen.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} slot 1 Account character slot that was cleared (0 to 3).
  */
+
 export default class DeleteCharacterSuccessPacket extends PacketOut {
     private readonly slot: number;
 

--- a/src/core/interface/networking/packets/packet/out/GameTimePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/GameTimePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name GameTimePacket
+ * @header 0x6a
+ * @size 5
+ * @description Sends the current server time so the client can sync its own clock. Matches the client struct TPacketGCTime.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} time 4 Server time as a unix timestamp in seconds (client time_t)
+ */
+
 export default class GameTimePacket extends PacketOut {
     private readonly time: number;
 

--- a/src/core/interface/networking/packets/packet/out/InternalPongPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/InternalPongPacket.ts
@@ -5,7 +5,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  * @packet
  * @type Out
  * @name InternalPongPacket
- * @header 253
+ * @header 0xef
  * @size 5
  * @description Used to internal pong.
  * @fields

--- a/src/core/interface/networking/packets/packet/out/ItemDroppedHidePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ItemDroppedHidePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name ItemDroppedHidePacket
+ * @header 0x1b
+ * @size 21
+ * @description Tells the client to remove a dropped item from the ground. Only the 5 bytes listed below are written by pack(); the declared size of 21 makes the buffer 16 bytes longer than the payload, and those trailing bytes are sent as zeros. The client reads 5 bytes (TPacketGCItemGroundDel).
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} virtualId 4 Virtual id of the ground item to remove
+ */
+
 export default class ItemDroppedHidePacket extends PacketOut {
     private readonly virtualId: number;
 

--- a/src/core/interface/networking/packets/packet/out/ItemDroppedPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ItemDroppedPacket.ts
@@ -1,6 +1,22 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name ItemDroppedPacket
+ * @header 0x1a
+ * @size 21
+ * @description Tells the client to spawn a dropped item on the ground at the given position.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} positionX 4 Position X of the item on the ground
+ *   - {int} positionY 4 Position Y of the item on the ground
+ *   - {int} positionZ 4 Position Z of the item on the ground, always 0
+ *   - {int} virtualId 4 Virtual id assigned to the ground item
+ *   - {int} id 4 Item vnum (prototype id) used to render the item
+ */
+
 export default class ItemDroppedPacket extends PacketOut {
     private readonly positionX: number;
     private readonly positionY: number;

--- a/src/core/interface/networking/packets/packet/out/ItemPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ItemPacket.ts
@@ -10,6 +10,27 @@ class ItemBonus {
     }
 }
 
+/**
+ * @packet
+ * @type Out
+ * @name ItemPacket
+ * @header 0x15
+ * @size 54
+ * @description Sets an item into a client window cell (inventory, equipment, ...). The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} window 1 Window the cell belongs to (See WindowTypeEnum)
+ *   - {short} position 2 Cell position inside the window
+ *   - {int} id 4 Item vnum (prototype id)
+ *   - {byte} count 1 Stack size of the item
+ *   - {int} flags 4 Item flags, currently always sent as 0
+ *   - {int} antiFlags 4 Item anti flags, currently always sent as 0
+ *   - {int} highlight 4 Non zero highlights the cell in the client, currently always sent as 0
+ *   - {int[3]} sockets 12 Metin socket values, 3 slots of 4 bytes
+ *   - {byte} bonusId 1 Attribute type of the bonus slot, repeated 7x
+ *   - {short} bonusValue 2 Attribute value of the bonus slot, repeated 7x
+ */
+
 export default class ItemPacket extends PacketOut {
     private readonly window: number;
     private readonly position: number;

--- a/src/core/interface/networking/packets/packet/out/ItemUsePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ItemUsePacket.ts
@@ -3,6 +3,19 @@ import PacketOut from './PacketOut';
 
 const PACKET_SIZE = 4;
 
+/**
+ * @packet
+ * @type Out
+ * @name ItemUsePacket
+ * @header 0x0b
+ * @size 4
+ * @description Sends the use of an item at a given window cell.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} window 1 Window the cell belongs to (See WindowTypeEnum)
+ *   - {short} position 2 Cell position inside the window
+ */
+
 export default class ItemUsePacket extends PacketOut {
     private readonly window: number;
     private readonly position: number;

--- a/src/core/interface/networking/packets/packet/out/LoginFailedPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/LoginFailedPacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name LoginFailedPacket
+ * @header 0x07
+ * @size 10
+ * @description Sent when the credentials are refused, the status text is the key the client uses to pick the error message (See LoginStatusEnum).
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {string} status 9 Status text, null terminated and zero padded, max 8 ascii characters (ex: WRONGPWD, ALREADY).
+ */
+
 export default class LoginFailedPacket extends PacketOut {
     private readonly status: string;
 

--- a/src/core/interface/networking/packets/packet/out/LoginSuccessPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/LoginSuccessPacket.ts
@@ -1,6 +1,19 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name LoginSuccessPacket
+ * @header 0x96
+ * @size 6
+ * @description Sent when the credentials are accepted, it carries the login key the client sends back on the game connection.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} key 4 Login key generated for this authentication, the client echoes it on the token packet.
+ *   - {byte} result 1 Number which indicates the authentication result (1 means success, 0 makes the client show a key failure).
+ */
+
 export default class LoginSuccessPacket extends PacketOut {
     private readonly key: number;
     private readonly result: number;

--- a/src/core/interface/networking/packets/packet/out/PingPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/PingPacket.ts
@@ -2,9 +2,16 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
 /**
- * Keepalive ping (GC_PING, header 44) sent periodically to every connection.
- * The client answers with CG_PONG (header 254). Header-only packet.
+ * @packet
+ * @type Out
+ * @name PingPacket
+ * @header 0x2c
+ * @size 1
+ * @description Keepalive ping (GC_PING, header 44) sent periodically to every connection; the client answers with CG_PONG (header 254). Header-only packet, matches the client struct TPacketGCPing.
+ * @fields
+ *   - {byte} header 1 Packet header
  */
+
 export default class PingPacket extends PacketOut {
     constructor() {
         super({

--- a/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestInfoPacket.ts
@@ -29,6 +29,27 @@ const COUNTER_NAME_SIZE = 17;
 const ICON_FILE_SIZE = 25;
 const INT_SIZE = 4;
 
+/**
+ * @packet
+ * @type Out
+ * @name QuestInfoPacket
+ * @header 0x51
+ * @size 105
+ * @description Used to send the state of a quest to the client quest window. The 6 byte head is always written, every field after the flag byte is optional and is only written when its bit is set in the flag, so the packet on the wire is between 6 and 105 bytes. The widths below are the maximum case, with every optional field present.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {short} size 2 Total size in bytes of this packet
+ *   - {short} id 2 Index of the quest this info belongs to
+ *   - {byte} flags 1 Bitmask telling which of the optional fields below follow. See QuestFlagEnum.
+ *   - {byte} wasStarted 1 Optional (ISBEGIN). 1 when the quest begins, 0 when it ends.
+ *   - {string} title 31 Optional (TITLE). Quest title (ascii).
+ *   - {string} clockName 17 Optional (CLOCK_NAME). Label of the quest clock (ascii).
+ *   - {int} clockValue 4 Optional (CLOCK_VALUE). Value shown in the quest clock.
+ *   - {string} counterName 17 Optional (COUNTER_NAME). Label of the quest counter (ascii).
+ *   - {int} counterValue 4 Optional (COUNTER_VALUE). Value shown in the quest counter.
+ *   - {string} iconFile 25 Optional (ICON_FILE). File name of the quest icon (ascii).
+ */
+
 export default class QuestInfoPacket extends PacketOut {
     private readonly id: number;
     private readonly flags: number;

--- a/src/core/interface/networking/packets/packet/out/QuestScriptPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestScriptPacket.ts
@@ -6,6 +6,21 @@ type QuestScriptPacketParams = {
     src: string;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name QuestScriptPacket
+ * @header 0x2d
+ * @size 6 + srcSize
+ * @description Used to send a quest script (the text and buttons of a quest dialog) to the client. The size is dynamic: a fixed 6 byte head followed by srcSize raw script bytes, so the packet is 6 + srcSize bytes. The script is not zero terminated on the wire, the client appends the terminator itself.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {short} size 2 Total size in bytes of this packet (6 + srcSize)
+ *   - {byte} skin 1 Quest dialog skin the client should render with
+ *   - {short} srcSize 2 Length in bytes of the script that follows
+ *   - {string} src 0 Quest script source. Variable length, srcSize bytes, so no fixed width applies.
+ */
+
 export default class QuestScriptPacket extends PacketOut {
     private readonly totalSize: number;
     private readonly skin: number;

--- a/src/core/interface/networking/packets/packet/out/QuestTargetCreatePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestTargetCreatePacket.ts
@@ -1,6 +1,21 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name QuestTargetCreatePacket
+ * @header 0x7d
+ * @size 51
+ * @description Used to create a quest target on the client minimap and, when the target is a character, the target effect in the world. pack() writes only the 43 bytes listed below, while the buffer is declared as 51 bytes, so 8 trailing zero bytes follow the type field.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} id 4 Identifier of the target, reused later to update or remove it
+ *   - {string} targetName 33 Name of the target (ascii)
+ *   - {int} targetVirtualId 4 Virtual id of the entity the target is attached to
+ *   - {byte} type 1 Kind of target: 0 none, 1 location, 2 character
+ */
+
 export default class QuestTargetCreatePacket extends PacketOut {
     private readonly id: number;
     private readonly targetName: string;

--- a/src/core/interface/networking/packets/packet/out/QuestTargetRemovePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuestTargetRemovePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name QuestTargetRemovePacket
+ * @header 0x7c
+ * @size 5
+ * @description Used to remove a quest target from the client minimap and drop its target effect.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} id 4 Identifier of the target to remove, the same one sent in QuestTargetCreatePacket
+ */
+
 export default class QuestTargetRemovePacket extends PacketOut {
     private readonly id: number;
 

--- a/src/core/interface/networking/packets/packet/out/QuickSlotAddResponsePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuickSlotAddResponsePacket.ts
@@ -2,6 +2,20 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import { QuickSlotTypeEnum } from '@/core/enum/QuickSlotTypeEnum';
 import PacketOut from './PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name QuickSlotAddResponsePacket
+ * @header 0x1c
+ * @size 4
+ * @description Used to confirm to the client that a quick slot was filled.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} slot 1 Quick slot position that was filled
+ *   - {byte} type 1 Kind of entry placed in the slot. See QuickSlotTypeEnum.
+ *   - {byte} position 1 Position of the item or skill inside its own container
+ */
+
 export default class QuickSlotAddResponsePacket extends PacketOut {
     private readonly slot: number;
     private readonly type: QuickSlotTypeEnum;

--- a/src/core/interface/networking/packets/packet/out/QuickSlotRemoveResponsePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuickSlotRemoveResponsePacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from './PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name QuickSlotRemoveResponsePacket
+ * @header 0x1d
+ * @size 2
+ * @description Used to confirm to the client that a quick slot was cleared.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} slot 1 Quick slot position that was cleared
+ */
+
 export default class QuickSlotRemoveResponsePacket extends PacketOut {
     private readonly slot: number;
 

--- a/src/core/interface/networking/packets/packet/out/QuickSlotSwapResponsePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/QuickSlotSwapResponsePacket.ts
@@ -1,6 +1,19 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from './PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name QuickSlotSwapResponsePacket
+ * @header 0x1e
+ * @size 3
+ * @description Used to confirm to the client that the content of two quick slots was swapped.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} slotA 1 First quick slot position of the swap
+ *   - {byte} slotB 1 Second quick slot position of the swap
+ */
+
 export default class QuickSlotSwapResponsePacket extends PacketOut {
     private readonly slotA: number;
     private readonly slotB: number;

--- a/src/core/interface/networking/packets/packet/out/RemoveCharacterPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/RemoveCharacterPacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name RemoveCharacterPacket
+ * @header 0x02
+ * @size 5
+ * @description Is used to despawn a character (player, mob, npc) from the client of nearby players.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} vid 4 Character identification in game
+ */
+
 export default class RemoveCharacterPacket extends PacketOut {
     private readonly vid: number;
 

--- a/src/core/interface/networking/packets/packet/out/ServerStatusPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ServerStatusPacket.ts
@@ -9,6 +9,21 @@ type ServerStatusPacketParams = {
     isSuccess?: boolean;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name ServerStatusPacket
+ * @header 0xd2
+ * @size 9
+ * @description Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the declared size of 9 only fits the default single channel.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} size 4 Value produced by calcSize(), 6 + 3 per channel. See notes, the client reads this as a channel count
+ *   - {short} port 2 Channel port. Repeated once per channel entry
+ *   - {byte} status 1 Channel status flag, 1 means online. Repeated once per channel entry
+ *   - {byte} isSuccess 1 Trailing success flag written after the channel entries. The client never reads it
+ */
+
 export default class ServerStatusPacket extends PacketOut {
     private readonly status: Array<{
         port: number;

--- a/src/core/interface/networking/packets/packet/out/SetItemOwnershipPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/SetItemOwnershipPacket.ts
@@ -3,6 +3,19 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
 
 const PLAYER_NAME_MAX_LENGTH = 25;
 
+/**
+ * @packet
+ * @type Out
+ * @name SetItemOwnershipPacket
+ * @header 0x1f
+ * @size 30
+ * @description Marks a dropped ground item as owned by a player, so only that player may loot it while the ownership lasts. Matches the client struct TPacketGCItemOwnership.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} virtualId 4 Virtual id of the ground item the ownership applies to
+ *   - {string} ownerName 25 Name of the owning player (ascii, null terminated), empty clears the ownership
+ */
+
 export default class SetItemOwnershipPacket extends PacketOut {
     private readonly virtualId: number;
     private readonly ownerName: string;

--- a/src/core/interface/networking/packets/packet/out/SetSkillGroupPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/SetSkillGroupPacket.ts
@@ -1,6 +1,18 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name SetSkillGroupPacket
+ * @header 0x70
+ * @size 2
+ * @description Tells the client which skill group (skill tree branch) the character has chosen. Matches the client struct TPacketGCChangeSkillGroup.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} skillGroup 1 Selected skill group, 0 means no group chosen yet
+ */
+
 export default class SetSkillGroupPacket extends PacketOut {
     private readonly skillGroup: number;
 

--- a/src/core/interface/networking/packets/packet/out/ShopEndPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopEndPacket.ts
@@ -4,6 +4,19 @@ import { ShopSubHeaderGC } from '@/core/enum/ShopSubHeaderEnum';
 
 const PACKET_SIZE = 4;
 
+/**
+ * @packet
+ * @type Out
+ * @name ShopEndPacket
+ * @header 0x26
+ * @size 4
+ * @description Is used to tell the client to close the shop window. Matches TPacketGCShop with subheader SHOP_SUBHEADER_GC_END (1).
+ * @fields
+ *   - {byte} header 1 Packet header.
+ *   - {short} size 2 Total packet size in bytes, including the header.
+ *   - {byte} subheader 1 Shop subheader, always END (1). See ShopSubHeaderGC.
+ */
+
 export default class ShopEndPacket extends PacketOut {
     constructor() {
         super({ header: PacketHeaderEnum.SHOP_OUT, size: PACKET_SIZE, name: 'ShopEndPacket' });

--- a/src/core/interface/networking/packets/packet/out/ShopResultPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopResultPacket.ts
@@ -8,6 +8,19 @@ export type ShopResultPacketParams = {
     result: ShopSubHeaderGC;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name ShopResultPacket
+ * @header 0x26
+ * @size 4
+ * @description Is used to send the outcome of a shop operation to the client. Matches TPacketGCShop, the subheader carries the result code.
+ * @fields
+ *   - {byte} header 1 Packet header.
+ *   - {short} size 2 Total packet size in bytes, including the header.
+ *   - {byte} subheader 1 Result code: OK (4), NOT_ENOUGH_MONEY (5), INVENTORY_FULL (7), INVALID_POS (8), SOLD_OUT (9). See ShopSubHeaderGC.
+ */
+
 export default class ShopResultPacket extends PacketOut {
     private readonly result: ShopSubHeaderGC;
 

--- a/src/core/interface/networking/packets/packet/out/ShopSignPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopSignPacket.ts
@@ -11,6 +11,19 @@ export type ShopSignPacketParams = {
     sign: string;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name ShopSignPacket
+ * @header 0x27
+ * @size 38
+ * @description Is used to show or hide the private shop sign above a player. An empty sign string tells the client the shop is closed. Matches SPacketGCShopSign.
+ * @fields
+ *   - {byte} header 1 Packet header.
+ *   - {int} ownerVid 4 Virtual id of the player owning the private shop.
+ *   - {string} sign 33 Shop sign text (ascii), at most 32 chars plus a null terminator.
+ */
+
 export default class ShopSignPacket extends PacketOut {
     private readonly ownerVid: number;
     private readonly sign: string;

--- a/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopStartPacket.ts
@@ -14,6 +14,26 @@ export type ShopStartPacketParams = {
     items: Array<ShopItem | undefined>;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name ShopStartPacket
+ * @header 0x26
+ * @size 1728
+ * @description Is used to open the shop window with its full item grid (we need to repeat the item block 40x, empty slots are sent zeroed). Matches TPacketGCShop + owner vid + TPacketGCShopStart.
+ * @fields
+ *   - {byte} header 1 Packet header.
+ *   - {short} size 2 Total packet size in bytes, including the header.
+ *   - {byte} subheader 1 Shop subheader, always START (0). See ShopSubHeaderGC.
+ *   - {int} ownerVid 4 Virtual id of the shop owner (npc or player).
+ *   - {int} vnum 4 Item vnum of this shop slot, 0 when the slot is empty.
+ *   - {int} price 4 Price of the item in yang.
+ *   - {byte} count 1 Item stack count.
+ *   - {byte} displayPos 1 Slot position of the item inside the shop grid.
+ *   - {int[3]} sockets 12 Three socket values, always 0 for shop items.
+ *   - {bonus[7]} bonuses 21 Seven attribute slots, each one a {byte} id plus a {short} value, always 0 for shop items.
+ */
+
 export default class ShopStartPacket extends PacketOut {
     private readonly ownerVid: number;
     private readonly items: Array<ShopItem | undefined>;

--- a/src/core/interface/networking/packets/packet/out/ShopUpdateItemPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ShopUpdateItemPacket.ts
@@ -14,6 +14,26 @@ export type ShopUpdateItemParams = {
     count?: number;
 };
 
+/**
+ * @packet
+ * @type Out
+ * @name ShopUpdateItemPacket
+ * @header 0x26
+ * @size 48
+ * @description Is used to refresh a single slot of an already open shop window. Matches TPacketGCShop + TPacketGCShopUpdateItem.
+ * @fields
+ *   - {byte} header 1 Packet header.
+ *   - {short} size 2 Total packet size in bytes, including the header.
+ *   - {byte} subheader 1 Shop subheader, always UPDATE_ITEM (2). See ShopSubHeaderGC.
+ *   - {byte} pos 1 Slot position being updated.
+ *   - {int} vnum 4 Item vnum of the slot, 0 when the slot became empty.
+ *   - {int} price 4 Price of the item in yang.
+ *   - {byte} count 1 Item stack count.
+ *   - {byte} displayPos 1 Slot position of the item inside the shop grid, same value as pos.
+ *   - {int[3]} sockets 12 Three socket values, always 0 for shop items.
+ *   - {bonus[7]} bonuses 21 Seven attribute slots, each one a {byte} id plus a {short} value, always 0 for shop items.
+ */
+
 export default class ShopUpdateItemPacket extends PacketOut {
     private readonly pos: number;
     private readonly vnum: number;

--- a/src/core/interface/networking/packets/packet/out/SkillLevelPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/SkillLevelPacket.ts
@@ -4,6 +4,20 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
 const PLAYER_SKILL_SIZE = 6;
 const SKILL_MAX_NUM = 255;
 
+/**
+ * @packet
+ * @type Out
+ * @name SkillLevelPacket
+ * @header 0x4c
+ * @size 1531
+ * @description Sends the level of every skill slot to the client; the 6 byte skill entry (masterType, level, nextReadTime) repeats SKILL_MAX_NUM = 255 times, so 1 + 255 * 6 = 1531 bytes. Matches the client struct TPacketGCSkillLevelNew with TPlayerSkill entries.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} masterType 1 Mastery stage of the skill, always 0 here. Repeated 255 times as part of the skill entry
+ *   - {byte} level 1 Current level of the skill, clamped to 0-255. Repeated 255 times as part of the skill entry
+ *   - {int} nextReadTime 4 Timestamp when the skill book may be read again, always 0 here. Repeated 255 times as part of the skill entry
+ */
+
 export default class SkillLevelPacket extends PacketOut {
     private readonly skills: Array<{
         rank: number;

--- a/src/core/interface/networking/packets/packet/out/TargetUpdatePacket.ts
+++ b/src/core/interface/networking/packets/packet/out/TargetUpdatePacket.ts
@@ -4,7 +4,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
 /**
  * @packet
  * @type Out
- * @name TargetUpdatedPacket
+ * @name TargetUpdatePacket
  * @header 0x3f
  * @size 6
  * @description Used to send the target to client.

--- a/src/core/interface/networking/packets/packet/out/TeleportPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/TeleportPacket.ts
@@ -1,6 +1,21 @@
 import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut';
 
+/**
+ * @packet
+ * @type Out
+ * @name TeleportPacket
+ * @header 0x41
+ * @size 15
+ * @description Is used to warp the player to another position, reconnecting it to the game server that owns the destination.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {int} positionX 4 Destination position X in game
+ *   - {int} positionY 4 Destination position Y in game
+ *   - {int} address 4 Address of the destination game server
+ *   - {short} port 2 Port of the destination game server
+ */
+
 export default class TeleportPacket extends PacketOut {
     private readonly positionX: number;
     private readonly positionY: number;

--- a/src/core/interface/networking/packets/packet/out/UpdateItemPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/UpdateItemPacket.ts
@@ -10,6 +10,23 @@ class ItemBonus {
     }
 }
 
+/**
+ * @packet
+ * @type Out
+ * @name UpdateItemPacket
+ * @header 0x19
+ * @size 38
+ * @description Updates the stack count, sockets and bonuses of an item already set in a client window cell. The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
+ * @fields
+ *   - {byte} header 1 Packet header
+ *   - {byte} window 1 Window the cell belongs to (See WindowTypeEnum)
+ *   - {short} position 2 Cell position inside the window
+ *   - {byte} count 1 New stack size of the item
+ *   - {int[3]} sockets 12 Metin socket values, 3 slots of 4 bytes
+ *   - {byte} bonusId 1 Attribute type of the bonus slot, repeated 7x
+ *   - {short} bonusValue 2 Attribute value of the bonus slot, repeated 7x
+ */
+
 export default class UpdateItemPacket extends PacketOut {
     private readonly window: number;
     private readonly position: number;


### PR DESCRIPTION
`docs/packets.md` is generated from `@packet` docblocks, and only **16 of the 51 out-packets** had one — so two thirds of the outbound protocol was missing from the published reference. This adds the 35 that were absent and corrects four entries that were wrong in the ones already there. The generated file goes from 16 sections to 51.

## How the docblocks were written

Each one comes from the packet's own `pack()` sequence, then cross-checked against the matching struct in the client's `Packet.h`, which is under `#pragma pack(1)` so a struct size is the plain sum of its fields. Where a packet writes a repeated group — shop slots, skill entries, item bonus slots — the group is documented once and the repeat count stated in the description, which is how `CharactersInfoPacket` already documents its four character slots.

## The four corrections

- **`AffectAddPacket`** omitted the `value` field entirely. Its documented fields summed to 18 against a declared size of 22, and everything after `apply` was described at the wrong offset — the worst kind of error for anyone parsing from the docs.
- **`CharacterPointsPacket`** documented its 255-entry point array as 4 bytes rather than 1020, so the fields summed to 5 against a size of 1021.
- **`InternalPongPacket`** documented header 253; the enum value is 239 (`0xef`).
- **`TargetUpdatePacket`** documented itself as `TargetUpdatedPacket`, so the generated section carried a name that matches no file.

## Two discrepancies stated rather than smoothed over

`ItemDroppedHidePacket` and `QuestTargetCreatePacket` both declare a buffer larger than `pack()` fills, so they ship trailing zero bytes. Their field lists describe what is actually written and the descriptions explain the gap. The defect itself is tracked in #152 and deliberately not fixed here, so this stays a documentation change.

`SyncPositionPacket` was left alone on purpose: its `size` field is documented as 2 bytes, which is exactly what `writeUint16LE` produces, even though the `{number}` token is used elsewhere for 4-byte fields. The number is right, so I did not touch it.

## Verified

`tsc` clean, 504 unit passing, and no executable code changed — the diff is docblocks plus `docs/packets.md` regenerated with `npm run generate:doc`. I also re-ran a check over every out-packet afterwards comparing each documented width against what the code writes, the `@header` against the enum entry, and the `@name` against the file name; the only remaining differences are the repeat-group convention above and the two tracked in #152.

## Merge note

This conflicts with #111 in `docs/packets.md` only — that PR adds `FlyTargetingPacket`, and both regenerate the same file. The resolution is one command: take either side and run `npm run generate:doc`. I built the pair locally to check, and the regenerated file comes out at 52 sections with `FlyTargetingPacket` present and `tsc` clean. Happy to push that to whichever branch is left after the first merge.

It also overlaps #153 conceptually — that one fixes two field widths in `FlyPacket` and `CharactersInfoPacket`. No file conflict, but if #153 lands first this branch wants a regenerate so the two corrections appear in the generated file too. Same one command, and I will send it.
