### PR TITLE
fix(item): expire dropped-item ownership even when nobody is nearby

### DIFF
--- a/src/core/domain/entities/game/item/DroppedItem.ts
+++ b/src/core/domain/entities/game/item/DroppedItem.ts
@@ -70,9 +70,9 @@ export default class DroppedItem extends GameEntity {
     public onSpawn() {
         this.addEventTimer({
             eventFunction: () => {
+                this.ownerName = null;
                 for (const entity of this.getNearbyEntities().values()) {
                     if (entity instanceof Player) {
-                        this.ownerName = null;
                         entity.sendSetItemOwnership({
                             ownerName: '\0',
                             virtualId: this.getVirtualId(),

--- a/test/unit/core/domain/entities/game/item/DroppedItem.test.ts
+++ b/test/unit/core/domain/entities/game/item/DroppedItem.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
+import Item from '@/core/domain/entities/game/item/Item';
+import Player from '@/core/domain/entities/game/player/Player';
+import GlobalEventTimerManager, { addTimerParam } from '@/core/domain/manager/GlobalEventTimeManager';
+
+const OWNER = 'dropper';
+
+function createDroppedItem(timers: Map<string, addTimerParam>) {
+    const eventTimerManager = {
+        addTimer: (params: addTimerParam) => timers.set(params.id, params),
+        removeTimersByOwner: () => {},
+        removeTimer: () => {},
+        isTimerActive: () => false,
+    } as unknown as GlobalEventTimerManager;
+
+    return DroppedItem.create(
+        {
+            item: { getId: () => 27003 } as unknown as Item,
+            count: 1,
+            ownerName: OWNER,
+            virtualId: 42,
+            positionX: 100,
+            positionY: 200,
+        },
+        { eventTimerManager },
+    );
+}
+
+function createNearbyPlayer(virtualId: number) {
+    const player = Object.create(Player.prototype);
+    player.getVirtualId = () => virtualId;
+    player.sendSetItemOwnership = sinon.spy();
+    return player;
+}
+
+describe('DroppedItem ownership expiry (issue #98)', () => {
+    it('should clear the ownership when the timer fires with nobody nearby', () => {
+        const timers = new Map<string, addTimerParam>();
+        const droppedItem = createDroppedItem(timers);
+
+        droppedItem.onSpawn();
+        timers.get('REMOVE_OWNER')!.eventFunction(1);
+
+        expect(droppedItem.getOwnerName()).to.equal(null);
+    });
+
+    it('should clear the ownership and notify a nearby player', () => {
+        const timers = new Map<string, addTimerParam>();
+        const droppedItem = createDroppedItem(timers);
+        const nearby = createNearbyPlayer(7);
+
+        droppedItem.addNearbyEntity(nearby);
+        droppedItem.onSpawn();
+        timers.get('REMOVE_OWNER')!.eventFunction(1);
+
+        expect(droppedItem.getOwnerName()).to.equal(null);
+        expect(nearby.sendSetItemOwnership.calledOnce).to.equal(true);
+        expect(nearby.sendSetItemOwnership.firstCall.args[0]).to.deep.equal({
+            ownerName: '\0',
+            virtualId: 42,
+        });
+    });
+
+    it('should keep the ownership until the timer fires', () => {
+        const timers = new Map<string, addTimerParam>();
+        const droppedItem = createDroppedItem(timers);
+
+        droppedItem.onSpawn();
+
+        expect(droppedItem.getOwnerName()).to.equal(OWNER);
+    });
+});


### PR DESCRIPTION
Fixes #98.

## What the code does today

`DroppedItem.onSpawn` arms the one-shot `REMOVE_OWNER` timer (15 s) whose callback clears `ownerName` from **inside** the loop over nearby entities. If no player is in view range at the exact moment it fires, the loop body never runs, ownership is never cleared, and there is no second chance — the item stays locked to the dropper for the rest of its 30-second life. `PickupItemService` keeps rejecting everyone else, dropped gold included, since the owner check sits ahead of the gold branch.

## The fix

The shape suggested in the issue: hoist `this.ownerName = null` out of the loop so expiry happens whether or not anyone is watching; the `sendSetItemOwnership` packet stays inside it, because only nearby clients need telling.

As the issue notes, a player who walks into range *after* the timer fired still sees the stale owner label client-side (ownership is only pushed on this one event) — but the pickup itself is now correct. That visual is a smaller, separate follow-up; say the word and I'll take it.

## Verified

- New `DroppedItem.test.ts` captures the armed `REMOVE_OWNER` callback through a stubbed timer manager and drives it directly:
  - nobody nearby → ownership cleared (**fails without the fix**: `expected 'dropper' to equal null`);
  - one nearby player → ownership cleared *and* the notification packet still goes out exactly once with `ownerName: '\0'`;
  - before the timer fires → ownership intact.
- Unit suite: 663/0 → **666/0**; `tsc --noEmit`, eslint and prettier clean.

## Note on scope

Pre-existing — #71 widened its reach to gold but did not create it. Independent of the other open PRs.
