### PR TITLE
fix: drop despawned entities from the entity maps and stop leaking virtual ids (fix #164, fix #126)

### DIFF
--- a/src/core/domain/manager/EntityManager.ts
+++ b/src/core/domain/manager/EntityManager.ts
@@ -102,13 +102,28 @@ export class EntityManager {
     }
 
     removeEntity(entity: GameEntity) {
-        if (entity.isMob()) return;
+        const virtualId = entity.getVirtualId();
 
         if (entity.isPlayer()) {
-            this.players.delete(entity.getVirtualId());
+            this.players.delete(virtualId);
         }
 
-        this.entities.delete(entity.getVirtualId());
+        if (entity.isMob()) {
+            this.mobs.delete(virtualId);
+            const mobsVirtualId = this.vnumToVirtualIdMobMapper.get(entity.getId());
+            if (mobsVirtualId) {
+                const index = mobsVirtualId.indexOf(virtualId);
+                if (index !== -1) {
+                    mobsVirtualId.splice(index, 1);
+                }
+                if (mobsVirtualId.length === 0) {
+                    this.vnumToVirtualIdMobMapper.delete(entity.getId());
+                }
+            }
+        }
+
+        this.entities.delete(virtualId);
+        this.virtualIdManager.release(virtualId);
     }
 
     createMob(info: { id: number; positionX: number; positionY: number; direction?: number }) {

--- a/src/core/domain/manager/VirtualIdManager.ts
+++ b/src/core/domain/manager/VirtualIdManager.ts
@@ -1,28 +1,15 @@
 export class VirtualIdManager {
     private nextId: number = 1;
-    private releasedIds: number[] = [];
     private readonly acquiredIds: Set<number> = new Set();
 
     acquire(): number {
-        let id: number;
-        if (this.releasedIds.length > 0) {
-            id = this.releasedIds.shift()!;
-        } else {
-            id = this.nextId++;
-        }
-
+        const id = this.nextId++;
         this.acquiredIds.add(id);
         return id;
     }
 
     release(id: number): boolean {
-        if (!this.acquiredIds.has(id)) {
-            return false;
-        }
-
-        this.acquiredIds.delete(id);
-        this.releasedIds.push(id);
-        return true;
+        return this.acquiredIds.delete(id);
     }
 
     isAcquired(id: number): boolean {
@@ -31,10 +18,6 @@ export class VirtualIdManager {
 
     getActiveCount(): number {
         return this.acquiredIds.size;
-    }
-
-    getReusableCount(): number {
-        return this.releasedIds.length;
     }
 
     getNextSequentialId(): number {
@@ -47,7 +30,6 @@ export class VirtualIdManager {
 
     clear(): void {
         this.nextId = 1;
-        this.releasedIds = [];
         this.acquiredIds.clear();
     }
 }

--- a/test/unit/core/domain/manager/EntityManager.test.ts
+++ b/test/unit/core/domain/manager/EntityManager.test.ts
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { EntityManager } from '@/core/domain/manager/EntityManager';
+import { VirtualIdManager } from '@/core/domain/manager/VirtualIdManager';
+
+const MONSTER_VNUM = 101;
+
+const makeManager = () => {
+    const virtualIdManager = new VirtualIdManager();
+    const entityManager = new EntityManager({ virtualIdManager } as any);
+    return { entityManager, virtualIdManager };
+};
+
+const makeMonster = (virtualId: number, vnum: number = MONSTER_VNUM) =>
+    ({
+        getVirtualId: () => virtualId,
+        getId: () => vnum,
+        isPlayer: () => false,
+        isMob: () => true,
+    }) as any;
+
+const makePlayer = (virtualId: number, name: string = 'player') =>
+    ({
+        getVirtualId: () => virtualId,
+        getId: () => 1,
+        getName: () => name,
+        isPlayer: () => true,
+        isMob: () => false,
+    }) as any;
+
+const makeDroppedItem = (virtualId: number) =>
+    ({
+        getVirtualId: () => virtualId,
+        getId: () => 10,
+        isPlayer: () => false,
+        isMob: () => false,
+    }) as any;
+
+describe('EntityManager entity removal (issues #164 and #126)', () => {
+    it('should stop resolving a despawned monster by virtual id', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const monster = makeMonster(virtualIdManager.acquire());
+
+        entityManager.addEntity(monster);
+        entityManager.removeEntity(monster);
+
+        expect(
+            entityManager.getEntity(monster.getVirtualId()),
+            'a resolvable despawned monster is what lets attack, on_click and pickup act on a corpse',
+        ).to.be.undefined;
+    });
+
+    it('should drop a despawned monster from the vnum mapper so quest targets cannot point at it', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const monster = makeMonster(virtualIdManager.acquire());
+
+        entityManager.addEntity(monster);
+        entityManager.removeEntity(monster);
+
+        expect(entityManager.getEntityByVnum(MONSTER_VNUM)).to.deep.equal([]);
+    });
+
+    it('should keep the other monsters of the same vnum resolvable', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const first = makeMonster(virtualIdManager.acquire());
+        const second = makeMonster(virtualIdManager.acquire());
+
+        entityManager.addEntity(first);
+        entityManager.addEntity(second);
+        entityManager.removeEntity(first);
+
+        expect(entityManager.getEntityByVnum(MONSTER_VNUM)).to.deep.equal([second.getVirtualId()]);
+        expect(entityManager.getEntity(second.getVirtualId())).to.be.equal(second);
+    });
+
+    it('should not accumulate duplicate virtual ids across despawn and respawn cycles', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const monster = makeMonster(virtualIdManager.acquire());
+
+        entityManager.addEntity(monster);
+        entityManager.removeEntity(monster);
+        entityManager.addEntity(monster);
+        entityManager.removeEntity(monster);
+        entityManager.addEntity(monster);
+
+        expect(
+            entityManager.getEntityByVnum(MONSTER_VNUM),
+            'every respawn used to push the same id again, growing the array forever',
+        ).to.deep.equal([monster.getVirtualId()]);
+    });
+
+    it('should remove a player from the player map as it already did', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const player = makePlayer(virtualIdManager.acquire(), 'leaver');
+
+        entityManager.addEntity(player);
+        entityManager.removeEntity(player);
+
+        expect(entityManager.getEntity(player.getVirtualId())).to.be.undefined;
+        expect(entityManager.getPlayerByName('leaver')).to.be.null;
+    });
+
+    it('should release the virtual id of every removed entity', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const monster = makeMonster(virtualIdManager.acquire());
+        const player = makePlayer(virtualIdManager.acquire());
+        const droppedItem = makeDroppedItem(virtualIdManager.acquire());
+
+        entityManager.addEntity(monster);
+        entityManager.addEntity(player);
+        entityManager.addEntity(droppedItem);
+        entityManager.removeEntity(monster);
+        entityManager.removeEntity(player);
+        entityManager.removeEntity(droppedItem);
+
+        expect(
+            virtualIdManager.getActiveCount(),
+            'an id kept acquired after removal is the leak of issue #126',
+        ).to.be.equal(0);
+    });
+
+    it('should let a respawning monster re-enter with the virtual id it kept', () => {
+        const { entityManager, virtualIdManager } = makeManager();
+        const monster = makeMonster(virtualIdManager.acquire());
+
+        entityManager.addEntity(monster);
+        entityManager.removeEntity(monster);
+        entityManager.addEntity(monster);
+
+        expect(entityManager.getEntity(monster.getVirtualId())).to.be.equal(monster);
+        expect(entityManager.getEntityByVnum(MONSTER_VNUM)).to.deep.equal([monster.getVirtualId()]);
+    });
+});

--- a/test/unit/core/domain/manager/VirtualIdManager.test.ts
+++ b/test/unit/core/domain/manager/VirtualIdManager.test.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { VirtualIdManager } from '@/core/domain/manager/VirtualIdManager';
+
+describe('VirtualIdManager', () => {
+    let manager: VirtualIdManager;
+
+    beforeEach(() => {
+        manager = new VirtualIdManager();
+    });
+
+    it('should hand out sequential ids starting at 1', () => {
+        expect(manager.acquire()).to.be.equal(1);
+        expect(manager.acquire()).to.be.equal(2);
+        expect(manager.acquire()).to.be.equal(3);
+    });
+
+    it('should forget a released id instead of keeping it acquired forever (issue #126)', () => {
+        const id = manager.acquire();
+
+        expect(manager.release(id)).to.be.true;
+
+        expect(manager.isAcquired(id), 'a released id kept in the set is the per-entity leak of issue #126').to.be
+            .false;
+        expect(manager.getActiveCount()).to.be.equal(0);
+    });
+
+    it('should never reissue a released id to a different entity', () => {
+        const first = manager.acquire();
+        manager.release(first);
+
+        const second = manager.acquire();
+
+        expect(second, 'a recycled id would let a stale client reference resolve to the wrong entity').to.not.be.equal(
+            first,
+        );
+        expect(second).to.be.equal(first + 1);
+    });
+
+    it('should refuse to release an id it never handed out', () => {
+        expect(manager.release(999)).to.be.false;
+    });
+
+    it('should refuse a double release', () => {
+        const id = manager.acquire();
+
+        expect(manager.release(id)).to.be.true;
+        expect(manager.release(id)).to.be.false;
+    });
+
+    it('should keep counting past released ids', () => {
+        manager.acquire();
+        const second = manager.acquire();
+        manager.release(second);
+
+        manager.acquire();
+
+        expect(manager.getTotalGenerated()).to.be.equal(3);
+        expect(manager.getNextSequentialId()).to.be.equal(4);
+        expect(manager.getActiveCount()).to.be.equal(2);
+    });
+
+    it('should start over after a clear', () => {
+        manager.acquire();
+        manager.acquire();
+
+        manager.clear();
+
+        expect(manager.acquire()).to.be.equal(1);
+        expect(manager.getActiveCount()).to.be.equal(1);
+    });
+});


### PR DESCRIPTION
Fixes #164
Fixes #126

## What the code does today

`EntityManager.removeEntity` early-returns for every mob, so the only remover in the codebase never removes a monster from `entities`, `mobs` or `vnumToVirtualIdMobMapper`. And `VirtualIdManager.release()` has zero callers, so `acquiredIds` grows by one per login, per drop and per horse summon, forever.

Since the issues were filed this got worse in two ways:

- `getEntityByVnum` is no longer reader-less: `QuestTargetManager.sendTargetByVnum` now maps **every** id in the vnum array through `getEntity` on each quest-target send, and every respawn pushes the same virtual id into that array again, so it grows without bound.
- Every horse summon abandons a whole `Monster` object: `spawnMob` acquires a fresh id, `despawnHorseEntity` despawns it, the early return keeps it in all three maps with its `area` still set — resolvable by the five client-driven `getEntity` paths (attack, target, on_click, pickup, quest targets) forever.

## What the original does

Both issues ended in a design question. The 40250 source answers both:

- *Should a despawned monster stay resolvable by VID?* No — `CHARACTER_MANAGER::DestroyCharacter` erases the char from `m_map_pkChrByVID` (`char_manager.cpp:130`); regen later creates a **new** character.
- *Recycle ids or hand out fresh ones?* `AllocVID()` is a bare `++m_iVIDCount` (`char_manager.cpp:68`) — no free list, ids climb monotonically, a released id is never reissued.

## The fix

- `removeEntity` now deletes mobs from all three maps, splices the id out of the vnum array (dropping the key when it empties) and releases the virtual id of every removed entity. `addEntity` re-adds a respawning monster with the id it kept, so despawn/respawn stay symmetric: one array entry per live mob, no duplicates.
- `acquire()` always returns `nextId++`; `release(id)` only forgets the id. The dead `releasedIds` free-list and `getReusableCount()` (zero callers) are gone. Recycling would let a stale reference — an in-flight packet, a stale target, an event timer keyed by owner id — resolve to the wrong entity; the original never takes that risk.

Two things I verified before trusting the shape: the respawn timer keeps firing while the monster is out of the maps (timers live in the `GlobalEventTimerManager` singleton ticked by `World.tick`, not in `EntityManager.tick`), and a `/goto` re-enters the same player object through `addEntity` unchanged.

## Trade-offs, and the alternatives

- **A respawning monster keeps its virtual id** (respawn reuses the same `Monster` object). The original would give the respawn a fresh id; what actually matters — the id resolves to nothing during the dead window — holds either way. Reacquiring per respawn means mutating the id mid-object and threading the manager into the respawn path; say the word and I will write that version.
- **`release` is unconditional**, so an entity that re-enters with its old id (group respawn, `/goto`) is briefly absent from `acquiredIds`. With no recycling this has no functional effect — none of the manager's accessors has a caller in `src/`. The alternative is gating release on "will not come back", but no single predicate at the `removeEntity` level distinguishes a logout despawn from a goto despawn today.
- The `mobs` map stays, though it is still write-only — removing it felt like a separate cleanup call that is yours to make.

## Verified

- Unit: 661/2 → **675/2** on current master, **677/0** with the #174 casing fix cherry-picked. The 2 are the pre-existing `PlayerToDatabaseStats` fixture cases that #175 fixes.
- Fail-without-fix: reverting the two source files fails **8** of the 14 new cases (6 EntityManager, 2 VirtualIdManager); the pinning cases stay green.
- Integration: 30/1 — **identical to master without this change**. The 1 is a logout gold-flush failure that pre-exists this branch; I am investigating it separately.

## Note on scope

Pre-existing, both issues. No packet or client-visible behaviour changes: despawn packets were already sent on despawn — the maps just kept resolving entities the clients could no longer see.
