### PR TITLE
fix(area): unlink a departing player from every nearby entity (fix #168)

### DIFF
--- a/src/core/domain/Area.ts
+++ b/src/core/domain/Area.ts
@@ -264,21 +264,30 @@ export default class Area {
     private processDespawnQueue() {
         for (const entity of this.entitiesToDespawn.dequeueIterator()) {
             if (!entity) continue;
-            const entities = this.aoi.queryAround(entity, CHAR_VIEW_SIZE, EntityTypeEnum.PLAYER) as Map<number, Player>;
-
-            for (const otherEntity of entities.values()) {
-                if (entity instanceof Character) {
-                    entity.removeNearbyEntity(otherEntity);
-                }
-
-                if (otherEntity instanceof Character) {
-                    otherEntity.removeNearbyEntity(entity);
-                }
-            }
-
+            this.unlinkNearbyEntities(entity);
             this.entityManager.removeEntity(entity);
             this.aoi.remove(entity);
             entity.onDespawn();
+        }
+    }
+
+    private unlinkNearbyEntities(entity: GameEntity) {
+        const entities = this.aoi.queryAround(
+            entity,
+            CHAR_VIEW_SIZE,
+            entity.getEntityType() !== EntityTypeEnum.PLAYER ? EntityTypeEnum.PLAYER : undefined,
+        );
+
+        for (const otherEntity of entities.values()) {
+            if (otherEntity.getVirtualId() === entity.getVirtualId()) continue;
+
+            if (entity instanceof Character) {
+                entity.removeNearbyEntity(otherEntity);
+            }
+
+            if (otherEntity instanceof Character) {
+                otherEntity.removeNearbyEntity(entity);
+            }
         }
     }
 }

--- a/test/unit/core/domain/AreaDespawnUnlink.test.ts
+++ b/test/unit/core/domain/AreaDespawnUnlink.test.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import Area from '@/core/domain/Area';
+import Character from '@/core/domain/entities/game/Character';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+
+const makeArea = () =>
+    new Area(
+        { name: 'test', positionX: 0, positionY: 0, width: 1, height: 1 },
+        {
+            spawnManager: { getSpawnPointsByAreaName: () => [] } as any,
+            entityManager: { addEntity: () => {}, removeEntity: () => {} } as any,
+        },
+    );
+
+const makeEntity = (virtualId: number, entityType: EntityTypeEnum, x = 100, y = 100) => {
+    const nearby = new Map<number, any>();
+    const entity: any = Object.create(Character.prototype);
+
+    Object.assign(entity, {
+        virtualId,
+        positionX: x,
+        positionY: y,
+        getVirtualId: () => virtualId,
+        getEntityType: () => entityType,
+        getPositionX: () => x,
+        getPositionY: () => y,
+        addNearbyEntity: (other: any) => nearby.set(other.getVirtualId(), other),
+        removeNearbyEntity: (other: any) => nearby.delete(other.getVirtualId()),
+        getNearbyEntities: () => nearby,
+        isNearby: (other: any) => nearby.has(other.getVirtualId()),
+        onSpawn: () => {},
+        onDespawn: () => {},
+        isPlayer: () => entityType === EntityTypeEnum.PLAYER,
+    });
+
+    return entity;
+};
+
+describe('Area despawn unlinking (issue #168)', () => {
+    it('should unlink a departing player from nearby monsters, not only from other players', () => {
+        const area = makeArea();
+        const monster = makeEntity(1, EntityTypeEnum.MONSTER);
+        const player = makeEntity(2, EntityTypeEnum.PLAYER);
+
+        area.spawn(monster);
+        area.spawn(player);
+        area.tick();
+
+        expect(monster.getNearbyEntities().has(2), 'the monster sees the player while both are in').to.be.true;
+
+        area.despawn(player);
+        area.tick();
+
+        expect(
+            monster.getNearbyEntities().has(2),
+            'a stale entry here is what lets findNextVictim re-acquire a phantom',
+        ).to.be.false;
+        expect(player.getNearbyEntities().has(1)).to.be.false;
+    });
+
+    it('should unlink a departing player from NPCs and stones, which never move to self-heal', () => {
+        const area = makeArea();
+        const npc = makeEntity(1, EntityTypeEnum.NPC);
+        const stone = makeEntity(3, EntityTypeEnum.METIN_STONE);
+        const player = makeEntity(2, EntityTypeEnum.PLAYER);
+
+        area.spawn(npc);
+        area.spawn(stone);
+        area.spawn(player);
+        area.tick();
+
+        area.despawn(player);
+        area.tick();
+
+        expect(npc.getNearbyEntities().has(2), 'an NPC never fires onMonsterMove, so this would leak forever').to.be
+            .false;
+        expect(stone.getNearbyEntities().has(2)).to.be.false;
+    });
+
+    it('should still unlink a departing player from other players', () => {
+        const area = makeArea();
+        const other = makeEntity(1, EntityTypeEnum.PLAYER);
+        const player = makeEntity(2, EntityTypeEnum.PLAYER);
+
+        area.spawn(other);
+        area.spawn(player);
+        area.tick();
+
+        area.despawn(player);
+        area.tick();
+
+        expect(other.getNearbyEntities().has(2)).to.be.false;
+    });
+
+    it('should keep a departing monster symmetric, which it already was', () => {
+        const area = makeArea();
+        const monster = makeEntity(1, EntityTypeEnum.MONSTER);
+        const player = makeEntity(2, EntityTypeEnum.PLAYER);
+
+        area.spawn(monster);
+        area.spawn(player);
+        area.tick();
+
+        area.despawn(monster);
+        area.tick();
+
+        expect(player.getNearbyEntities().has(1)).to.be.false;
+        expect(monster.getNearbyEntities().has(2)).to.be.false;
+    });
+});


### PR DESCRIPTION
Fixes #168.

`processDespawnQueue` always filtered its AOI query to `PLAYER`, whatever was leaving, while `linkNearbyEntities` on the spawn side is asymmetric **by design** — a non-player links only to players, a player links to everything. So a monster despawn was symmetric and fine, but a player logout left the departed `Player` in the `nearbyEntities` of every nearby monster, NPC and metin stone.

## Why a stale entry latches

On the next tick — the *same* tick, since `World.tick` runs `area.tick()` before `entityManager.tick()` — `Behavior.idleState` calls `findNextVictim`, and `isAttackableVictim` checks `isPlayer`, `isDead`, invisibility and empire but never world membership. The ghost passes.

Once `setTarget` runs, nothing takes it back: `findNextVictim` has one caller and it is gated on `!getTarget()`, `battleState` releases only on `!target || target.isDead()`, and **no AOI path touches `Monster.target`**. The monster walks to a spot where nobody is and ignores real players until it finishes killing a character who already left.

## The fix

The despawn query now uses the same expression as the spawn side, so the two are symmetric by construction instead of by coincidence, and the self-id skip is added for the same reason.

Because `area.tick()` runs before the monsters tick, unlinking properly at despawn prevents the re-acquisition outright — which is why one expression closes the whole chain rather than just narrowing the window.

## Why the two things that already existed were not enough

`Player.onDespawn` → `forgetMeAsTarget()` clears monsters **currently** targeting the leaver, but it runs before the re-acquisition.

`Area.onMonsterMove:167-172` scrubs the stale entry from both sides — but only when that monster next moves, up to a full wander delay later, and by then the target is latched. Neither helps an NPC or a metin stone at all, since they never move; those retained the whole `Player` object, connection included, for the lifetime of the process.

## Verified

Against `352eaa2f`. **2 of the 4 new cases fail without the fix** — the monster case and the NPC/stone case.

The other 2 are controls for the paths that were already correct: player-to-player unlinking, and a departing monster staying symmetric. They pass either way, so I am not counting them.

508 unit passing; the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115. `tsc`, `eslint`, `prettier` clean. There was no spec for `Area` before this.

## Note on scope

Pre-existing. This touches the top of `processDespawnQueue` while PR #143 changes its last line, so I built the pair rather than trusting `merge-tree`: it auto-merges, `tsc` clean, 512 unit passing, and the merged function reads correctly with my query at the top and `runIsolated` at the bottom. Clean against all 30 open PRs.

Deliberately not included, and asked in #168 instead: whether `Monster.target` should also get a liveness check so that no future path can leave a monster chasing an entity that left the world. The AOI fix is sufficient for this bug; the target field having no validation at all is what turned a transient inconsistency into a latched one, and that is a broader decision than this PR.
