### PR TITLE
fix(networking): await the item use and item move services so their failures cannot kill the process

### DIFF
--- a/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/itemMove/ItemMovePacketHandler.ts
@@ -32,7 +32,7 @@ export default class ItemMovePacketHandler extends PacketHandler<ItemMovePacket>
             return;
         }
 
-        this.moveItemService.execute({
+        await this.moveItemService.execute({
             player,
             fromWindow: packet.getFromWindow(),
             fromPosition: packet.getFromPosition(),

--- a/src/core/interface/networking/packets/packet/in/itemUse/ItemUsePacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/itemUse/ItemUsePacketHandler.ts
@@ -35,6 +35,6 @@ export default class ItemUsePacketHandler extends PacketHandler<ItemUsePacket> {
         const window = packet.getWindow();
         const position = packet.getPosition();
 
-        this.useItemService.execute(player, window, position);
+        await this.useItemService.execute(player, window, position);
     }
 }

--- a/test/unit/core/interface/networking/packets/packets/in/itemUse/ItemUsePacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/itemUse/ItemUsePacketHandler.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ItemUsePacketHandler from '@/core/interface/networking/packets/packet/in/itemUse/ItemUsePacketHandler';
+import ItemMovePacketHandler from '@/core/interface/networking/packets/packet/in/itemMove/ItemMovePacketHandler';
+import GameConnection from '@/game/interface/networking/GameConnection';
+
+/**
+ * Regression for issue #103: both handlers dispatched their service without
+ * awaiting it, so a rejection inside the service escaped the dispatcher's
+ * catch and reached the process-level unhandledRejection handler, which
+ * main.ts turns into a process exit. Awaiting is what lets GameServer's
+ * .catch see it.
+ */
+describe('Item handlers propagate service rejections (issue #103)', () => {
+    const logger = () => ({ error: sinon.spy(), info: sinon.spy(), debug: sinon.spy() });
+
+    const connectionWithPlayer = () =>
+        ({
+            getPlayer: () => ({ getName: () => 'tester' }),
+            close: sinon.spy(),
+        }) as unknown as GameConnection;
+
+    const usePacket = () =>
+        ({
+            isValid: () => true,
+            getWindow: () => 1,
+            getPosition: () => 0,
+        }) as any;
+
+    const movePacket = () =>
+        ({
+            isValid: () => true,
+            getFromWindow: () => 1,
+            getFromPosition: () => 0,
+            getToWindow: () => 1,
+            getToPosition: () => 1,
+            getCount: () => 1,
+        }) as any;
+
+    it('should surface a failing item use instead of leaking its rejection to the process', async () => {
+        const failure = new Error('boom');
+        const useItemService = { execute: sinon.stub().rejects(failure) };
+        const handler = new ItemUsePacketHandler({ logger: logger() as any, useItemService: useItemService as any });
+
+        const outcome = await handler
+            .execute(connectionWithPlayer(), usePacket())
+            .then(() => 'resolved')
+            .catch((err) => err);
+
+        expect(outcome, 'the caller can see the failure').to.equal(failure);
+    });
+
+    it('should surface a failing item move instead of leaking its rejection to the process', async () => {
+        const failure = new Error('boom');
+        const moveItemService = { execute: sinon.stub().rejects(failure) };
+        const handler = new ItemMovePacketHandler({ logger: logger() as any, moveItemService: moveItemService as any });
+
+        const outcome = await handler
+            .execute(connectionWithPlayer(), movePacket())
+            .then(() => 'resolved')
+            .catch((err) => err);
+
+        expect(outcome, 'the caller can see the failure').to.equal(failure);
+    });
+
+    it('should still resolve normally when the item use succeeds', async () => {
+        const useItemService = { execute: sinon.stub().resolves() };
+        const handler = new ItemUsePacketHandler({ logger: logger() as any, useItemService: useItemService as any });
+
+        await handler.execute(connectionWithPlayer(), usePacket());
+
+        expect(useItemService.execute.calledOnceWith(sinon.match.any, 1, 0)).to.equal(true);
+    });
+});


### PR DESCRIPTION
Refs #103 — this takes only the first of that issue's three parts, and **corrects the second one**, which is mechanically wrong as filed.

## What the code does today

`ItemUsePacketHandler` and `ItemMovePacketHandler` dispatch their service without awaiting it. `GameServer` catches and logs whatever the handler's promise rejects with (`GameServer.ts:61-63`) — but a floating promise is not part of that chain, so a rejection inside `UseItemService` or `MoveItemService` escapes to the process-level `unhandledRejection` listener, which `main.ts` turns into a process exit. That is the exact mechanism that made #83 a full outage. Both services await `itemManager` and repository calls, so they really can reject.

## Sweep, and what is deliberately left alone

All 26 `in/` handlers checked. Six dispatch without `await`; three of those callees are synchronous and are not promises at all (`EnterGame`, `QuestAnswer`, `Shop`). Of the remaining three:

- **`ItemUse` and `ItemMove`** — fixed here.
- **`ItemDrop`** — same defect, but open PR #116 already fixes that exact line. Left untouched so this does not conflict.
- **`QuestButton`** — floats, but `AbstractQuest` swallows every error on that path so it cannot reach the process handler, and #116 rewrites that file. Worth a follow-up after #116 lands, not a conflict now.

## Correction to the issue: part 2's mechanism is wrong

I wrote in #103 that equip/unequip toggling "drives unbounded database writes". That is not what happens. `ItemManager.update` is an in-memory `Map.set` into `ItemCache` (`ItemManager.ts:90-93` → `ItemCache.ts:20-23`), keyed by item id, so repeated toggles of one item collapse to a single entry; the only DB write is the 120-second save tick. The real cost of that loop is `points.calcPoints()` plus an O(nearby players) `CharacterUpdatePacket` fan-out per packet (`Player.ts:963-966` → `:1379-1400`) — CPU and bandwidth, not I/O. Still worth throttling, but the amplification argument in the issue should not be taken at face value, and I would rather correct it than build a fix on it. Part 3 (the unvalidated `window` field) stands as filed.

## Verified

- Unit suite 663/0 → **666/0**; new specs drive each handler with a rejecting service stub and assert the returned promise rejects — which is what makes the failure visible to the dispatcher. Both fail without the `await`.
- `tsc --noEmit`, eslint, prettier clean.

## Note on scope

Pre-existing. No behaviour change on the success path.
