### PR TITLE
fix(quest): gate onButton on the running-quest check like every other quest event

### DIFF
--- a/src/core/domain/quests/QuestManager.ts
+++ b/src/core/domain/quests/QuestManager.ts
@@ -415,6 +415,13 @@ export class QuestManager {
     }
 
     async onButton(player: Player, questId: number) {
+        if (player.isQuestRunning()) {
+            this.logger.info(
+                `[QUEST_MANAGER] Player ${player.getId()} pressed a quest button with running quest ${player.getCurrentQuest()?.getName()}`,
+            );
+            return;
+        }
+
         const event: QuestEventEnum = questId & 0x80000000 ? QuestEventEnum.INFO : QuestEventEnum.BUTTON;
 
         const questMap = this.getQuestsForEvent(event);

--- a/test/unit/core/domain/quests/QuestManager.test.ts
+++ b/test/unit/core/domain/quests/QuestManager.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { QuestManager } from '@/core/domain/quests/QuestManager';
 import { QuestStatusEnum } from '@/core/domain/quests/decorators/QuestDecorator';
+import { QuestEventEnum } from '@/core/enum/QuestEventEnum';
 
 const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
 
@@ -46,6 +47,47 @@ describe('QuestManager', () => {
 
         it('should not throw when there is no active quest', () => {
             expect(() => questManager.onAnswer(createPlayer({}), CLOSE_WINDOW_ANSWER)).to.not.throw();
+        });
+    });
+
+    describe('onButton (issue #100)', () => {
+        const QUEST_ID = 7;
+        const STATE = 'RUN';
+
+        let questManager: QuestManager;
+        let quest: any;
+
+        const createPlayer = (isQuestRunning: boolean) =>
+            ({
+                getId: () => 1,
+                getQuest: () => quest,
+                getCurrentQuest: () => (isQuestRunning ? quest : null),
+                isQuestRunning: () => isQuestRunning,
+            }) as any;
+
+        beforeEach(() => {
+            questManager = new QuestManager({ logger, shopManager: {} as any });
+            quest = {
+                getName: () => 'TestQuest',
+                getCurrentState: () => ({ name: STATE }),
+                runState: sinon.stub().resolves(),
+            };
+            (questManager as any).eventQuestMap.set(QuestEventEnum.BUTTON, new Map([[QUEST_ID, new Set([STATE])]]));
+        });
+
+        it('should dispatch the button event when no quest is running', async () => {
+            await questManager.onButton(createPlayer(false), QUEST_ID);
+
+            expect(quest.runState.calledOnce, 'the button reaches the quest').to.be.equal(true);
+        });
+
+        it('should refuse a button press while another quest is mid-flight', async () => {
+            await questManager.onButton(createPlayer(true), QUEST_ID);
+
+            expect(
+                quest.runState.called,
+                'a second dispatch would strand the suspended coroutine on an orphaned promise',
+            ).to.be.equal(false);
         });
     });
 });


### PR DESCRIPTION
Fixes #100.

## What the code does today

`QuestManager.onButton` dispatches straight to `runState` with no `isQuestRunning()` check, unlike `onLogin`, `onLevelUp`, `onClick` and `onKill`. A second BUTTON packet arriving while a quest is suspended on a select starts a second `runState` on the same quest object, and `AbstractQuest` keeps exactly one `currentChoicePromise` holder which `select()` overwrites unconditionally. The first coroutine is then awaiting a promise whose resolver has been replaced, so `unselect()` can never reach it: that quest is stranded for the session, and because `isRunning()` also counts a non-`NONE` status, it reports running forever afterwards.

## It is reachable with shipped quests

I filed this as framework-only; re-checking before implementing showed it is not. `SkillQuest`'s BUTTON and INFO tasks (`SkillQuest.ts:167-175`) delegate to `onLetterDescribeQuest`, which awaits `select()` at `:141-150`, and its letter is on screen for **every level-6+ character without a skill group**. Still needs a modified client — a stock one destroys the letter button on click — but no custom quest.

## The fix

The gate the issue asked for, matching the original: `NPC::OnButton` (`questnpc.cpp:786-802`) checks `PC::IsRunning()` before dispatching, exactly as `OnInfo`, `OnClick`, `OnKill`, `OnLevelUp` and `OnChat` do.

## Deliberately scoped to `onButton` alone

The issue also asked whether to route the call through the shared `run()` helper. Not here, for a concrete reason: `onLogin`, `onLevelUp` and `onKill` call `runState` directly too, and **open PR #140 already refactors those three into a shared dispatch path**. Changing them here would conflict textually and duplicate a change under review. The remaining re-entrancy hardening inside `AbstractQuest` (a busy check on `runState` itself) is a separate question — I tried it and it breaks `HorseUpgradeQuest`'s expiry-timer reset, which reaches `runState` internally rather than from a packet, so it needs its own design pass.

## Verified

- Unit suite 663/0 → **665/0**; the new cases pin that a button press dispatches normally and is refused while another quest is mid-flight. The rejection case fails without the gate.
- `tsc --noEmit`, eslint, prettier clean.

## Note on scope

Pre-existing; #59 changed the letter's lifecycle but not this method.
