### PR TITLE
fix(test): seed the skills column so the integration harness works on the new schema

### DIFF
--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -157,8 +157,8 @@ export default class AttackHarness {
         await this.db.getConnection().query(
             `INSERT INTO game.player (accountId, empire, playerClass, skillGroup, playTime, level, experience,
                 gold, st, ht, dx, iq, positionX, positionY, health, mana, stamina, bodyPart, hairPart, name,
-                givenStatusPoints, availableStatusPoints, slot)
-             VALUES (?, 2, 4, 0, 9105, 99, 0, 12038002, 17, 107, 12, 6, ?, ?, 15950, 5570, 1000, 0, 0, ?, 396, 192, 0)`,
+                givenStatusPoints, availableStatusPoints, slot, skills)
+             VALUES (?, 2, 4, 0, 9105, 99, 0, 12038002, 17, 107, 12, 6, ?, ?, 15950, 5570, 1000, 0, 0, ?, 396, 192, 0, '[]')`,
             [accountId, x, y, username],
         );
         this.seededAccounts.push(username);


### PR DESCRIPTION
Fixes the fresh-database half of #178.

## What the code does today

`AttackHarness.login` seeds its character with an explicit column list that predates the skill system. The new `skills` column is `JSON NOT NULL`, and on MySQL 5.7 (the image in `docker-compose`) a JSON column cannot carry a DEFAULT at all — so with the stock `STRICT_TRANS_TABLES` mode, the seeding INSERT fails with `ER_NO_DEFAULT_FOR_FIELD` (1364) on any database built from current `script.sql`. Every integration spec that logs a character in dies at seeding.

## The fix

One line: the seed INSERT now supplies `skills` as `'[]'` — the same empty list `PlayerRepository.create` writes for a fresh character.

## Verified

Against a schema matching current `script.sql` (MySQL 5.7.44):

- Without the column: **21 of 25** login-dependent integration cases fail at seeding, 18 of them with `Field 'skills' doesn't have a default value`.
- With it: the integration suite runs **31/0** — the first green integration baseline since the skill system landed.
- `eslint` and `prettier --check` clean on the touched file.

## Note on scope

Test support only, no `src/` changes. The existing-database half of #178 (the silent save failures and the missing upgrade path) is a design call and stays open there.
