### PR TITLE
fix(item): drain the item cache instead of clearing it after the await (fix #165)

### DIFF
--- a/src/core/domain/manager/ItemManager.ts
+++ b/src/core/domain/manager/ItemManager.ts
@@ -108,17 +108,19 @@ export default class ItemManager {
             return;
         }
 
-        const itemsToUpdate = this.itemCache.getItemsToUpdate(ownerId);
-        const itemsToDelete = this.itemCache.getItemsToDelete(ownerId);
+        const drained = this.itemCache.drain(ownerId);
 
-        const updatePromises = Array.from(itemsToUpdate || []).map((item) => this.itemRepository.update(item));
-        const deletePromises = Array.from(itemsToDelete || []).map((item) => this.itemRepository.delete(item));
+        if (drained.update.length === 0 && drained.delete.length === 0) return;
 
-        if (updatePromises.length === 0 && deletePromises.length === 0) return;
-
-        await Promise.all([...updatePromises, ...deletePromises]);
-
-        this.itemCache.clear(ownerId);
+        try {
+            await Promise.all([
+                ...drained.update.map((item) => this.itemRepository.update(item)),
+                ...drained.delete.map((item) => this.itemRepository.delete(item)),
+            ]);
+        } catch (error) {
+            this.itemCache.restore(ownerId, drained);
+            throw error;
+        }
 
         this.logger.debug(`[ITEM MANAGER] Saving items of player id: ${ownerId}`);
     }

--- a/src/core/domain/util/ItemCache.ts
+++ b/src/core/domain/util/ItemCache.ts
@@ -40,6 +40,26 @@ export default class ItemCache {
         return cache.delete.values();
     }
 
+    drain(ownerId: number) {
+        const cache = this.get(ownerId);
+        const drained = { update: [...cache.update.values()], delete: [...cache.delete.values()] };
+        cache.update.clear();
+        cache.delete.clear();
+        return drained;
+    }
+
+    restore(ownerId: number, drained: { update: Array<ItemState>; delete: Array<ItemState> }) {
+        const cache = this.get(ownerId);
+
+        for (const item of drained.update) {
+            if (!cache.update.has(item.id) && !cache.delete.has(item.id)) cache.update.set(item.id, item);
+        }
+
+        for (const item of drained.delete) {
+            if (!cache.delete.has(item.id)) cache.delete.set(item.id, item);
+        }
+    }
+
     clear(ownerId: number) {
         const cache = this.get(ownerId);
         cache?.update.clear();

--- a/test/unit/core/domain/manager/ItemManagerFlush.test.ts
+++ b/test/unit/core/domain/manager/ItemManagerFlush.test.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+import ItemManager from '@/core/domain/manager/ItemManager';
+import ItemCache from '@/core/domain/util/ItemCache';
+
+const state = (id: number) => ({ id }) as any;
+
+const makeManager = (
+    update: (item: any) => Promise<unknown>,
+    remove: (item: any) => Promise<unknown> = async () => {},
+) => {
+    const itemCache = new ItemCache();
+    const manager = new ItemManager({
+        itemRepository: { update, delete: remove } as any,
+        logger: { debug: () => {}, info: () => {}, error: () => {} } as any,
+        config: {} as any,
+        cacheProvider: {} as any,
+    } as any);
+
+    (manager as any).itemCache = itemCache;
+
+    return { manager, itemCache };
+};
+
+describe('ItemManager.flush (issue #165)', () => {
+    it('should keep a write queued during the await instead of discarding it', async () => {
+        let resolveUpdate: () => void = () => {};
+        const started = new Promise<void>((r) => (resolveUpdate = r));
+        let queuedDuringAwait = false;
+
+        const { manager, itemCache } = makeManager(async () => {
+            if (!queuedDuringAwait) {
+                queuedDuringAwait = true;
+                itemCache.setToUpdate(1, state(99));
+            }
+            resolveUpdate();
+        });
+
+        itemCache.setToUpdate(1, state(10));
+
+        await manager.flush(1);
+        await started;
+
+        const left = Array.from(itemCache.getItemsToUpdate(1)).map((item: any) => item.id);
+        expect(left, 'the item queued while the DB write was in flight must survive').to.deep.equal([99]);
+    });
+
+    it('should write everything that was queued before the flush', async () => {
+        const written: Array<number> = [];
+        const { manager, itemCache } = makeManager(async (item) => {
+            written.push(item.id);
+        });
+
+        itemCache.setToUpdate(1, state(10));
+        itemCache.setToUpdate(1, state(11));
+
+        await manager.flush(1);
+
+        expect(written.sort()).to.deep.equal([10, 11]);
+        expect(Array.from(itemCache.getItemsToUpdate(1)), 'the flushed entries are gone').to.have.lengthOf(0);
+    });
+
+    it('should put the entries back when the database write fails', async () => {
+        const { manager, itemCache } = makeManager(async () => {
+            throw new Error('db down');
+        });
+
+        itemCache.setToUpdate(1, state(10));
+
+        let rejection: unknown = null;
+        await manager.flush(1).catch((error) => (rejection = error));
+
+        expect(rejection, 'the failure still propagates').to.be.instanceOf(Error);
+        expect(
+            Array.from(itemCache.getItemsToUpdate(1)).map((item: any) => item.id),
+            'a failed flush must not lose the queued writes',
+        ).to.deep.equal([10]);
+    });
+
+    it('should not resurrect an entry that was superseded while the write was failing', async () => {
+        const itemCacheRef: { current: ItemCache | null } = { current: null };
+
+        const { manager, itemCache } = makeManager(async () => {
+            itemCacheRef.current!.setToDelete(1, state(10));
+            throw new Error('db down');
+        });
+        itemCacheRef.current = itemCache;
+
+        itemCache.setToUpdate(1, state(10));
+
+        await manager.flush(1).catch(() => {});
+
+        expect(
+            Array.from(itemCache.getItemsToUpdate(1)),
+            'the newer delete wins over the restored update',
+        ).to.have.lengthOf(0);
+        expect(Array.from(itemCache.getItemsToDelete(1)).map((item: any) => item.id)).to.deep.equal([10]);
+    });
+
+    it('should do nothing when there is nothing queued', async () => {
+        let called = 0;
+        const { manager } = makeManager(async () => {
+            called++;
+        });
+
+        await manager.flush(1);
+
+        expect(called).to.equal(0);
+    });
+});


### PR DESCRIPTION
Fixes #165.

`flush` snapshotted the pending writes, awaited them, and then called `ItemCache.clear`, which empties the owner's `update` and `delete` maps wholesale. Anything queued while the database round trip was in flight was thrown away without ever being written, and nothing retried it because nothing knew it had been lost.

## The window is reachable

Same-connection frames cannot interleave — `Server.handleData` serialises them behind a draining flag. But the autosave is not a connection frame: `EntityManager`'s 120s timer calls `SaveCharacterService`, which calls `flush`, and the `await` yields to the event loop. A `data` event for that same player can then run `MoveItemService`, `DropItemService`, `ShopManager` or `PrivateShopService` and queue a write that the subsequent `clear` discards.

## The fix

`ItemCache` gains `drain()`, which removes and returns both sets in one synchronous step, so anything queued afterwards is simply part of the next batch. The loss becomes impossible by construction rather than by ordering — which is why I chose this over deleting the flushed keys individually after the await.

## The thing draining breaks, and how it is handled

Draining up front changes one behaviour that had to be dealt with rather than ignored.

On master a rejected `Promise.all` means `clear` never runs, so the entries survive for the next flush. Draining first would lose them on a database failure — trading one silent loss for another, which would not be much of a fix.

So `flush` now restores the drained entries when the write fails, and rethrows. `restore()` skips any key that was superseded in the meantime, so a delete queued during a failing update is not overwritten by the stale update coming back. There is a spec for exactly that case.

`getItemsToUpdate`, `getItemsToDelete` and `clear` are left in place — `flush` was their only production caller, and the existing `ItemCache` spec still covers them.

## Verified

Against `352eaa2f`. **1 of the 5 new cases fails without the fix**, and it fails on the *value*: the item queued during the await is absent rather than present.

The other 4 pass on master as well, but for different reasons than they pass here — master keeps the entries after a failure because `clear` never runs, and the superseded case is vacuous there. They are regression guards for the new failure path, not evidence of the bug, and I would rather say so than quote "5 of 5".

509 unit passing; the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115. `tsc`, `eslint`, `prettier` clean.

## Note on scope

Pre-existing. Distinct from #149/#150, which are about *when* the player save runs rather than the item cache losing entries, and from #118, which is about the items map being keyed by a `dbId` that does not exist yet. Merges clean against all 30 open PRs.

I have not reproduced the loss against a live server — the window is one database round trip, and the mechanism is from reading plus the unit case above. Worth knowing when weighing how urgent this is.
