### PR TITLE
fix(battle): clear the battle affects on death instead of leaking them (fix #163)

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -17,6 +17,7 @@ import { QuestManager } from '../../quests/QuestManager';
 import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
 import { MovementTypeEnum } from '@/core/enum/MovementTypeEnum';
 import GlobalEventTimerManager from '../../manager/GlobalEventTimeManager';
+import { SLOW_AFFECT_MOVE_SPEED_PENALTY } from './shared/AffectConstants';
 
 type MovementNodeProvider = () => { x: number; y: number } | null;
 
@@ -144,7 +145,18 @@ export default abstract class Character extends GameEntity {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     die(_killer?: Character) {
         this.pos = PositionEnum.DEAD;
+        this.clearBattleAffects();
         this.removeTimers();
+    }
+
+    protected clearBattleAffects() {
+        if (this.isAffectByFlag(AffectBitsTypeEnum.SLOW)) {
+            this.addPoint(PointsEnum.MOVE_SPEED, SLOW_AFFECT_MOVE_SPEED_PENALTY);
+        }
+
+        this.removeAffectFlag(AffectBitsTypeEnum.POISON);
+        this.removeAffectFlag(AffectBitsTypeEnum.SLOW);
+        this.removeAffectFlag(AffectBitsTypeEnum.STUN);
     }
 
     isDead(): boolean {

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -12,6 +12,7 @@ import Player from '../../../player/Player';
 import { MobImmuneFlagEnum } from '@/core/enum/MobImmuneFlagEnum';
 import Monster from '../../Monster';
 import { TimedEventsEnum } from '@/core/enum/TimedEventsEnum';
+import { SLOW_AFFECT_MOVE_SPEED_PENALTY } from '../../../shared/AffectConstants';
 
 export default class MonsterBattle {
     private readonly logger: Logger;
@@ -294,8 +295,7 @@ export default class MonsterBattle {
     private applySlow(victim: Player) {
         //TODO: use antislow to calculate this chance to apply or not
         if (victim.isAffectByFlag(AffectBitsTypeEnum.SLOW)) return;
-        const SLOW_VALUE = 30;
-        victim.addPoint(PointsEnum.MOVE_SPEED, -SLOW_VALUE);
+        victim.addPoint(PointsEnum.MOVE_SPEED, -SLOW_AFFECT_MOVE_SPEED_PENALTY);
 
         victim.setAffectFlag(AffectBitsTypeEnum.SLOW);
         victim.updateView();
@@ -303,7 +303,7 @@ export default class MonsterBattle {
         victim.addEventTimer({
             id: TimedEventsEnum.SLOW,
             eventFunction: () => {
-                victim.addPoint(PointsEnum.MOVE_SPEED, SLOW_VALUE);
+                victim.addPoint(PointsEnum.MOVE_SPEED, SLOW_AFFECT_MOVE_SPEED_PENALTY);
                 victim.removeAffectFlag(AffectBitsTypeEnum.SLOW);
                 victim.updateView();
             },

--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
@@ -18,6 +18,7 @@ import MathUtil from '@/core/domain/util/MathUtil';
 import { FlyEnum } from '@/core/enum/FlyEnum';
 import PlayerBattleStrategy from './PlayerBattleStrategy';
 import { TimedEventsEnum } from '@/core/enum/TimedEventsEnum';
+import { SLOW_AFFECT_MOVE_SPEED_PENALTY } from '../../../shared/AffectConstants';
 
 const weaponResistanceMapper: { [key in ItemWeaponSubTypeEnum]: MobResistEnum } = {
     [ItemWeaponSubTypeEnum.WEAPON_BELL]: MobResistEnum.BELL,
@@ -418,8 +419,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
     protected applySlow(victim: Monster) {
         if (victim.isImmuneByFlag(MobImmuneFlagEnum.SLOW)) return;
         if (victim.isAffectByFlag(AffectBitsTypeEnum.SLOW)) return;
-        const SLOW_VALUE = 30;
-        victim.addPoint(PointsEnum.MOVE_SPEED, -SLOW_VALUE);
+        victim.addPoint(PointsEnum.MOVE_SPEED, -SLOW_AFFECT_MOVE_SPEED_PENALTY);
 
         victim.setAffectFlag(AffectBitsTypeEnum.SLOW);
         victim.sendUpdateEvent();
@@ -427,7 +427,7 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
         victim.addEventTimer({
             id: TimedEventsEnum.SLOW,
             eventFunction: () => {
-                victim.addPoint(PointsEnum.MOVE_SPEED, SLOW_VALUE);
+                victim.addPoint(PointsEnum.MOVE_SPEED, SLOW_AFFECT_MOVE_SPEED_PENALTY);
                 victim.removeAffectFlag(AffectBitsTypeEnum.SLOW);
                 victim.sendUpdateEvent();
             },

--- a/src/core/domain/entities/game/shared/AffectConstants.ts
+++ b/src/core/domain/entities/game/shared/AffectConstants.ts
@@ -1,0 +1,1 @@
+export const SLOW_AFFECT_MOVE_SPEED_PENALTY = 30;

--- a/test/unit/core/domain/entities/game/CharacterAffectsOnDeath.test.ts
+++ b/test/unit/core/domain/entities/game/CharacterAffectsOnDeath.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import Character from '@/core/domain/entities/game/Character';
+import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { SLOW_AFFECT_MOVE_SPEED_PENALTY } from '@/core/domain/entities/game/shared/AffectConstants';
+
+class TestCharacter extends Character {
+    private moveSpeed = 100;
+    public timersRemoved = 0;
+
+    constructor() {
+        super(
+            {
+                id: 1,
+                classId: 0,
+                virtualId: 1,
+                entityType: 0,
+                positionX: 0,
+                positionY: 0,
+                name: 'Test',
+                empire: 1,
+            } as any,
+            {
+                animationManager: { getAnimation: () => undefined } as any,
+                questManager: {} as any,
+                eventTimerManager: { removeAllTimersFromOwner: () => {} } as any,
+            },
+        );
+    }
+
+    addPoint(point: PointsEnum, value: number): void {
+        if (point === PointsEnum.MOVE_SPEED) this.moveSpeed += value;
+    }
+    setPoint(): void {}
+    getPoint(point: PointsEnum): number {
+        return point === PointsEnum.MOVE_SPEED ? this.moveSpeed : 0;
+    }
+    getHealthPercentage(): number {
+        return 0;
+    }
+    getAttack(): number {
+        return 0;
+    }
+    getDefense(): number {
+        return 0;
+    }
+    removeTimers(): void {
+        this.timersRemoved++;
+    }
+}
+
+describe('battle affects on death (issue #163)', () => {
+    it('should clear a stun instead of leaving it set after death', () => {
+        const character = new TestCharacter();
+        character.setAffectFlag(AffectBitsTypeEnum.STUN);
+
+        character.die();
+
+        expect(character.isAffectByFlag(AffectBitsTypeEnum.STUN), 'the client stays input locked otherwise').to.be
+            .false;
+    });
+
+    it('should clear poison, which otherwise blocks regeneration for the session', () => {
+        const character = new TestCharacter();
+        character.setAffectFlag(AffectBitsTypeEnum.POISON);
+
+        character.die();
+
+        expect(character.isAffectByFlag(AffectBitsTypeEnum.POISON)).to.be.false;
+    });
+
+    it('should clear slow and give the movement speed penalty back', () => {
+        const character = new TestCharacter();
+        character.addPoint(PointsEnum.MOVE_SPEED, -SLOW_AFFECT_MOVE_SPEED_PENALTY);
+        character.setAffectFlag(AffectBitsTypeEnum.SLOW);
+
+        character.die();
+
+        expect(character.isAffectByFlag(AffectBitsTypeEnum.SLOW)).to.be.false;
+        expect(
+            character.getPoint(PointsEnum.MOVE_SPEED),
+            'a mob never recomputes move speed on respawn, so an unreturned penalty is permanent',
+        ).to.equal(100);
+    });
+
+    it('should not hand back a penalty that was never applied', () => {
+        const character = new TestCharacter();
+
+        character.die();
+
+        expect(character.getPoint(PointsEnum.MOVE_SPEED)).to.equal(100);
+    });
+
+    it('should leave affects that death does not own alone', () => {
+        const character = new TestCharacter();
+        character.setAffectFlag(AffectBitsTypeEnum.POLYMORPH);
+        character.setAffectFlag(AffectBitsTypeEnum.STUN);
+
+        character.die();
+
+        expect(character.isAffectByFlag(AffectBitsTypeEnum.POLYMORPH), 'only the battle debuffs are cleared').to.be
+            .true;
+        expect(character.isAffectByFlag(AffectBitsTypeEnum.STUN)).to.be.false;
+    });
+
+    it('should still remove the timers', () => {
+        const character = new TestCharacter();
+
+        character.die();
+
+        expect(character.timersRemoved).to.equal(1);
+    });
+});


### PR DESCRIPTION
Fixes #163.

Poison, slow and stun are applied by setting an affect bit and scheduling the clear on an event timer. `Character.die()` wipes every timer for its owner through `GlobalEventTimerManager.removeAllTimersFromOwner`, which deletes the entries **without running their callbacks**, so the clear never fired and the bit survived death and respawn. Nothing else resets `affectBitFlag`, and `Player.init()` recomputes points on respawn without touching affects.

For stun the consequence is user visible. Our `STUN` is ordinal 6, `AffectBitFlag` writes it as bit 5, and bit 5 is the client's `AFFECT_STUN` (`InstanceBase.h:73`), which calls `SetSleep(true)` (`InstanceBaseEffect.cpp:932`) and gates mouse input (`PythonPlayerInputMouse.cpp:115`) and auto-attack (`PythonPlayer.cpp:237`) until the player relogs. Poison keeps `isRecoveryBlocked()` true, so regeneration stays dead for the session.

## The shape I chose, and the one I did not

`die()` now clears the three battle debuffs before the timer wipe.

The alternative was to make forced timer removal run its callbacks. That is one line, but it changes semantics for **every** timer in the codebase, including ones that should not fire on logout. #163 argued for the local option and this implements it — if you would rather have the timer-contract version, say so and I will send that instead.

Only those three bits are cleared, not the whole flag word. The original distinguishes affects that survive death with `IS_NO_CLEAR_ON_DEATH_AFFECT` (`char_affect.cpp:22`), and we have no per-affect metadata to reproduce that, so clearing exactly the debuffs the battle code owns is the faithful subset. When the affect list from #54 lands this can generalise. The spec pins that a non-battle bit (`POLYMORPH`) is left alone.

## Why the slow penalty has to be handed back

This is the part I would have got wrong without checking: `MobPoints.calcPoints` only recomputes defense, attack and health, so **a monster never recovers its move speed on respawn** (`PlayerPoints.resetMoveSpeed` does, for players).

Clearing the `SLOW` bit without restoring the 30 would make the mob eligible to be slowed again on its next life and subtract another 30 permanently, compounding every death. Master avoids that only by never clearing the bit at all. So the fix restores the penalty when the bit was set, and the value — previously a duplicated local `const SLOW_VALUE = 30` in both `applySlow` implementations — becomes a shared constant so the restore cannot drift from the penalty.

## Verified

Against `352eaa2f`. **4 of the 6 new cases fail without the fix**: stun, poison, slow-plus-speed, and the "leave other affects alone" case (which fails because stun is still set).

The other 2 are regression guards — that no penalty is handed back when none was applied, and that `die()` still removes the timers — and pass either way by design.

510 unit passing; the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115. `tsc`, `eslint`, `prettier` clean.

## Note on scope

Pre-existing. It touches `Character.ts` and both `applySlow` sites, which overlaps #111 and #134. I checked properly rather than trusting `merge-tree`: both merge clean, and I built the pair with #111 (the one that touches both files) — auto-merged, `tsc` clean, 512 unit passing.

Deliberately not touched: the `//TODO: reset player future position` in `applyStun` is #52 and is a different bug; I left it exactly where it is.
