### PR TITLE
fix(drop): roll the drop tables instead of handing out guaranteed items (fix #157)

### DIFF
--- a/src/core/domain/manager/DropManager.ts
+++ b/src/core/domain/manager/DropManager.ts
@@ -9,6 +9,7 @@ import ItemManager from './ItemManager';
 import Player from '../entities/game/player/Player';
 import { PrivilegeManager, PrivilegeTypeEnum } from './PrivilegeManager';
 import { PointsEnum } from '@/core/enum/PointsEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
 
 class DropItem {
     public readonly item: Item;
@@ -41,9 +42,10 @@ export default class DropManager {
     }
 
     load() {
-        Object.keys(this.config.commonDrops).forEach((rank) => {
-            const rankEnum = rank as unknown as MobRankEnum;
-            this.commonDrops.set(rankEnum, this.config.commonDrops[rankEnum]);
+        Object.entries(this.config.commonDrops).forEach(([rank, drops]) => {
+            const rankEnum = MobRankEnum[rank as keyof typeof MobRankEnum];
+            if (rankEnum === undefined) return;
+            this.commonDrops.set(rankEnum, drops);
         });
     }
 
@@ -64,6 +66,12 @@ export default class DropManager {
             if (percent >= target) {
                 const item = this.itemManager.getItem(drop.vnum);
                 if (!item) continue;
+
+                if (item.getType() === ItemTypeEnum.ITEM_POLYMORPH) {
+                    if (drop.vnum !== monster.getPolymorphItem()) continue;
+                    item.setSocket0(monster.getId());
+                }
+
                 drops.push(new DropItem(item, 1));
             }
         }
@@ -88,8 +96,8 @@ export default class DropManager {
 
         let delta =
             monster.getRank() === MobRankEnum.BOSS
-                ? this.config.dropDeltaBoss[MathUtil.minMax(0, levelDelta, this.config.dropDeltaBoss.length)]
-                : this.config.dropDeltaLevel[MathUtil.minMax(0, levelDelta, this.config.dropDeltaLevel.length)];
+                ? this.config.dropDeltaBoss[MathUtil.minMax(0, levelDelta, this.config.dropDeltaBoss.length - 1)]
+                : this.config.dropDeltaLevel[MathUtil.minMax(0, levelDelta, this.config.dropDeltaLevel.length - 1)];
 
         if (1 === MathUtil.getRandomInt(1, 50_000)) {
             delta += 1000;
@@ -123,13 +131,15 @@ export default class DropManager {
         let percent =
             (goldPercent *
                 (monster.getRank() === MobRankEnum.BOSS
-                    ? this.config.dropDeltaBoss[MathUtil.minMax(0, levelDelta, this.config.dropDeltaBoss.length)]
-                    : this.config.dropDeltaLevel[MathUtil.minMax(0, levelDelta, this.config.dropDeltaLevel.length)])) /
+                    ? this.config.dropDeltaBoss[MathUtil.minMax(0, levelDelta, this.config.dropDeltaBoss.length - 1)]
+                    : this.config.dropDeltaLevel[
+                          MathUtil.minMax(0, levelDelta, this.config.dropDeltaLevel.length - 1)
+                      ])) /
             100;
 
         percent += this.privilegeManager.getEmpirePrivilege(player.getEmpire(), PrivilegeTypeEnum.GOLD);
         percent += this.privilegeManager.getPlayerPrivilege(player, PrivilegeTypeEnum.GOLD);
-        percent = Math.max(100, percent);
+        percent = Math.min(100, percent);
 
         if (MathUtil.getRandomInt(1, 100) > percent) return null;
 
@@ -216,11 +226,6 @@ export default class DropManager {
         if (goldDrop) {
             drops.push(goldDrop);
         }
-
-        const item = this.itemManager.getItem(70104);
-        if (!item) return drops;
-        item.setSocket0(monster.getId());
-        drops.push(new DropItem(item, 1));
 
         return drops;
     }

--- a/test/unit/core/domain/manager/DropManager.test.ts
+++ b/test/unit/core/domain/manager/DropManager.test.ts
@@ -1,0 +1,195 @@
+import { expect } from 'chai';
+import DropManager from '@/core/domain/manager/DropManager';
+import { MobRankEnum } from '@/core/enum/MobRankEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
+
+const POLYMORPH_VNUM = 70104;
+const OTHER_POLYMORPH_VNUM = 70105;
+const PLAIN_VNUM = 27001;
+
+const makeItem = (vnum: number, type: ItemTypeEnum) => {
+    let socket0 = 0;
+    return {
+        getType: () => type,
+        setSocket0: (value: number) => (socket0 = value),
+        getSocket0: () => socket0,
+        getVnum: () => vnum,
+    };
+};
+
+const makeConfig = (commonDrops: Record<string, Array<unknown>>) => ({
+    commonDrops,
+    dropDeltaLevel: Array.from({ length: 31 }, (_unused, i) => i * 10),
+    dropDeltaBoss: Array.from({ length: 31 }, (_unused, i) => i * 10),
+    dropGoldByRank: { [MobRankEnum.PAWN]: 20, [MobRankEnum.KNIGHT]: 25 },
+    PERCENT_TO_MULT_GOLD_BY_50: 0,
+    PERCENT_TO_MULT_GOLD_BY_10: 0,
+    PERCENT_TO_MULT_GOLD_BY_5: 0,
+});
+
+const makeManager = (commonDrops: Record<string, Array<unknown>> = {}) =>
+    new DropManager({
+        config: makeConfig(commonDrops) as any,
+        itemManager: {
+            getItem: (vnum: number) =>
+                makeItem(
+                    vnum,
+                    vnum === POLYMORPH_VNUM || vnum === OTHER_POLYMORPH_VNUM
+                        ? ItemTypeEnum.ITEM_POLYMORPH
+                        : ItemTypeEnum.ITEM_USE,
+                ),
+        } as any,
+        privilegeManager: {
+            getEmpirePrivilege: () => 0,
+            getPlayerPrivilege: () => 0,
+        } as any,
+    });
+
+const makePlayer = (level = 30) =>
+    ({
+        getLevel: () => level,
+        getPoint: () => 0,
+        getEmpire: () => 1,
+        isEquippedWithUniqueItem: () => false,
+    }) as any;
+
+const makeMonster = ({
+    rank = MobRankEnum.PAWN,
+    level = 30,
+    polymorphItem = 0,
+    vnum = 101,
+}: { rank?: MobRankEnum; level?: number; polymorphItem?: number; vnum?: number } = {}) =>
+    ({
+        getRank: () => rank,
+        getLevel: () => level,
+        getId: () => vnum,
+        getPolymorphItem: () => polymorphItem,
+        getDropItem: () => 0,
+        getGoldMin: () => 10,
+        getGoldMax: () => 20,
+    }) as any;
+
+describe('DropManager', () => {
+    describe('common drop table lookup (issue #157)', () => {
+        it('should find the table for a rank whose enum value is 0', () => {
+            const manager = makeManager({ PAWN: [{ minLevel: 1, maxLevel: 99, percentage: 400, vnum: PLAIN_VNUM }] });
+            manager.load();
+
+            const drops = manager.getCommonDrops(makePlayer(), makeMonster({ rank: MobRankEnum.PAWN }), 100_000_000, 1);
+
+            expect(drops, 'the PAWN table must be reachable by the numeric rank').to.have.lengthOf(1);
+        });
+
+        it('should find the table for a non-zero rank too', () => {
+            const manager = makeManager({
+                KNIGHT: [{ minLevel: 1, maxLevel: 99, percentage: 400, vnum: PLAIN_VNUM }],
+            });
+            manager.load();
+
+            const drops = manager.getCommonDrops(
+                makePlayer(),
+                makeMonster({ rank: MobRankEnum.KNIGHT }),
+                100_000_000,
+                1,
+            );
+
+            expect(drops).to.have.lengthOf(1);
+        });
+
+        it('should ignore a rank name the enum does not know', () => {
+            const manager = makeManager({ NOT_A_RANK: [{ minLevel: 1, maxLevel: 99, percentage: 400, vnum: 1 }] });
+
+            expect(() => manager.load()).to.not.throw();
+        });
+    });
+
+    describe('polymorph marble (issue #157)', () => {
+        const table = { PAWN: [{ minLevel: 1, maxLevel: 99, percentage: 400, vnum: POLYMORPH_VNUM }] };
+
+        it('should drop the marble only when it matches the monster, and stamp its vnum', () => {
+            const manager = makeManager(table);
+            manager.load();
+
+            const drops = manager.getCommonDrops(
+                makePlayer(),
+                makeMonster({ polymorphItem: POLYMORPH_VNUM, vnum: 101 }),
+                100_000_000,
+                1,
+            );
+
+            expect(drops).to.have.lengthOf(1);
+            expect((drops[0].item as any).getSocket0(), 'socket 0 carries the monster vnum').to.equal(101);
+        });
+
+        it('should not drop a marble the monster does not yield', () => {
+            const manager = makeManager(table);
+            manager.load();
+
+            const drops = manager.getCommonDrops(
+                makePlayer(),
+                makeMonster({ polymorphItem: OTHER_POLYMORPH_VNUM }),
+                100_000_000,
+                1,
+            );
+
+            expect(drops, 'the table entry is 70104 but this monster yields 70105').to.have.lengthOf(0);
+        });
+
+        it('should not drop a marble for a monster that yields none', () => {
+            const manager = makeManager(table);
+            manager.load();
+
+            const drops = manager.getCommonDrops(makePlayer(), makeMonster({ polymorphItem: 0 }), 100_000_000, 1);
+
+            expect(drops).to.have.lengthOf(0);
+        });
+
+        it('should not append a marble outside the drop table', () => {
+            const manager = makeManager({});
+            manager.load();
+
+            const drops = manager.getDrops(makePlayer(), makeMonster({ polymorphItem: POLYMORPH_VNUM }));
+
+            expect(
+                drops.filter((drop) => (drop.item as any).getType() === ItemTypeEnum.ITEM_POLYMORPH),
+                'the marble must come from the table, not from getDrops itself',
+            ).to.have.lengthOf(0);
+        });
+    });
+
+    describe('gold drop chance (issue #157)', () => {
+        it('should refuse the gold drop when the computed chance is 0', () => {
+            const manager = makeManager();
+            const monster = makeMonster({ rank: MobRankEnum.PAWN, level: 1 });
+
+            const gold = manager.getGoldDrop(makePlayer(30), monster);
+
+            expect(gold, 'levelDelta -14 clamps to index 0, so the chance is 0 and must not pay out').to.equal(null);
+        });
+
+        it('should not turn a small chance into a certainty', () => {
+            const manager = makeManager();
+            const monster = makeMonster({ rank: MobRankEnum.PAWN, level: 1 });
+
+            const results = Array.from({ length: 200 }, () => manager.getGoldDrop(makePlayer(30), monster));
+
+            expect(
+                results.every((r) => r === null),
+                'Math.max(100, percent) made every kill pay gold',
+            ).to.be.true;
+        });
+    });
+
+    describe('level delta table bounds (issue #157)', () => {
+        it('should stay inside the table for a monster far above the player', () => {
+            const manager = makeManager();
+            const { delta } = manager.calcDropPercent(makePlayer(1), makeMonster({ level: 90 }));
+
+            expect(
+                Number.isNaN(delta),
+                'levelDelta 104 is far past the 31-entry table; an out-of-bounds index yields undefined and poisons the maths',
+            ).to.be.false;
+            expect(delta).to.be.a('number');
+        });
+    });
+});


### PR DESCRIPTION
Fixes #157.

Four defects in `DropManager`, which runs on every monster death via `Monster.reward` (`Monster.ts:235`).

## The common drop table was unreachable

`load()` filled the map with the **string** keys of `common_drops.json` (`"PAWN"`, `"S_PAWN"`, …) while `getCommonDrops` looked it up with the **numeric** `MobRankEnum` that `Mob.rank` holds, so every lookup missed and the method returned empty at `:54`. **202 table entries** — 54 PAWN, 55 S_PAWN, 53 KNIGHT, 40 S_KNIGHT — could never fire.

`load()` now resolves each name through `MobRankEnum` and skips a name the enum does not know. The `dropGoldByRank` table beside it was already keyed by the numeric enum, which is what hid the asymmetry.

## Gold dropped on 100% of kills

`percent = Math.max(100, percent)` is a floor, so `getRandomInt(1, 100)` could never exceed it. The original applies a **ceiling** at the same point (`char_battle.cpp:572-573`). Now `Math.min`.

## The Polymorph Marble dropped on every kill

`getDrops` appended a hardcoded vnum 70104 with no roll and no check that the monster yields it.

The original produces the marble as an ordinary common-drop entry, subject to the same `iPercent >= number(1, iRandRange)` roll as anything else, and **only when the entry's vnum matches that monster's own polymorph item**, stamping socket 0 with the monster's race (`item_manager.cpp:876-887`).

Our data supports exactly that, which I checked before writing the gate rather than inventing a rule:

- `common_drops.json` already carries a 70104 entry per rank (400 / 4M, levels 10-120);
- **250 protos declare a `polymorph_item`** of 70104, 70105, 70106 or 70107;
- `Mob` already exposes `getPolymorphItem()` (`Mob.ts:471`).

So the unconditional push is gone and the gate lives in `getCommonDrops`, where the original has it. The socket value was already correct — `Monster.getId()` is the proto vnum (`Mob.ts:192`), matching the original's `GetRaceNum()`.

## The level-delta index was clamped one past the end

`MathUtil.minMax(0, levelDelta, table.length)` at four sites, on 31-entry tables. A monster 16+ levels above the player read `table[31]`, got `undefined`, and turned every percentage into `NaN`. Now `length - 1`.

The same expression is at `ExperienceManager.ts:28` with `expDeltaLevel`. I left it out to keep this PR to one file — happy to send it as a one-liner separately, or fold it in here if you would rather have it in one go.

## The one thing I did not fix, because it is your call

`getDefaultMonsterDrop` still hands out the proto's `drop_item` on every kill, with no roll.

While checking what the original does with that field I found it does **nothing**: `GetDropItemVnum` (`char.cpp:1998`) has **zero callers** — the field is read into the struct and printed in one startup log line, and that is all. Per-mob drops in the original come from `mob_drop_item.txt` → `m_map_pkDropItemGroup`, which we do not have.

So there are two honest options and they differ in intent, not in correctness:

1. **Delete it** — faithful to the original, but 245 protos stop dropping their item entirely.
2. **Keep it as our stand-in for `mob_drop_item.txt`** and give it a rate — but there is no rate anywhere in our data, so the number would be invented.

I would rather ask than pick. Say which and I will send it.

## Verified

Against `352eaa2f`. **7 of the 10 new cases fail without the fix**, one per defect.

The other 3 are negative controls ("a marble the monster does not yield must not drop", "a monster with no polymorph item gets none", "an unknown rank name is ignored"). They also pass on master — but **vacuously**, because nothing drops there at all. They are only meaningful once the table lookup works, so I am not counting them as evidence.

514 unit passing; the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115, which is not part of this branch. `tsc`, `eslint`, `prettier` clean.

## Note on scope

Pre-existing. Two siblings from the same audit are filed separately because they live in other files: #158 (`getRandomInt` draws one byte, so every roll here has 256 possible outcomes) and #159 (`Mob.rank` falls back with `||`, so 197 PAWN monsters are ranked KNIGHT).

**#159 matters for this one.** Its bug is invisible today, but the moment this PR makes the table lookup work, those 197 monsters start reading the KNIGHT table. Landing #159 first, or together, avoids that window. Neither blocks this PR from being correct on its own terms.
