### PR TITLE
fix(auth): make the login token single-use so a captured key cannot be replayed

### DIFF
--- a/src/auth/app/service/LoginService.ts
+++ b/src/auth/app/service/LoginService.ts
@@ -7,7 +7,7 @@ import { EncryptionProvider } from '@/core/infra/encryption/EncryptionProvider';
 import Result from '@/core/domain/util/Result';
 import { IAccountRepository } from '@/core/domain/repository/IAccountRepository';
 
-const TOKEN_EXPIRATION_SECS = 60 * 60 * 24;
+const TOKEN_EXPIRATION_SECS = 60;
 
 export default class LoginService {
     private readonly accountRepository: IAccountRepository;

--- a/src/core/infra/cache/CacheProvider.ts
+++ b/src/core/infra/cache/CacheProvider.ts
@@ -2,6 +2,7 @@ export default interface CacheProvider {
     init(): Promise<void>;
     set(key: string, value: any, expirationInSec?: number): Promise<void>;
     get<T>(key: string): Promise<T>;
+    take<T>(key: string): Promise<T | null>;
     delete(key: string): Promise<void>;
     close(): Promise<void>;
     exists(key: string): Promise<boolean>;

--- a/src/core/infra/cache/RedisCacheProvider.ts
+++ b/src/core/infra/cache/RedisCacheProvider.ts
@@ -44,6 +44,10 @@ export default class RedisCacheProvider implements CacheProvider {
         return this.client.get(key) as T;
     }
 
+    async take<T>(key: string) {
+        return (await this.client.getDel(key)) as T | null;
+    }
+
     async delete(key: string) {
         await this.client.del(key);
     }

--- a/src/game/domain/service/AuthenticateService.ts
+++ b/src/game/domain/service/AuthenticateService.ts
@@ -20,14 +20,14 @@ export default class AuthenticateService {
 
     async execute(key: number, username: string): Promise<Result<Token, ErrorTypesEnum>> {
         const cacheKey = CacheKeyGenerator.createTokenKey(String(key));
-        const tokenExists = await this.cacheProvider.exists(cacheKey);
+        const rawToken = await this.cacheProvider.take<string>(cacheKey);
 
-        if (!tokenExists) {
+        if (!rawToken) {
             this.logger.info(`[AuthenticateService] Invalid token for username: ${username}`);
             return Result.error(ErrorTypesEnum.INVALID_TOKEN);
         }
 
-        const token = JSON.parse(await this.cacheProvider.get<string>(cacheKey));
+        const token = JSON.parse(rawToken);
 
         if (username !== token.username) {
             this.logger.info(`[AuthenticateService] Invalid token for username: ${username}`);

--- a/test/unit/core/infra/cache/RedisCacheProvider.test.ts
+++ b/test/unit/core/infra/cache/RedisCacheProvider.test.ts
@@ -25,6 +25,7 @@ describe('RedisCacheProvider', () => {
             set: sinon.stub().resolves(),
             get: sinon.stub().resolves(),
             del: sinon.stub().resolves(),
+            getDel: sinon.stub().resolves(),
             quit: sinon.stub().resolves(),
             expire: sinon.stub().resolves(),
             exists: sinon.stub().resolves(),
@@ -69,6 +70,15 @@ describe('RedisCacheProvider', () => {
         redisClient.get.resolves('value');
         const value = await cacheProvider.get('key');
         expect(redisClient.get.calledWith('key')).to.be.true;
+        expect(value).to.equal('value');
+    });
+
+    it('should read and remove a value in one round trip', async () => {
+        redisClient.getDel.resolves('value');
+
+        const value = await cacheProvider.take('key');
+
+        expect(redisClient.getDel.calledOnceWith('key')).to.be.true;
         expect(value).to.equal('value');
     });
 

--- a/test/unit/game/domain/service/AuthenticateService.test.ts
+++ b/test/unit/game/domain/service/AuthenticateService.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import AuthenticateService from '@/game/domain/service/AuthenticateService';
+import { ErrorTypesEnum } from '@/core/enum/ErrorTypesEnum';
+
+/**
+ * Regression for issue #104: the login token was looked up with exists() then
+ * get(), and never removed, so the same key could be redeemed any number of
+ * times for the whole of its lifetime.
+ */
+describe('AuthenticateService token redemption (issue #104)', () => {
+    const KEY = 0x0badf00d;
+    const USERNAME = 'tester';
+    const CACHE_KEY = `token:${KEY}`;
+
+    let logger: any;
+    let cacheProvider: any;
+    let service: AuthenticateService;
+
+    /**
+     * A working cache, not a stub: take() removes what it returns (Redis
+     * GETDEL) while get()/exists() leave the entry alone. Implementing all
+     * three is what makes the fail-without-fix signal behavioural — against
+     * the old exists()+get() code these cases fail because the token survives,
+     * not because a method is missing.
+     */
+    const workingCache = (entries: Record<string, string>) => ({
+        take: sinon.stub().callsFake(async (key: string) => {
+            const value = entries[key] ?? null;
+            delete entries[key];
+            return value;
+        }),
+        get: sinon.stub().callsFake(async (key: string) => entries[key] ?? null),
+        exists: sinon.stub().callsFake(async (key: string) => key in entries),
+    });
+
+    beforeEach(() => {
+        logger = { info: sinon.spy(), error: sinon.spy(), debug: sinon.spy() };
+        cacheProvider = workingCache({
+            [CACHE_KEY]: JSON.stringify({ username: USERNAME, accountId: 7 }),
+        });
+        service = new AuthenticateService({ logger, cacheProvider });
+    });
+
+    it('should authenticate the first redemption of a token', async () => {
+        const result = await service.execute(KEY, USERNAME);
+
+        expect(result.isOk()).to.equal(true);
+        expect(result.getData()).to.deep.equal({ username: USERNAME, accountId: 7 });
+    });
+
+    it('should reject the second redemption of the same token', async () => {
+        await service.execute(KEY, USERNAME);
+
+        const replay = await service.execute(KEY, USERNAME);
+
+        expect(replay.hasError(), 'a captured key must not be reusable').to.equal(true);
+        expect(replay.getError()).to.equal(ErrorTypesEnum.INVALID_TOKEN);
+    });
+
+    it('should let exactly one of two concurrent redemptions win', async () => {
+        const [first, second] = await Promise.all([service.execute(KEY, USERNAME), service.execute(KEY, USERNAME)]);
+
+        const accepted = [first, second].filter((result) => result.isOk());
+        expect(accepted.length, 'the take is atomic, so a race cannot admit both').to.equal(1);
+    });
+
+    it('should reject an unknown token', async () => {
+        const result = await service.execute(0x11111111, USERNAME);
+
+        expect(result.hasError()).to.equal(true);
+        expect(result.getError()).to.equal(ErrorTypesEnum.INVALID_TOKEN);
+    });
+
+    it('should burn the token when the username does not match it', async () => {
+        const mismatch = await service.execute(KEY, 'someone-else');
+        expect(mismatch.hasError()).to.equal(true);
+
+        const retry = await service.execute(KEY, USERNAME);
+        expect(retry.hasError(), 'a wrong guess must not leave the key usable').to.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #104.

## What the code does today

`AuthenticateService` checks the token with `exists()`, reads it with `get()`, and nothing ever removes it. The key stays valid for its full 24h TTL — it survives redemption, logout, and even a password change, because only a fresh login writes that key and a fresh login mints a *different* one. Since this port implements none of the original's packet encryption, the key travels in cleartext in both directions, so a captured one is an unrevocable bearer credential for the account for a day.

## The fix

Redemption becomes a single atomic `take()` backed by Redis `GETDEL`. That also closes a TOCTOU the old shape had: `exists()` then `get()` is two round trips, so two connections could both pass the existence check before either read. With `GETDEL` exactly one caller receives the JSON and the other gets `null`.

A username mismatch now **burns** the key rather than leaving it in place. Re-setting it would reopen the race and hand an attacker a free retry loop, and the legitimate client always sends the username it just logged in with.

The TTL drops from 24h to **60s** — it was never a session lifetime, it is the hand-off window between `LoginSuccessPacket` on the auth port and `TOKEN` on the game port. The original expires its login key on the same order of magnitude: 60s past auth-descriptor teardown (`desc.cpp:115`, `desc_manager.cpp:504`).

## One correction to the issue

I wrote that the token is guessable. **It is not** — `randomBytes(4).readUInt32LE()` is a CSPRNG over the full 32-bit space, the username must match, and a failed attempt closes the connection, so it is a targeted 2^32 search at one guess per TCP handshake. For reference our space is *wider* than the original's, which uses `number(1, INT_MAX)` (31 bits, `desc_manager.cpp:478`). This is capture-and-replay, not brute force.

## What this deliberately does not fix

Logging in twice with the real password still yields two concurrent sessions on one account. The original refuses that with `FindLogonAccount` → `HEADER_DG_LOGIN_ALREADY` (`ClientManagerLogin.cpp:115`) and we have no equivalent — that is **#105**, and a faithful port lands it in this same function, so bundling the two would tangle both changes. Happy to take it next, on top of this.

Also skipped, with reasons: **IP binding**, which the original stores (`db.cpp:485`) but never compares, and which breaks NAT/mobile clients; and **client-key binding**, the genuinely faithful defence (`ClientManagerLogin.cpp:132`), which cannot be done cleanly yet — `LoginRequestPacket` reads `passwd` as 16 bytes where `TPacketCGLogin3` has 17, so our key DWORD straddles the terminator and `adwClientKey[0]`, and the handler discards it anyway. That layout bug is worth its own issue; say the word and I'll file it.

## Verified

- New `AuthenticateService` spec (none existed): first redemption succeeds, second is refused, a concurrent pair admits exactly one, an unknown key is refused, and a wrong username burns the key.
- The fake cache implements `take`/`get`/`exists` over one store deliberately, so reverting the source fails **three cases on behaviour** — the token surviving — rather than on a missing method.
- Unit suite 663/0 → **669/0**; `tsc --noEmit`, eslint, prettier clean.

## Note on scope

Pre-existing. `take()` is added to the `CacheProvider` port and implemented once, in `RedisCacheProvider`.
