### PR TITLE
fix(character): refuse an occupied slot and a full account on creation

### DIFF
--- a/src/core/enum/CreateCharacterFailureReasonEnum.ts
+++ b/src/core/enum/CreateCharacterFailureReasonEnum.ts
@@ -1,4 +1,4 @@
 export enum CreateCharacterFailureReasonEnum {
     UNKNOWN = 0,
-    NAME_ALREADY_EXISTS = 1,
+    ALREADY_EXISTS = 1,
 }

--- a/src/core/enum/ErrorTypesEnum.ts
+++ b/src/core/enum/ErrorTypesEnum.ts
@@ -9,4 +9,5 @@ export enum ErrorTypesEnum {
     INVALID_EMPIRE = 8,
     PLAYER_NOT_FOUND = 9,
     INVALID_DELETE_CODE = 10,
+    SLOT_ALREADY_TAKEN = 11,
 }

--- a/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacketHandler.ts
@@ -62,9 +62,10 @@ export default class CreateCharacterPacketHandler extends PacketHandler<CreateCh
 
             switch (error) {
                 case ErrorTypesEnum.NAME_ALREADY_EXISTS:
+                case ErrorTypesEnum.SLOT_ALREADY_TAKEN:
                     connection.send(
                         new CreateCharacterFailurePacket({
-                            reason: CreateCharacterFailureReasonEnum.NAME_ALREADY_EXISTS,
+                            reason: CreateCharacterFailureReasonEnum.ALREADY_EXISTS,
                         }),
                     );
                     break;

--- a/src/game/app/service/CreateCharacterService.ts
+++ b/src/game/app/service/CreateCharacterService.ts
@@ -7,7 +7,7 @@ import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
 import { IPlayerRepository } from '@/core/domain/repository/IPlayerRepository';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
 
-const MAX_PLAYERS_PER_ACCOUNT = 4;
+export const MAX_PLAYERS_PER_ACCOUNT = 4;
 
 type CreateCharacterServiceParams = {
     playerName: string;
@@ -54,9 +54,16 @@ export default class CreateCharacterService {
             return Result.error(ErrorTypesEnum.NAME_ALREADY_EXISTS);
         }
 
+        const slotTaken = await this.playerRepository.getByAccountIdAndSlot(accountId, slot);
+
+        if (slotTaken) {
+            this.logger.info(`[CreateCharacterService] The slot: ${slot} is already taken, accountId: ${accountId}`);
+            return Result.error(ErrorTypesEnum.SLOT_ALREADY_TAKEN);
+        }
+
         const players = await this.playerRepository.getByAccountId(accountId);
 
-        if (players.length > MAX_PLAYERS_PER_ACCOUNT) {
+        if (players.length >= MAX_PLAYERS_PER_ACCOUNT) {
             this.logger.info(`[CreateCharacterService] The player account is full`);
             return Result.error(ErrorTypesEnum.ACCOUNT_FULL);
         }

--- a/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/createCharacter/CreateCharacterPacketHandler.test.ts
@@ -2,6 +2,7 @@ import { ErrorTypesEnum } from '@/core/enum/ErrorTypesEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import CreateCharacterPacketHandler from '@/core/interface/networking/packets/packet/in/createCharacter/CreateCharacterPacketHandler';
 import CreateCharacterFailurePacket from '@/core/interface/networking/packets/packet/out/CreateCharacterFailurePacket';
+import { CreateCharacterFailureReasonEnum } from '@/core/enum/CreateCharacterFailureReasonEnum';
 import CreateCharacterSuccessPacket from '@/core/interface/networking/packets/packet/out/CreateCharacterSuccessPacket';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -57,6 +58,30 @@ describe('CreateCharacterPacketHandler', function () {
         expect(mockConnection.send.calledOnce).to.be.true;
         const sentPacket = mockConnection.send.getCall(0).args[0];
         expect(sentPacket).to.be.instanceOf(CreateCharacterFailurePacket);
+    });
+
+    it('should refuse an occupied slot with a failure packet rather than a disconnect', async function () {
+        const validPacket = {
+            isValid: () => true,
+            getPlayerName: () => 'test',
+            getPlayerClass: () => 1,
+            getAppearance: () => 'appearance',
+            getSlot: () => 0,
+        } as any;
+
+        mockCreateCharacterService.execute.resolves({
+            hasError: () => true,
+            getError: () => ErrorTypesEnum.SLOT_ALREADY_TAKEN,
+        });
+
+        await createCharacterPacketHandler.execute(mockConnection, validPacket);
+
+        const sentPacket = mockConnection.send.getCall(0).args[0];
+        expect(sentPacket).to.be.instanceOf(CreateCharacterFailurePacket);
+        expect(sentPacket.pack()[1], 'the original answers an occupied slot with the ALREADY reason').to.equal(
+            CreateCharacterFailureReasonEnum.ALREADY_EXISTS,
+        );
+        expect(mockConnection.close.called).to.be.false;
     });
 
     it('should close connection if account is full', async function () {

--- a/test/unit/game/app/service/CreateCharacterService.test.ts
+++ b/test/unit/game/app/service/CreateCharacterService.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ErrorTypesEnum } from '@/core/enum/ErrorTypesEnum';
-import CreateCharacterService from '@/game/app/service/CreateCharacterService';
+import CreateCharacterService, { MAX_PLAYERS_PER_ACCOUNT } from '@/game/app/service/CreateCharacterService';
 
 describe('CreateCharacterService', function () {
     let loggerMock;
@@ -23,6 +23,7 @@ describe('CreateCharacterService', function () {
         playerRepositoryMock = {
             nameAlreadyExists: sinon.stub(),
             getByAccountId: sinon.stub(),
+            getByAccountIdAndSlot: sinon.stub().resolves(null),
             create: sinon.stub(),
         };
 
@@ -57,7 +58,7 @@ describe('CreateCharacterService', function () {
 
         it('should return error if the account is full', async function () {
             playerRepositoryMock.nameAlreadyExists.resolves(false);
-            playerRepositoryMock.getByAccountId.resolves(new Array(5));
+            playerRepositoryMock.getByAccountId.resolves(new Array(MAX_PLAYERS_PER_ACCOUNT));
 
             const result = await createCharacterService.execute({
                 playerName: 'newName',
@@ -70,6 +71,61 @@ describe('CreateCharacterService', function () {
             expect(playerRepositoryMock.getByAccountId.calledOnce).to.be.true;
             expect(result.hasError()).to.be.true;
             expect(result.getError()).to.equal(ErrorTypesEnum.ACCOUNT_FULL);
+            expect(playerRepositoryMock.create.called).to.be.false;
+        });
+
+        it('should still allow a character while the account is one short of full', async function () {
+            playerRepositoryMock.nameAlreadyExists.resolves(false);
+            playerRepositoryMock.getByAccountId.resolves(new Array(MAX_PLAYERS_PER_ACCOUNT - 1));
+            cacheProviderMock.exists.resolves(true);
+            cacheProviderMock.get.resolves(2);
+            entityManagerMock.createPlayer.returns({ toDatabase: sinon.stub().returns({}), setId: sinon.spy() });
+            playerRepositoryMock.create.resolves(100);
+
+            const result = await createCharacterService.execute({
+                playerName: 'newName',
+                playerClass: 1,
+                appearance: 123,
+                slot: 1,
+                accountId: 10,
+            });
+
+            expect(result.hasError()).to.be.false;
+        });
+
+        it('should return error if the slot is already taken', async function () {
+            playerRepositoryMock.nameAlreadyExists.resolves(false);
+            playerRepositoryMock.getByAccountIdAndSlot.resolves({ id: 1, slot: 1, name: 'occupant' });
+
+            const result = await createCharacterService.execute({
+                playerName: 'newName',
+                playerClass: 1,
+                appearance: 123,
+                slot: 1,
+                accountId: 10,
+            });
+
+            expect(playerRepositoryMock.getByAccountIdAndSlot.calledOnceWith(10, 1)).to.be.true;
+            expect(result.hasError()).to.be.true;
+            expect(result.getError()).to.equal(ErrorTypesEnum.SLOT_ALREADY_TAKEN);
+            expect(playerRepositoryMock.create.called).to.be.false;
+        });
+
+        it('should refuse the occupied slot even when the account has room', async function () {
+            playerRepositoryMock.nameAlreadyExists.resolves(false);
+            playerRepositoryMock.getByAccountId.resolves([{ slot: 0 }]);
+            playerRepositoryMock.getByAccountIdAndSlot.resolves({ id: 1, slot: 0, name: 'occupant' });
+
+            const result = await createCharacterService.execute({
+                playerName: 'newName',
+                playerClass: 1,
+                appearance: 123,
+                slot: 0,
+                accountId: 10,
+            });
+
+            expect(result.getError()).to.equal(ErrorTypesEnum.SLOT_ALREADY_TAKEN);
+            expect(playerRepositoryMock.create.called).to.be.false;
         });
 
         it('should return error if the empire is not selected', async function () {


### PR DESCRIPTION
Addresses defects 1 and 2 of #115. Defect 3 and the database constraints are **not** here, because the suggestion I made in that issue was wrong — last section.

## The occupied slot

`CreateCharacterService.execute` validated the name, the capacity and the empire, but never asked whether the slot was taken. `getByAccountIdAndSlot` already existed and is used by select and delete; creation just did not call it, and `game.player` has no unique key over `(accountId, slot)`, so the INSERT landed:

```ts
const slotTaken = await this.playerRepository.getByAccountIdAndSlot(accountId, slot);

if (slotTaken) {
    return Result.error(ErrorTypesEnum.SLOT_ALREADY_TAKEN);
}
```

With two rows on one slot the readers disagree: the select screen shows the row that came back last, entering the slot gives the first row, and deleting destroys that same first row — so the other character becomes unreachable and undeletable.

## The off-by-one

`players.length > MAX_PLAYERS_PER_ACCOUNT` with `MAX = 4`, so a full account passed and a fifth character was created. Now `>=`. This one needed no crafted packet, just a player filling their account.

**The slot check goes in before the capacity check on purpose.** Once an occupied slot is refused, a full account is refused by that same path for every slot the client can offer — and refused with a failure packet, rather than the disconnect `ACCOUNT_FULL` still triggers in the handler. The capacity guard stays a backstop instead of becoming the thing players hit.

## The wire reason — answering the question I left open in #115

I asked whether to add a new failure reason or reuse one, and said I leaned toward a new one. **Having checked the original and the client, I no longer do.**

The original refuses an occupied slot exactly as it refuses a duplicate name: `__QUERY_PLAYER_CREATE` tests the slot with `SELECT pid<n> FROM player_index` and answers `HEADER_DG_PLAYER_CREATE_ALREADY`, the same header it sends for a taken name, and `input_db.cpp` maps that to `PlayerCreateFailure(desc, 1)`. There is no third code. The client agrees one would buy nothing — `introcreate.py` shows `CREATE_EXIST_SAME_NAME` for `1` and a generic `CREATE_FAILURE` for anything else.

So no new wire value is invented. `CreateCharacterFailureReasonEnum.NAME_ALREADY_EXISTS` is renamed to `ALREADY_EXISTS`, since code `1` now covers both — which is what the original calls it. `SLOT_ALREADY_TAKEN` exists only as an internal `ErrorTypesEnum` member, so the log and the `Result` still distinguish them.

**If you would rather the client could tell them apart, it is a one-line switch** — add `SLOT_ALREADY_TAKEN = 2` and send it; the stock client renders it as the generic failure, so nothing breaks. I chose fidelity because the stock client never offers an occupied slot, so only tooling reaches this path, and tooling does not read popups.

## Why the existing spec missed the off-by-one

It asserted the full account with `new Array(5)` — and `5 > 4` holds, so the guard fired and the test passed. It now uses `MAX_PLAYERS_PER_ACCOUNT`, exported for that purpose, with a companion case pinning that one short of full is still allowed.

## Verified

- Reverting both guards fails **five** cases: the capacity boundary, both occupied-slot cases, and two in the standalone audit spec that has been pinning these defects locally.
- Tracked unit suite **661/2 → 665/2**; the two remaining are the unrelated ones master carries until #175 lands. With #175 on top: **669 passing, 0 failing.**
- `tsc`, `eslint`, `prettier --check` clean.

## Correcting myself on the constraints

#115 suggested `UNIQUE (accountId, slot)` and `UNIQUE (name)`, and called them the part that actually closes the hole. **That does not work, and I should have caught it before filing.** Deletion is soft — `softDelete` sets `deletedAt`, every read filters `deletedAt IS NULL` — so a plain unique key keeps a deleted character's slot occupied forever and reserves its name for good. MySQL has no partial indexes, so the honest form is a generated column:

```sql
ALTER TABLE game.player
    ADD COLUMN activeSlot TINYINT UNSIGNED AS (IF(deletedAt IS NULL, slot, NULL)) STORED,
    ADD UNIQUE KEY uq_player_account_slot (accountId, activeSlot);
```

NULLs do not collide in a MySQL unique index, so soft-deleted rows drop out. The same shape works for `name` and would close defect 3, the check-then-act race between `nameAlreadyExists` and `create`.

I left that out because it is a schema decision, not a bug fix. **Tell me which way and I will send it separately.** #115 should stay open for it either way.
