### PR TITLE
fix(battle): close the attack cooldown bypass by porting the original's victim-side log

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -42,6 +42,9 @@ export default abstract class Character extends GameEntity {
     protected target: Character | null = null;
     protected readonly targetedBy = new Map<number, Character>();
 
+    private lastAttackedById: number = 0;
+    private lastAttackedTime: number = 0;
+
     protected readonly affectBitFlag = new AffectBitFlag();
     protected readonly animationManager: AnimationManager;
 
@@ -186,6 +189,15 @@ export default abstract class Character extends GameEntity {
 
     addTargetedBy(entity: Character) {
         this.targetedBy.set(entity.virtualId, entity);
+    }
+
+    wasAttackedRecentlyBy(attackerId: number, within: number, now: number) {
+        return this.lastAttackedById === attackerId && now - this.lastAttackedTime < within;
+    }
+
+    recordAttackedBy(attackerId: number, now: number) {
+        this.lastAttackedById = attackerId;
+        this.lastAttackedTime = now;
     }
 
     broadcastMyTarget() {

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -628,18 +628,22 @@ export default class Player extends Character {
             return;
         }
 
-        // Reject hits that arrive faster than the attack speed allows (packet
-        // flood / attack-speed hack). Only throttles repeated hits on the same
-        // victim, matching the original's per-target attack log.
+        // Mirrors the original's two speed-hack logs: the attacker's own
+        // last-victim slot, then the victim's last-attacker slot, which is the
+        // one that catches target rotation.
         const now = performance.now();
-        if (
-            victim.getVirtualId() === this.lastAttackVictimVid &&
-            now - this.lastAttackTime < this.getAttackCooldown()
-        ) {
+        const cooldown = this.getAttackCooldown();
+        if (victim.getVirtualId() === this.lastAttackVictimVid && now - this.lastAttackTime < cooldown) {
             return;
         }
         this.lastAttackVictimVid = victim.getVirtualId();
         this.lastAttackTime = now;
+
+        if (victim.wasAttackedRecentlyBy(this.getId(), cooldown, now)) {
+            victim.recordAttackedBy(this.getId(), now);
+            return;
+        }
+        victim.recordAttackedBy(this.getId(), now);
 
         this.setPos(PositionEnum.FIGHTING);
         this.lastTimeInBattle = now;

--- a/test/unit/core/domain/entities/game/player/PlayerAttackThrottle.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerAttackThrottle.test.ts
@@ -1,0 +1,101 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Player from '@/core/domain/entities/game/player/Player';
+import Character from '@/core/domain/entities/game/Character';
+import { PositionEnum } from '@/core/enum/PositionEnum';
+
+/**
+ * Regression for issue #101: the throttle only compared against the attacker's
+ * own last victim, so alternating targets skipped the time check entirely and
+ * the guard never rejected a packet. The original does a second, victim-side
+ * check (battle.cpp:794) which is what closes rotation.
+ */
+describe('Player.attack throttle across rotating victims (issue #101)', () => {
+    const ATTACKER_ID = 42;
+
+    const createVictim = (virtualId: number) => {
+        const victim = Object.create(Character.prototype);
+        victim.lastAttackedById = 0;
+        victim.lastAttackedTime = 0;
+        victim.getVirtualId = () => virtualId;
+        victim.isDead = () => false;
+        return victim as Character;
+    };
+
+    const createAttacker = () => {
+        const attacker = Object.create(Player.prototype);
+        attacker.lastAttackVictimVid = 0;
+        attacker.lastAttackTime = 0;
+        attacker.getId = () => ATTACKER_ID;
+        attacker.getAttackSpeed = () => 100;
+        attacker.isDead = () => false;
+        attacker.isStun = () => false;
+        attacker.setPos = sinon.spy();
+        attacker.onMove = sinon.spy();
+        attacker.horse = { isTemporaryRiding: () => false };
+        attacker.battle = { attack: sinon.spy() };
+        return attacker;
+    };
+
+    const landedHits = (attacker: any) => attacker.battle.attack.callCount;
+
+    it('should reject a second immediate hit on the same victim', () => {
+        const attacker = createAttacker();
+        const victim = createVictim(1);
+
+        attacker.attack(PositionEnum.STANDING, victim);
+        attacker.attack(PositionEnum.STANDING, victim);
+
+        expect(landedHits(attacker)).to.equal(1);
+    });
+
+    it('should reject the second round when the attacker rotates between two victims', () => {
+        const attacker = createAttacker();
+        const first = createVictim(1);
+        const second = createVictim(2);
+
+        attacker.attack(PositionEnum.STANDING, first);
+        attacker.attack(PositionEnum.STANDING, second);
+        attacker.attack(PositionEnum.STANDING, first);
+        attacker.attack(PositionEnum.STANDING, second);
+
+        expect(landedHits(attacker), 'A,B are free; the second A,B round is inside the cooldown').to.equal(2);
+    });
+
+    it('should still allow the first hit on a fresh victim inside the cooldown', () => {
+        const attacker = createAttacker();
+        const first = createVictim(1);
+        const second = createVictim(2);
+
+        attacker.attack(PositionEnum.STANDING, first);
+        attacker.attack(PositionEnum.STANDING, second);
+
+        expect(landedHits(attacker), 'switching targets mid-swing is legal play in the original').to.equal(2);
+    });
+
+    it('should let a hit through once the cooldown has elapsed', () => {
+        const attacker = createAttacker();
+        const victim = createVictim(1);
+
+        attacker.attack(PositionEnum.STANDING, victim);
+        attacker.lastAttackTime -= 10_000;
+        victim.recordAttackedBy(ATTACKER_ID, performance.now() - 10_000);
+
+        attacker.attack(PositionEnum.STANDING, victim);
+
+        expect(landedHits(attacker)).to.equal(2);
+    });
+
+    it('should not throttle two different attackers hitting the same victim', () => {
+        const attackerOne = createAttacker();
+        const attackerTwo = createAttacker();
+        attackerTwo.getId = () => ATTACKER_ID + 1;
+        const victim = createVictim(1);
+
+        attackerOne.attack(PositionEnum.STANDING, victim);
+        attackerTwo.attack(PositionEnum.STANDING, victim);
+
+        expect(landedHits(attackerOne)).to.equal(1);
+        expect(landedHits(attackerTwo), 'the victim log is keyed by attacker, as in the original').to.equal(1);
+    });
+});


### PR DESCRIPTION
Fixes #101 — and corrects that issue in two places, one of which understated the severity.

## What the code does today

`Player.attack` throttles with a single scalar pair (the attacker's last victim and the time it was hit), and the time comparison only runs when the incoming victim equals the previous one. Alternating targets therefore skips the check entirely: `A,B,A,B` never compares any timestamp.

**Correction 1 — the issue said "roughly Nx the intended rate". That understates it.** With two or more victims the throttle does not fire at all, so the accepted rate is bounded by packet throughput, not by the number of targets. The targets do have to be in one pack (each hit still passes the 300-unit range check), which is routine.

## The fix: port the original's second check

**Correction 2 — the in-code comment claimed the scalar shape "matches the original's per-target attack log". Only half of it does**, and that is what made the gap look deliberate. The original runs *two* checks (`battle.cpp:746-821`, `IS_SPEED_HACK`):

1. attacker-side on `m_kAttackLog` — same-victim, which is what we ported;
2. victim-side on `m_AttackedLog` — if the victim was last hit by *this same attacker* inside the attack-speed window, drop the hit.

The second one is precisely what closes rotation, and it is the half we never had. So this adds an attacked-log to `Character` (two fields, a reader, a writer) rather than the `Map` the issue proposed. It is what the original does, it is O(1), it dies with the entity, and it needs no eviction policy — and a `Map` keyed by virtual id would have been unsound here, since `VirtualIdManager` reuses released ids and a stale entry could be resurrected under a different entity.

## What deliberately stays legal

The first hit on a *fresh* target inside the window is still accepted, because both of the original's checks are keyed on identity. Switching targets mid-swing is normal play. The issue's other proposal — one global cooldown per attacker — would reject it and is strictly harsher than 40250.

## Verified

`Player.attack` had no test coverage at all. The new spec pins: the rotation rejection, the same-victim rejection, the legal target switch, the release once the cooldown elapses, and that two different attackers are not throttled against each other. Suite 663/0 → **668/0**; reverting the fix fails the rotation case on behaviour. `tsc --noEmit`, eslint, prettier clean.

## Note on scope

Ours, from PR #31 — the limiter did what its comment said, the comment was just describing half an algorithm.
