### PR TITLE
fix(item): enforce the original's anti-drop gate in DropItemService

### DIFF
--- a/src/game/app/service/DropItemService.ts
+++ b/src/game/app/service/DropItemService.ts
@@ -1,6 +1,7 @@
 import Player from '@/core/domain/entities/game/player/Player';
 import ItemManager from '@/core/domain/manager/ItemManager';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 import Logger from '@/core/infra/logger/Logger';
 
@@ -33,6 +34,14 @@ export default class DropItemService {
 
         if (!item) return;
         if (player.isItemLockedInPrivateShop(item)) return;
+
+        if (item.getAntiFlags().is(ItemAntiFlagEnum.ANTI_DROP | ItemAntiFlagEnum.ANTI_GIVE)) {
+            player.chat({
+                messageType: ChatMessageTypeEnum.INFO,
+                message: '[SYSTEM] This item cannot be dropped',
+            });
+            return;
+        }
 
         if (!Number.isInteger(count) || count <= 0 || count > item.getCount()) return;
 

--- a/test/unit/game/app/service/DropItemService.test.ts
+++ b/test/unit/game/app/service/DropItemService.test.ts
@@ -1,6 +1,8 @@
 import Player from '@/core/domain/entities/game/player/Player';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+import { ItemAntiFlagEnum } from '@/core/enum/ItemAntiFlagEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
+import BitFlag from '@/core/util/BitFlag';
 import DropItemService from '@/game/app/service/DropItemService';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -36,6 +38,7 @@ describe('DropItemService', function () {
             getId: sinon.stub().returns(27001),
             getCount: sinon.stub().returns(10),
             setCount: sinon.spy(),
+            getAntiFlags: sinon.stub().returns(new BitFlag()),
         };
 
         const playerMock = {
@@ -131,6 +134,7 @@ describe('DropItemService', function () {
             const itemMock = {
                 getCount: sinon.stub().returns(5),
                 getSize: sinon.stub().returns(1),
+                getAntiFlags: sinon.stub().returns(new BitFlag()),
             };
 
             const playerMock = {
@@ -225,6 +229,82 @@ describe('DropItemService', function () {
             expect(playerMock.dropItem.called).to.be.false;
             expect(itemManagerMock.delete.called).to.be.false;
             expect(loggerMock.error.calledOnce).to.be.true;
+        });
+
+        const antiFlagDropSetup = (flag: number) => {
+            const antiFlags = new BitFlag();
+            antiFlags.set(flag);
+
+            const itemMock = {
+                getCount: sinon.stub().returns(5),
+                getSize: sinon.stub().returns(1),
+                getAntiFlags: sinon.stub().returns(antiFlags),
+            };
+
+            const playerMock = {
+                isItemLockedInPrivateShop: sinon.stub().returns(false),
+                getInventory: sinon.stub().returns({
+                    getItem: sinon.stub().returns(itemMock),
+                    removeItem: sinon.spy(),
+                }),
+                sendItemRemoved: sinon.spy(),
+                dropItem: sinon.spy(),
+                chat: sinon.spy(),
+            };
+
+            return { itemMock, playerMock };
+        };
+
+        it('should refuse to drop an item carrying ANTI_DROP (issue #97)', async function () {
+            const { playerMock } = antiFlagDropSetup(ItemAntiFlagEnum.ANTI_DROP);
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            expect(playerMock.getInventory().removeItem.called, 'the item stays in the inventory').to.be.false;
+            expect(playerMock.dropItem.called, 'nothing hits the ground').to.be.false;
+            expect(itemManagerMock.delete.called, 'the row survives').to.be.false;
+            expect(playerMock.chat.calledOnce).to.be.true;
+            expect(playerMock.chat.firstCall.args[0]).to.deep.equal({
+                messageType: ChatMessageTypeEnum.INFO,
+                message: '[SYSTEM] This item cannot be dropped',
+            });
+        });
+
+        it('should refuse to drop an item carrying ANTI_GIVE, like the original (issue #97)', async function () {
+            const { playerMock } = antiFlagDropSetup(ItemAntiFlagEnum.ANTI_GIVE);
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            expect(playerMock.getInventory().removeItem.called).to.be.false;
+            expect(playerMock.dropItem.called).to.be.false;
+            expect(playerMock.chat.calledOnce).to.be.true;
+        });
+
+        it('should still drop an item whose anti-flags do not include ANTI_DROP or ANTI_GIVE', async function () {
+            const { playerMock } = antiFlagDropSetup(ItemAntiFlagEnum.ANTI_SELL);
+
+            await dropItemService.execute({
+                window: 1,
+                position: 0,
+                gold: 0,
+                count: 5,
+                player: playerMock as unknown as Player,
+            });
+
+            expect(playerMock.dropItem.calledOnce, 'ANTI_SELL alone does not block a drop').to.be.true;
+            expect(playerMock.chat.called).to.be.false;
         });
 
         it('should do nothing if item is not found', async function () {


### PR DESCRIPTION
Fixes #97 — and corrects two of that issue's own claims against the original source.

## What the code does today

`ItemAntiFlagEnum` declares `ANTI_DROP`, 517 protos in `items.json` carry it, and nothing ever consults it: a drop packet grounds any item. Since pickup hands the item to whoever is standing there, drop + pickup works as a transfer for exactly the items whose flags exist to make them non-transferable.

## The fix

The gate mirrors `CHARACTER::DropItem` in the original (`char_item.cpp:5388`), which rejects on **`ANTI_DROP | ANTI_GIVE` together** — not `ANTI_DROP` alone — with an info chat message. `BitFlag.is` has the same any-bit semantics as the original's `IS_SET`, so the mask translates directly:

```ts
if (item.getAntiFlags().is(ItemAntiFlagEnum.ANTI_DROP | ItemAntiFlagEnum.ANTI_GIVE)) { ... reject }
```

## Two corrections to the issue, verified against the 40250 source

- **The original does not check `ANTI_GET` on pickup.** The flag exists only in `item_length.h`; a grep over `game/src` finds zero uses. So no pickup check is added here — enforcing it would be an invention, not a restoration. If you want it anyway as a deliberate hardening, say so and it is a three-line follow-up.
- **The original does not refuse to drop equipped items.** `ItemDrop2` passes straight to `DropItem`, and `IsValidItemPosition` accepts equipment cells. Our equipped-drop path is also no longer desynced: `Inventory.removeItem` on an equipment slot publishes `ITEM_UNEQUIPPED`, and `Player` subscribes (applies removed, `calcPoints()`, `updateView()`) — the issue's second half was resolved by the applies work that landed after it was filed.

## Verified

- Unit suite: 663/0 → **666/0**. Without the gate, exactly the `ANTI_DROP` and `ANTI_GIVE` rejection cases fail; an `ANTI_SELL` passthrough case pins that unrelated flags keep dropping.
- `tsc --noEmit`, eslint and prettier clean.

## Note on scope

Pre-existing; both halves of the original issue re-verified before implementing, per the usual routine.
