### PR TITLE
fix(inventory): stop a fresh item from evicting the previous one from the items collection

### DIFF
--- a/src/core/domain/entities/game/inventory/Inventory.ts
+++ b/src/core/domain/entities/game/inventory/Inventory.ts
@@ -17,7 +17,7 @@ export default class Inventory {
     private readonly height = DEFAULT_INVENTORY_HEIGHT;
     private readonly equipment: Equipment;
     private readonly emitter = new EventEmitter();
-    private readonly items: Map<number, Item>;
+    private readonly items: Set<Item>;
     private readonly ownerId: number;
 
     constructor({ config, ownerId }: { config: GameConfig; ownerId: number }) {
@@ -26,7 +26,7 @@ export default class Inventory {
         }
 
         this.equipment = new Equipment(this.size());
-        this.items = new Map<number, Item>();
+        this.items = new Set<Item>();
         this.ownerId = ownerId;
     }
 
@@ -58,7 +58,7 @@ export default class Inventory {
                 item.setWindow(
                     this.isEquipmentPosition(realPosition) ? WindowTypeEnum.EQUIPMENT : WindowTypeEnum.INVENTORY,
                 );
-                this.items.set(item.getDbId()!, item);
+                this.items.add(item);
                 return realPosition;
             }
         }
@@ -72,7 +72,7 @@ export default class Inventory {
             item.setPosition(position);
             item.setOwnerId(this.ownerId);
             item.setWindow(this.isEquipmentPosition(position) ? WindowTypeEnum.EQUIPMENT : WindowTypeEnum.INVENTORY);
-            this.items.set(item.getDbId()!, item);
+            this.items.add(item);
             this.publish(ItemEquippedEvent.type, new ItemEquippedEvent({ item, slot: position - this.size() }));
             return;
         }
@@ -87,7 +87,7 @@ export default class Inventory {
             item.setPosition(position);
             item.setOwnerId(this.ownerId);
             item.setWindow(this.isEquipmentPosition(position) ? WindowTypeEnum.EQUIPMENT : WindowTypeEnum.INVENTORY);
-            this.items.set(item.getDbId()!, item);
+            this.items.add(item);
         }
     }
 
@@ -128,7 +128,7 @@ export default class Inventory {
 
         if (this.isFromEquipmentSlots(position)) {
             const unequippedItem = this.equipment.removeItem(position);
-            this.deleteFromItemsMap(item);
+            this.items.delete(item);
             this.publish(
                 ItemUnequippedEvent.type,
                 new ItemUnequippedEvent({ item: unequippedItem!, slot: position - this.size() }),
@@ -139,21 +139,7 @@ export default class Inventory {
         const page = this.calcPage(position);
         const pagePosition = this.calcPagePosition(page, position);
         this.pages[page].removeItem(pagePosition, size);
-        this.deleteFromItemsMap(item);
-    }
-
-    /**
-     * Removes the map entry for this exact item instance. Items bought from a
-     * shop are added to the map before their dbId is assigned (key undefined),
-     * so deleting by getDbId() would miss them and leave a ghost entry behind.
-     */
-    private deleteFromItemsMap(item: Item) {
-        for (const [key, mapped] of this.items) {
-            if (mapped === item) {
-                this.items.delete(key);
-                return;
-            }
-        }
+        this.items.delete(item);
     }
 
     haveAvailablePosition(position: number, size: number) {

--- a/test/unit/core/domain/inventory/Inventory.test.ts
+++ b/test/unit/core/domain/inventory/Inventory.test.ts
@@ -8,7 +8,7 @@ import { GameConfig } from '@/game/infra/config/GameConfig';
 
 const PAGE_SIZE = 45; // 5 x 9
 
-function createItem(id: number, dbId: number, size: number = 1) {
+function createItem(id: number, dbId: number | null, size: number = 1) {
     return new Item({
         id,
         name: `item-${id}`,
@@ -162,5 +162,66 @@ describe('Inventory', () => {
 
         expect(inventory.getItem(0)).to.equal(null);
         expect(inventory.haveAvailablePosition(0, 2)).to.equal(true);
+    });
+});
+
+describe('Inventory items collection (issue #118)', () => {
+    it('should keep every item added before its database insert, not just the last', () => {
+        const inventory = createInventory();
+        const first = createItem(27003, null);
+        const second = createItem(27004, null);
+
+        inventory.addItem(first);
+        inventory.addItem(second);
+
+        const listed = [...inventory.getItems().values()];
+        expect(listed, 'both fresh items were filed under one key, so the second evicted the first').to.have.members([
+            first,
+            second,
+        ]);
+    });
+
+    it('should keep an item placed at a fixed position before its database insert', () => {
+        const inventory = createInventory();
+        const first = createItem(27003, null);
+        const second = createItem(27004, null);
+
+        inventory.addItemAt(first, 0);
+        inventory.addItemAt(second, 1);
+
+        expect([...inventory.getItems().values()]).to.have.members([first, second]);
+    });
+
+    it('should still list an item after it gains its database id', () => {
+        const inventory = createInventory();
+        const item = createItem(27003, null);
+
+        inventory.addItem(item);
+        item.setDbId(4242);
+
+        expect([...inventory.getItems().values()]).to.have.members([item]);
+    });
+
+    it('should drop exactly the removed instance and keep the other fresh item', () => {
+        const inventory = createInventory();
+        const first = createItem(27003, null);
+        const second = createItem(27004, null);
+
+        inventory.addItemAt(first, 0);
+        inventory.addItemAt(second, 1);
+        inventory.removeItem(0, 1);
+
+        expect([...inventory.getItems().values()]).to.have.members([second]);
+    });
+
+    it('should drop an unequipped fresh item from the collection', () => {
+        const inventory = createInventory();
+        const armor = createItem(11299, null, 2);
+        const equipmentSlot = inventory.size() + 1;
+
+        inventory.addItemAt(armor, equipmentSlot);
+        inventory.removeItem(equipmentSlot, 1);
+
+        expect([...inventory.getItems().values()]).to.deep.equal([]);
     });
 });


### PR DESCRIPTION
Fixes #118.

## What the code does today

`Inventory` keeps its auxiliary lookup as `Map<number, Item>` keyed by `item.getDbId()!` — but an item created from a proto has no dbId until `ItemManager.save` mints one after the DB insert, and both write paths (shop buy via `addItemStacking`, stack split via `addItemAt`) put the item in the map first. Every fresh item lands under the key `null`, and the next one evicts it.

The grid stays right; the map does not — and the map is what stack merging (`Player.mergeIntoExistingStacks`), quest item counting (`AbstractQuest`), the private-shop Bundle check (`PrivateShopService.findBundle`) and the horse feed/name commands read. Two same-vnum purchases stop merging into each other, quest progress undercounts, and a bought Bundle is invisible to the shop opener.

## The fix — and the answer to the issue's open question

The issue asked whether to re-key the map on save or switch to a `Set`. The codebase answered: **every reader of `getItems()` iterates `.values()`** — none looks an item up by id (checked all six call sites). So the collection is now a `Set<Item>` keyed by identity, which removes the whole class of bug instead of patching the keying at each call site.

This also retires `deleteFromItemsMap`, the identity-scan workaround whose docblock documented this exact symptom on the removal side — deletion is now a plain `this.items.delete(item)`.

If you would rather keep the `Map<number, Item>` shape public (e.g. to support id lookups later), the narrow re-key-on-save fix is a straightforward switch — happy to do it.

## Verified

- Unit suite: 663/0 → **668/0** on current master (5 new cases in the existing `Inventory.test.ts`).
- Integration suite: **31/0**.
- Fail-without-fix: reverting the source change fails exactly the 2 eviction cases, while the 3 pinning cases (delete by identity, no re-key needed after `setDbId`) stay green.
- Items loaded at login were never affected — they arrive with a real id — and that path is covered by the existing spec cases.

## Note on scope

Pre-existing, independent of the open PRs. `tsc --noEmit`, eslint and prettier clean; no comments added to `src/` (the workaround docblock is removed).
