### PR TITLE
fix(util): draw a uniform random integer instead of scaling one byte (fix #158)

### DIFF
--- a/src/core/domain/util/MathUtil.ts
+++ b/src/core/domain/util/MathUtil.ts
@@ -35,11 +35,12 @@ export default class MathUtil {
     }
 
     static getRandomInt(min: number, max: number) {
-        const randomBytes = crypto.randomBytes(1);
-        const randomInt = randomBytes[0];
-        const range = max - min + 1;
-        const adjustedInt = Math.floor((randomInt / 256) * range) + min;
-        return adjustedInt;
+        const lower = Math.ceil(min);
+        const upper = Math.floor(max);
+
+        if (!Number.isFinite(lower) || !Number.isFinite(upper) || upper <= lower) return lower;
+
+        return crypto.randomInt(lower, upper + 1);
     }
 
     static calcRotationFromXY(x: number, y: number) {

--- a/test/unit/core/domain/util/MathUtil.test.ts
+++ b/test/unit/core/domain/util/MathUtil.test.ts
@@ -45,4 +45,50 @@ describe('MathUtil', () => {
         expect(randomInt).to.be.at.least(min);
         expect(randomInt).to.be.at.most(max);
     });
+
+    describe('getRandomInt over a wide range (issue #158)', () => {
+        it('should reach more than 256 distinct values', () => {
+            const seen = new Set<number>();
+            for (let i = 0; i < 4000; i++) seen.add(MathUtil.getRandomInt(1, 50_000));
+
+            expect(seen.size, 'a single byte can only produce 256 outcomes').to.be.greaterThan(256);
+        });
+
+        it('should not turn a 1-in-50000 chance into 1-in-256', () => {
+            let hits = 0;
+            for (let i = 0; i < 20_000; i++) if (MathUtil.getRandomInt(1, 50_000) === 1) hits++;
+
+            expect(hits, 'a one-byte draw would hit about 78 times in 20000').to.be.lessThan(10);
+        });
+
+        it('should produce values that are not all multiples of range/256', () => {
+            const step = Math.floor(4_000_001 / 256);
+            let offGrid = 0;
+            for (let i = 0; i < 500; i++) if ((MathUtil.getRandomInt(1, 4_000_001) - 1) % step !== 0) offGrid++;
+
+            expect(offGrid, 'a scaled byte can only land on the grid').to.be.greaterThan(400);
+        });
+    });
+
+    describe('getRandomInt bounds (issue #158)', () => {
+        it('should accept a non-integer max, as the drop range is', () => {
+            const range = (4_000_000 * 100) / 103;
+
+            expect(() => MathUtil.getRandomInt(1, range + 1)).to.not.throw();
+            expect(MathUtil.getRandomInt(1, range + 1)).to.be.at.most(Math.floor(range + 1));
+        });
+
+        it('should return min when the range is empty or inverted', () => {
+            expect(MathUtil.getRandomInt(5, 5)).to.equal(5);
+            expect(MathUtil.getRandomInt(5, 3)).to.equal(5);
+        });
+
+        it('should still honour a negative range', () => {
+            for (let i = 0; i < 200; i++) {
+                const value = MathUtil.getRandomInt(-90, 90);
+                expect(value).to.be.at.least(-90);
+                expect(value).to.be.at.most(90);
+            }
+        });
+    });
 });


### PR DESCRIPTION
Fixes #158.

`getRandomInt` drew a single byte and scaled it, so any range had at most 256 possible outcomes and every outcome was a multiple of `range / 256`. The wider the range, the worse it got.

Measured by enumerating all 256 byte values: `getRandomInt(1, 50_000)` returned one of 256 values, the lowest three being 1, 196 and 391, and `=== 1` came up **1 time in 256** rather than 1 in 50000.

## Why it mattered

`DropManager.calcDropPercent` rolls `getRandomInt(1, 50_000)` and `getRandomInt(1, 10_000)` for the `+1000` and `+500` delta jackpots, mirroring `item_manager.cpp:809-811`. Both fired at 1/256 — roughly 195 times too often for the first — and each one multiplies every drop rate for that kill.

`getCommonDrops` rolls against a range of about four million, where the lowest reachable value above 1 is 15626. Any table entry whose computed percentage reached 1 therefore passed whenever the byte was zero: a flat **1/256 floor on every entry**, regardless of its configured rate. The three gold multiplier rolls (caps 50000, 10000, 5000) have the same shape.

Narrow ranges were biased rather than broken. `getRandomInt(1, 100)` does cover 1..100, but 256 bytes over 100 buckets means some values are drawn three times and others twice, so the most likely value was 50% more likely than the least. That is the form used by most combat rolls — block, dodge, critical, penetrate, poison, stun, slow. Fixing the helper fixes all 49 call sites at once.

## The fix

`crypto.randomInt` is uniform and rejects the biased tail internally.

Two behaviours of the old implementation had to be preserved explicitly, because `crypto.randomInt` throws where the old code silently coped. I found both by trying the naive one-line swap first, so they are worth calling out:

**Non-integer bounds.** `calcDropPercent` computes its range as `(4_000_000 * 100) / (100 + bonuses)`, which is fractional for any drop bonus other than 0 or 100 — with a 3% bonus it is `3883495.145…` — and `getCommonDrops` passes `range + 1` straight in. A bare `crypto.randomInt(1, range + 1)` throws `The "max" argument must be a safe integer`. So any player with a drop bonus would have crashed the kill path. The bounds are now ceiled and floored before the draw.

**Empty and inverted ranges.** The old code returned `min` for `max === min`, but could return `min - 1` for an inverted range, which does not look deliberate. Both now return `min`.

```ts
static getRandomInt(min: number, max: number) {
    const lower = Math.ceil(min);
    const upper = Math.floor(max);

    if (!Number.isFinite(lower) || !Number.isFinite(upper) || upper <= lower) return lower;

    return crypto.randomInt(lower, upper + 1);
}
```

I checked the two call sites whose range comes from data rather than a literal, and neither can reach the degenerate case today: no proto in `mobs.json` has `gold_max < gold_min`, the 581 protos with both at 0 map to `randomInt(0, 1)` which is valid, and no proto has level 0, so `getRandomInt(1, level * 50)` is always at least 50 wide.

## Verified

Against `352eaa2f`. **4 of the 6 new cases fail without the fix**: the distinct-value count, the 1-in-50000 frequency, the off-grid check, and the inverted-range return.

The other 2 are regression guards for the two preserved behaviours above and pass either way by design — I am not counting them as evidence of the bug.

510 unit passing; the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115. `tsc`, `eslint`, `prettier` clean.

## Note on scope

Pre-existing. Two siblings from the same audit are filed separately and touch different files: #157 (the drop pipeline these rolls feed) and #159 (the monster rank that selects its tables). All three merge cleanly together — I built the combined tree: `tsc` clean, 528 unit passing.

This one is independent and can land in any order. It is the only one of the three that also touches combat, and I have deliberately not claimed a gameplay consequence there — I measured the bias, not its effect on play.
