### PR TITLE
fix(networking): reject clicks on entities outside the player's area and view radius

### DIFF
--- a/src/core/domain/Area.ts
+++ b/src/core/domain/Area.ts
@@ -14,7 +14,7 @@ import { AtlasInfoGoto } from '@/game/infra/config/GameConfig';
 import { EntityManager } from './manager/EntityManager';
 
 const SIZE_QUEUE = 5_000;
-const CHAR_VIEW_SIZE = 8000;
+export const CHAR_VIEW_SIZE = 8000;
 const SPAWN_POSITION_MULTIPLIER = 100;
 
 export default class Area {

--- a/src/core/interface/networking/packets/packet/in/onclick/OnClickPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/onclick/OnClickPacketHandler.ts
@@ -6,6 +6,8 @@ import { QuestManager } from '@/core/domain/quests/QuestManager';
 import NPC from '@/core/domain/entities/game/mob/NPC';
 import ShopManager from '@/core/domain/shop/ShopManager';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
+import { CHAR_VIEW_SIZE } from '@/core/domain/Area';
+import MathUtil from '@/core/domain/util/MathUtil';
 
 export default class OnClickPacketHandler extends PacketHandler<OnClickPacket> {
     private readonly logger: Logger;
@@ -58,7 +60,26 @@ export default class OnClickPacketHandler extends PacketHandler<OnClickPacket> {
             return;
         }
 
-        //TODO: validate id the target item is in the same map, maybe the distance too (avoid hacking)
+        if (target.getArea() !== player.getArea()) {
+            this.logger.info(
+                `[OnClickPacketHandler] Player ${player.getName()} clicked virtualId ${packet.getTargetVirtualId()} from another area`,
+            );
+            return;
+        }
+
+        const distance = MathUtil.calcDistance(
+            player.getPositionX(),
+            player.getPositionY(),
+            target.getPositionX(),
+            target.getPositionY(),
+        );
+
+        if (distance > CHAR_VIEW_SIZE) {
+            this.logger.info(
+                `[OnClickPacketHandler] Player ${player.getName()} clicked virtualId ${packet.getTargetVirtualId()} from ${distance} units away`,
+            );
+            return;
+        }
 
         if (target instanceof NPC) {
             this.logger.info(`[OnClickPacketHandler] You have clicked on: ${target.getId()}`);

--- a/test/unit/core/interface/networking/packets/packets/in/onclick/OnClickPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/onclick/OnClickPacketHandler.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import OnClickPacketHandler from '@/core/interface/networking/packets/packet/in/onclick/OnClickPacketHandler';
+import GameConnection from '@/game/interface/networking/GameConnection';
+
+/**
+ * Regression for issue #102: the handler resolved the clicked entity from a
+ * world-wide virtual-id lookup and dispatched with no positional check, so a
+ * crafted virtual id reached QuestManager.onClick and ShopManager.openShop
+ * from any distance and any map.
+ */
+describe('OnClickPacketHandler range gate (issue #102)', () => {
+    const AREA_A = { id: 'a' };
+    const AREA_B = { id: 'b' };
+
+    let questManager: any;
+    let shopManager: any;
+    let entityManager: any;
+    let logger: any;
+    let handler: OnClickPacketHandler;
+
+    const target = ({ area = AREA_A, x = 100, y = 100 } = {}) => ({
+        getArea: () => area,
+        getPositionX: () => x,
+        getPositionY: () => y,
+        getId: () => 20001,
+        getVirtualId: () => 77,
+    });
+
+    const connectionWith = (player: any) =>
+        ({ getPlayer: () => player, close: sinon.spy() }) as unknown as GameConnection;
+
+    const player = ({ area = AREA_A, x = 100, y = 100 } = {}) => ({
+        getArea: () => area,
+        getPositionX: () => x,
+        getPositionY: () => y,
+        getName: () => 'clicker',
+    });
+
+    const packet = () => ({ isValid: () => true, getTargetVirtualId: () => 77 }) as any;
+
+    beforeEach(() => {
+        questManager = { onClick: sinon.stub().resolves(false) };
+        shopManager = { openShop: sinon.stub().resolves() };
+        entityManager = { getEntity: sinon.stub() };
+        logger = { error: sinon.spy(), info: sinon.spy(), debug: sinon.spy() };
+        handler = new OnClickPacketHandler({ logger, questManager, shopManager, entityManager });
+    });
+
+    it('should dispatch a click on a target standing next to the player', async () => {
+        entityManager.getEntity.returns(target({ x: 150, y: 150 }));
+
+        await handler.execute(connectionWith(player()), packet());
+
+        expect(questManager.onClick.calledOnce, 'the quest path runs').to.equal(true);
+        expect(shopManager.openShop.calledOnce, 'and the shop path follows it').to.equal(true);
+    });
+
+    it('should refuse a click on a target in another area', async () => {
+        entityManager.getEntity.returns(target({ area: AREA_B, x: 100, y: 100 }));
+
+        await handler.execute(connectionWith(player({ area: AREA_A })), packet());
+
+        expect(questManager.onClick.called, 'no quest state is advanced across maps').to.equal(false);
+        expect(shopManager.openShop.called, 'and no shop is opened across maps').to.equal(false);
+    });
+
+    it('should refuse a click from beyond the view radius', async () => {
+        entityManager.getEntity.returns(target({ x: 100_000, y: 100_000 }));
+
+        await handler.execute(connectionWith(player({ x: 100, y: 100 })), packet());
+
+        expect(questManager.onClick.called).to.equal(false);
+        expect(shopManager.openShop.called).to.equal(false);
+    });
+
+    it('should still allow a click at the edge of the view radius', async () => {
+        entityManager.getEntity.returns(target({ x: 100 + 7_999, y: 100 }));
+
+        await handler.execute(connectionWith(player({ x: 100, y: 100 })), packet());
+
+        expect(questManager.onClick.calledOnce, 'an honest client can hold this virtual id').to.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #102.

## What the code does today

`OnClickPacketHandler` resolves the clicked entity straight from `EntityManager.getEntity` — one global map over the whole world — and dispatches with no positional check; the in-tree TODO on that line said as much. Virtual ids are sequential, so a crafted id reaches both consumers from anywhere: quest CLICK states advance from another map, and `PrivateShopService.openShopForGuest` returns a stranger's full item list and registers the sender as a guest of their shop.

## The fix, and why these two gates

**The area check is the load-bearing half, and it cannot reject an honest click.** `Area.linkNearbyEntities` and `Area.onCharacterMove` only ever query the per-Area AoI, so a client is never told about a virtual id outside its own area. Anything arriving from another area was fabricated.

**The distance ceiling is `CHAR_VIEW_SIZE`, not `SHOP_MAX_DISTANCE`.** That is the same radius those two methods use to decide what the client learns about, so it is the real "could this client even hold this id" bound. I had first reached for the tighter 2000 — it would have silently narrowed quest clicks from ~8000 to 2000, with no log, no client feedback and nothing in the suite to catch it. Flagging that explicitly since the issue's own suggestion pointed that way.

## Deliberate deviation from the original

The original has **no** spatial gate on this path: `CInputMain::OnClick` (`input_main.cpp:1091`) and `CHARACTER::OnClick` (`char.cpp:4846`) check state — dead, exchanging, already shopping — never position. The justification for being stricter is architectural rather than cosmetic: the original's `CHARACTER_MANAGER` is per-game-core with each core serving a fixed subset of maps, so cross-map clicking was bounded by process topology. Our `EntityManager` has no such bound, so it has to be explicit.

Left alone deliberately: the NPC shop path already gates on `isNearShopOwner`, and private-shop purchases already gate on `SHOP_MAX_DISTANCE`. Those stay as defence in depth rather than being rewritten here.

## Verified

- Unit suite 663/0 → **667/0**. The handler had no spec at all; the new one covers the adjacent click, the cross-area click, the far click, and a click at the very edge of the view radius that must still work. Both rejection cases fail without the gate.
- `tsc --noEmit`, eslint, prettier clean. `CHAR_VIEW_SIZE` is exported from `Area.ts` rather than duplicated.

## Two adjacent things I found and did not bundle

- Our NPC-shop open range is 2000, but the original's `CShopManager::StartShopping` uses `SHOP_MAX_DISTANCE = 1000` (`shop.h:6`); 2000 is only its buy/sell ceiling. Separate, smaller question.
- `char.cpp:4860` refuses a click when the *causer* is running their own private shop. We only check that inside `openShopForGuest`, so it does not block quest clicks or NPC shops. Happy to file it.
