### PR TITLE
chore(lint): make unobserved promise rejections visible to the linter

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,11 +4,22 @@ import tseslint from "typescript-eslint";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
+  { ignores: ["dist"] },
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "warn",
+      "@typescript-eslint/no-misused-promises": "warn",
+    },
+  },
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",


### PR DESCRIPTION
Every unawaited async call in this codebase is a process exit waiting to happen. `GameServer.onData` wraps each handler in a `.catch`, but a handler that dispatches without awaiting resolves first, so the later rejection reaches `process.on('unhandledRejection')` in `main.ts` and calls `process.exit(1)`.

That one shape is behind **#103, #116, #124 and #155**. This turns on the two type-aware rules that detect it.

## What it finds

28 sites, and **8 of them are already filed as bugs**:

| site | filed as |
|---|---|
| `ChatInPacketHandler.ts:49` | #155 |
| `ItemDropPacketHandler.ts:35` | #116 |
| `AbstractQuest.ts:166` | #116 |
| `Area.ts:238` and `:281` | #124 |
| `ItemUsePacketHandler.ts:38` | #103 |
| `ItemMovePacketHandler.ts:35` | #103 |
| `QuestButtonPacketHandler.ts:35` | adjacent to #100 |

The rest are leads nobody has looked at. The ones I would look at first:

- **`World.ts:182`** drops the promise of the tick loop itself.
- **Four unawaited quest hooks** — `Monster.ts:229`, `Player.ts:416`, `:473`, `:816` (`onKill`, `onLevelUp`, `onLogin`).
- **`Server.ts:87` and `:91`, plus `GameServer.onClose`** register `async` handlers on socket events. `GameServer.onClose` runs the whole logout path, so a database failure while a player disconnects exits the process.
- `HuntQuest.ts:176-177` and `AbstractQuest.ts:185` (`done()` inside a `finally`).

I have not filed any of these — the point of the PR is that the linter reports them from now on, not that I hand you another six issues.

## Why warn and not error

As errors this would fail the build until all 28 are resolved, and several are the subject of PRs already in flight — #116 fixes two of them, #143 touches the `Area` ones — so the fixes belong there rather than in a config change.

Warn makes the class visible now without forcing a 15-file refactor through a queue that is already deep. Flipping to `error` once the in-flight PRs land is a one-word follow-up and I am happy to send it.

## Cost, and one thing I did not enable

Type-aware linting is scoped to `src/**/*.ts`, so tests and tools keep the cheap parser. Lint goes from about 5s to about 10s.

I did **not** turn on `prefer-nullish-coalescing`, which would have caught the other class we have hit (`enumMapper[x] || DEFAULT` discarding a zero-valued enum member, #159). That rule requires `strictNullChecks`, which is off here, so it cannot work — turning strict mode on is a much bigger conversation and not one to smuggle into a lint PR.

## The `dist` ignore

`dist` was not in the ignores. With a local build present, `npm run lint:fix` reports **3106 errors from compiled output** and the 28 warnings are invisible. CI never saw this because it lints before building.

It is a separate concern from the rules, but without it the rules cannot be read locally, so it rides along. Happy to split it out if you would rather keep the PR to one thing.

## Verified

`npm run lint:fix` exits 0 on this branch, exactly as on master, with 28 warnings and **no new errors**. Neither rule has an autofix, so the `--fix` in that script does not silently rewrite any source — I checked `git status` after running it.

`tsc` clean; the unit suite is unchanged at 504 passing (the 2 failures are the untracked `CreateCharacterSlotAudit` spec from #115).
