### PR TITLE
fix(auth): refuse logins the account status does not allow

### DIFF
--- a/src/auth/app/service/LoginService.ts
+++ b/src/auth/app/service/LoginService.ts
@@ -7,6 +7,10 @@ import { EncryptionProvider } from '@/core/infra/encryption/EncryptionProvider';
 import Result from '@/core/domain/util/Result';
 import { IAccountRepository } from '@/core/domain/repository/IAccountRepository';
 
+export type LoginError =
+    | { type: Exclude<ErrorTypesEnum, ErrorTypesEnum.LOGIN_NOT_ALLOWED> }
+    | { type: ErrorTypesEnum.LOGIN_NOT_ALLOWED; clientStatus: string };
+
 export default class LoginService {
     private readonly accountRepository: IAccountRepository;
     private readonly logger: Logger;
@@ -30,25 +34,31 @@ export default class LoginService {
         this.encryptionProvider = encryptionProvider;
     }
 
-    async execute({
-        username,
-        password,
-    }: {
-        username: string;
-        password: string;
-    }): Promise<Result<number, ErrorTypesEnum>> {
+    async execute({ username, password }: { username: string; password: string }): Promise<Result<number, LoginError>> {
         const account = await this.accountRepository.findByUsername(username);
 
         if (!account) {
             this.logger.info(`[LoginService] Username not found for username ${username}`);
-            return Result.error(ErrorTypesEnum.INVALID_USERNAME);
+            return Result.error({ type: ErrorTypesEnum.INVALID_USERNAME });
         }
 
         const isPasswordValid = await this.encryptionProvider.compare(password, account.getPassword());
 
         if (!isPasswordValid) {
             this.logger.info(`[LoginService] Invalid password for username ${username}`);
-            return Result.error(ErrorTypesEnum.INVALID_PASSWORD);
+            return Result.error({ type: ErrorTypesEnum.INVALID_PASSWORD });
+        }
+
+        const accountStatus = account.getAccountStatus();
+
+        if (!accountStatus.getAllowLogin()) {
+            this.logger.info(
+                `[LoginService] Login not allowed for username ${username} (status: ${accountStatus.getClientStatus()})`,
+            );
+            return Result.error({
+                type: ErrorTypesEnum.LOGIN_NOT_ALLOWED,
+                clientStatus: accountStatus.getClientStatus(),
+            });
         }
 
         const key = randomBytes(4).readUInt32LE();

--- a/src/core/enum/ErrorTypesEnum.ts
+++ b/src/core/enum/ErrorTypesEnum.ts
@@ -10,4 +10,5 @@ export enum ErrorTypesEnum {
     PLAYER_NOT_FOUND = 9,
     INVALID_DELETE_CODE = 10,
     SLOT_ALREADY_TAKEN = 11,
+    LOGIN_NOT_ALLOWED = 12,
 }

--- a/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacketHandler.ts
@@ -9,6 +9,7 @@ import LoginStatusEnum from '@/core/enum/LoginStatusEnum';
 import LoginSuccessPacket from '../../out/LoginSuccessPacket';
 
 const LOGIN_SUCCESS_RESULT = 1;
+const ACCOUNT_STATUS_MAX_LEN = 8;
 
 export default class LoginRequestPacketHandler extends PacketHandler<LoginRequestPacket> {
     private readonly loginService: LoginService;
@@ -37,9 +38,9 @@ export default class LoginRequestPacketHandler extends PacketHandler<LoginReques
         });
 
         if (result.hasError()) {
-            const error = result.getError();
+            const error = result.getError()!;
 
-            switch (error) {
+            switch (error.type) {
                 case ErrorTypesEnum.INVALID_USERNAME:
                 case ErrorTypesEnum.INVALID_PASSWORD:
                     connection.send(
@@ -49,8 +50,16 @@ export default class LoginRequestPacketHandler extends PacketHandler<LoginReques
                     );
                     break;
 
+                case ErrorTypesEnum.LOGIN_NOT_ALLOWED:
+                    connection.send(
+                        new LoginFailedPacket({
+                            status: error.clientStatus.slice(0, ACCOUNT_STATUS_MAX_LEN),
+                        }),
+                    );
+                    break;
+
                 default:
-                    this.logger.info(`[LoginRequestPacketHandler] Invalid error: ${error}`);
+                    this.logger.info(`[LoginRequestPacketHandler] Invalid error: ${error.type}`);
                     break;
             }
             return;

--- a/test/unit/auth/app/service/LoginService.test.ts
+++ b/test/unit/auth/app/service/LoginService.test.ts
@@ -35,29 +35,49 @@ describe('LoginService', function () {
         loginService = new LoginService({ accountRepository, logger, cacheProvider, encryptionProvider });
     });
 
+    const createAccount = ({ allowLogin = true, clientStatus = 'OK' } = {}) => ({
+        id: 1,
+        getId: () => 1,
+        getUsername: () => 'user',
+        getPassword: () => 'hashedPassword',
+        getAccountStatus: () => ({
+            getAllowLogin: () => allowLogin,
+            getClientStatus: () => clientStatus,
+        }),
+    });
+
     it('should return an error if username is not found', async function () {
         accountRepository.findByUsername.resolves(null);
 
         const result = await loginService.execute({ username: 'nonexistent', password: 'password' });
 
-        expect(result).to.deep.equal(Result.error(ErrorTypesEnum.INVALID_USERNAME));
+        expect(result).to.deep.equal(Result.error({ type: ErrorTypesEnum.INVALID_USERNAME }));
         expect(logger.info.calledOnce).to.be.true;
     });
 
     it('should return an error if password is invalid', async function () {
-        const account = { id: 1, getId: () => 1, getUsername: () => 'user', getPassword: () => 'hashedPassword' };
-        accountRepository.findByUsername.resolves(account);
+        accountRepository.findByUsername.resolves(createAccount());
         encryptionProvider.compare.resolves(false);
 
         const result = await loginService.execute({ username: 'user', password: 'wrongPassword' });
 
-        expect(result).to.deep.equal(Result.error(ErrorTypesEnum.INVALID_PASSWORD));
+        expect(result).to.deep.equal(Result.error({ type: ErrorTypesEnum.INVALID_PASSWORD }));
+        expect(logger.info.calledOnce).to.be.true;
+    });
+
+    it('should refuse a login the account status does not allow (issue #106)', async function () {
+        accountRepository.findByUsername.resolves(createAccount({ allowLogin: false, clientStatus: 'BLOCK' }));
+        encryptionProvider.compare.resolves(true);
+
+        const result = await loginService.execute({ username: 'user', password: 'correctPassword' });
+
+        expect(result).to.deep.equal(Result.error({ type: ErrorTypesEnum.LOGIN_NOT_ALLOWED, clientStatus: 'BLOCK' }));
+        expect(cacheProvider.set.notCalled, 'no session token is minted for a blocked account').to.be.true;
         expect(logger.info.calledOnce).to.be.true;
     });
 
     it('should return a key and cache the token if credentials are valid', async function () {
-        const account = { id: 1, getId: () => 1, getUsername: () => 'user', getPassword: () => 'hashedPassword' };
-        accountRepository.findByUsername.resolves(account);
+        accountRepository.findByUsername.resolves(createAccount());
         encryptionProvider.compare.resolves(true);
 
         const result = await loginService.execute({ username: 'user', password: 'correctPassword' });

--- a/test/unit/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacketHandler.test.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import LoginRequestPacketHandler from '@/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacketHandler';
+import LoginFailedPacket from '@/core/interface/networking/packets/packet/out/LoginFailedPacket';
+import LoginSuccessPacket from '@/core/interface/networking/packets/packet/out/LoginSuccessPacket';
+import Result from '@/core/domain/util/Result';
+import { ErrorTypesEnum } from '@/core/enum/ErrorTypesEnum';
+import GameConnection from '@/game/interface/networking/GameConnection';
+
+describe('LoginRequestPacketHandler', function () {
+    let loginService: any;
+    let logger: any;
+    let connection: any;
+    let handler: LoginRequestPacketHandler;
+
+    const packet = (username = 'user', password = 'pass') =>
+        ({
+            isValid: () => true,
+            getUsername: () => username,
+            getPassword: () => password,
+        }) as any;
+
+    beforeEach(function () {
+        loginService = { execute: sinon.stub() };
+        logger = { info: sinon.spy(), error: sinon.spy() };
+        connection = { send: sinon.spy(), close: sinon.spy() };
+        handler = new LoginRequestPacketHandler({ loginService, logger });
+    });
+
+    it('should answer wrong credentials with WRONGPWD', async function () {
+        loginService.execute.resolves(Result.error({ type: ErrorTypesEnum.INVALID_PASSWORD }));
+
+        await handler.execute(connection as GameConnection, packet());
+
+        expect(connection.send.calledOnce).to.be.true;
+        const sent = connection.send.firstCall.args[0];
+        expect(sent).to.be.instanceOf(LoginFailedPacket);
+        expect(sent['status']).to.equal('WRONGPWD');
+    });
+
+    it('should answer a blocked account with its clientStatus string (issue #106)', async function () {
+        loginService.execute.resolves(Result.error({ type: ErrorTypesEnum.LOGIN_NOT_ALLOWED, clientStatus: 'BLOCK' }));
+
+        await handler.execute(connection as GameConnection, packet());
+
+        expect(connection.send.calledOnce).to.be.true;
+        const sent = connection.send.firstCall.args[0];
+        expect(sent).to.be.instanceOf(LoginFailedPacket);
+        expect(sent['status']).to.equal('BLOCK');
+    });
+
+    it('should clamp the status string to the wire limit of the failure packet', async function () {
+        loginService.execute.resolves(
+            Result.error({ type: ErrorTypesEnum.LOGIN_NOT_ALLOWED, clientStatus: 'BLOCKED_FOR_ABUSE' }),
+        );
+
+        await handler.execute(connection as GameConnection, packet());
+
+        const sent = connection.send.firstCall.args[0];
+        expect(sent['status'], 'ACCOUNT_STATUS_MAX_LEN is 8 in the client struct').to.equal('BLOCKED_');
+    });
+
+    it('should answer valid credentials with the session key', async function () {
+        loginService.execute.resolves(Result.ok(1234));
+
+        await handler.execute(connection as GameConnection, packet());
+
+        expect(connection.send.calledOnce).to.be.true;
+        expect(connection.send.firstCall.args[0]).to.be.instanceOf(LoginSuccessPacket);
+    });
+});

--- a/test/unit/game/domain/service/LoginTokenLifetime.test.ts
+++ b/test/unit/game/domain/service/LoginTokenLifetime.test.ts
@@ -70,7 +70,14 @@ describe('login token lifetime (issue #237)', () => {
             cacheProvider: minted,
             encryptionProvider: { compare: async () => true },
             accountRepository: {
-                findByUsername: async () => ({ id: 1, getPassword: () => 'hashed' }),
+                findByUsername: async () => ({
+                    id: 1,
+                    getPassword: () => 'hashed',
+                    getAccountStatus: () => ({
+                        getAllowLogin: () => true,
+                        getClientStatus: () => 'OK',
+                    }),
+                }),
             },
         } as never);
 


### PR DESCRIPTION
Fixes #106 — and answers the design question that issue left open, with the original as the tiebreaker.

## What the code does today

`AccountRepository.findByUsername` joins `account_status` on every login and maps `allowLogin` and `clientStatus` into the entity — and then nothing reads them. `Account.getAccountStatus()` has zero callers in `src/`; setting `allowLogin = FALSE` changes nothing and the ban flag in the schema is decorative.

## The fix

`LoginService` checks the status **after** the password, so a blocked account answers identically whether or not its password was right, and no session token is minted for it. The service's error channel widens from a bare enum to a small discriminated union so the status string travels with the `LOGIN_NOT_ALLOWED` error; the two existing error returns keep their semantics.

## The design question: fixed string or the `clientStatus` column?

The original settles it — **the per-row string**: `input_db.cpp:142` forwards `pTab->status` verbatim whenever it is not `"OK"`, and the client's `intrologin.py` maps known strings (`BLOCK`, `QUIT`, `SHUTDOWN`, …) to specific messages, falling back to `LOGIN_FAILURE_UNKNOWN + error` for anything else. An admin-authored status is therefore safe to forward, and the column finally does what it looks like it was built for.

One wire detail: the handler clamps the string to 8 characters before packing — `ACCOUNT_STATUS_MAX_LEN` is 8 in the client struct (`common/length.h:12`), and `LoginFailedPacket`'s declared size of 10 holds exactly header + 8 chars + NUL, while our `clientStatus` column allows `VARCHAR(20)`.

## Verified

- Unit suite: 663/0 → **668/0** — one new service case, and four handler cases in a new `LoginRequestPacketHandler.test.ts` (the handler had no behavioural spec at all): WRONGPWD mapping, blocked → `BLOCK`, the 8-char clamp, and the success path.
- Fail-without-fix: on master the blocked account **logs in normally** and five of the new assertions fail.
- `tsc --noEmit`, eslint and prettier clean. Happy to also run the issue's live reproduction against the stock client (`UPDATE auth.account_status SET allowLogin = FALSE` → login as `admin`) and report the rendered message, if you want it double-checked end-to-end.

## Note on scope

Pre-existing. The `ALREADY` double-login gap is #105 and stays separate.
