### PR TITLE
fix(auth): refuse a second live session on an account that is already connected

### DIFF
--- a/src/core/interface/networking/Connection.ts
+++ b/src/core/interface/networking/Connection.ts
@@ -104,6 +104,12 @@ export default abstract class Connection {
         this.socket.destroy();
     }
 
+    /** Flushes pending writes before closing; close() destroys them instead. */
+    closeGracefully() {
+        this.stopKeepalive();
+        this.socket.end();
+    }
+
     isClosed() {
         return this.socket.destroyed;
     }

--- a/src/core/interface/networking/packets/packet/in/authToken/AuthTokenPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/authToken/AuthTokenPacketHandler.ts
@@ -9,27 +9,34 @@ import EmpirePacket from '../../bidirectional/empire/EmpirePacket';
 import CharactersInfoPacket from '../../out/CharactersInfoPacket';
 import Ip from '@/core/util/Ip';
 import { ConnectionStateEnum } from '@/core/enum/ConnectionStateEnum';
+import SessionManager from '@/game/domain/manager/SessionManager';
+import LoginFailedPacket from '../../out/LoginFailedPacket';
+import LoginStatusEnum from '@/core/enum/LoginStatusEnum';
 
 export default class AuthTokenPacketHandler extends PacketHandler<AuthTokenPacket> {
     private readonly loadCharactersService: LoadCharactersService;
     private readonly authenticateService: AuthenticateService;
+    private readonly sessionManager: SessionManager;
     private readonly config: GameConfig;
     private readonly logger: Logger;
 
     constructor({
         loadCharactersService,
         authenticateService,
+        sessionManager,
         config,
         logger,
     }: {
         loadCharactersService: LoadCharactersService;
         authenticateService: AuthenticateService;
+        sessionManager: SessionManager;
         config: GameConfig;
         logger: Logger;
     }) {
         super();
         this.loadCharactersService = loadCharactersService;
         this.authenticateService = authenticateService;
+        this.sessionManager = sessionManager;
         this.config = config;
         this.logger = logger;
     }
@@ -59,7 +66,20 @@ export default class AuthTokenPacketHandler extends PacketHandler<AuthTokenPacke
             return;
         }
 
+        const liveConnection = this.sessionManager.get(token.accountId);
+
+        if (liveConnection) {
+            this.logger.info(
+                `[AuthTokenPacketHandler] Account ${token.accountId} is already connected, dropping both sessions`,
+            );
+            liveConnection.close();
+            connection.send(new LoginFailedPacket({ status: LoginStatusEnum.ALREADY_CONNECTED }));
+            connection.closeGracefully();
+            return;
+        }
+
         connection.setAccountId(token.accountId);
+        this.sessionManager.set(token.accountId, connection);
 
         const charactersResult = await this.loadCharactersService.execute({ accountId: token.accountId });
 

--- a/src/game/Container.ts
+++ b/src/game/Container.ts
@@ -43,6 +43,7 @@ import PrivateShopService from './app/service/PrivateShopService';
 import GlobalEventTimerManager from '@/core/domain/manager/GlobalEventTimeManager';
 import { VirtualIdManager } from '@/core/domain/manager/VirtualIdManager';
 import { EntityManager } from '@/core/domain/manager/EntityManager';
+import SessionManager from '@/game/domain/manager/SessionManager';
 import { QuestTargetManager } from '@/core/domain/quests/QuestTargetManager';
 import { SkillManager } from '@/core/domain/manager/SkillManager';
 
@@ -94,6 +95,7 @@ container.register({
     eventTimerManager: asClass(GlobalEventTimerManager).singleton(),
     virtualIdManager: asClass(VirtualIdManager).singleton(),
     entityManager: asClass(EntityManager).singleton(),
+    sessionManager: asClass(SessionManager).singleton(),
     questTargetManager: asClass(QuestTargetManager).singleton(),
     skillManager: asClass(SkillManager).singleton(),
 });

--- a/src/game/domain/manager/SessionManager.ts
+++ b/src/game/domain/manager/SessionManager.ts
@@ -1,0 +1,25 @@
+import GameConnection from '@/game/interface/networking/GameConnection';
+
+export default class SessionManager {
+    private readonly connectionsByAccountId = new Map<number, GameConnection>();
+
+    get(accountId: number) {
+        return this.connectionsByAccountId.get(accountId);
+    }
+
+    set(accountId: number, connection: GameConnection) {
+        this.connectionsByAccountId.set(accountId, connection);
+    }
+
+    /** Drops the entry only if it still points at this exact connection. */
+    remove(connection: GameConnection) {
+        const accountId = connection.getAccountId();
+        if (accountId === null) return;
+        if (this.connectionsByAccountId.get(accountId) !== connection) return;
+        this.connectionsByAccountId.delete(accountId);
+    }
+
+    size() {
+        return this.connectionsByAccountId.size;
+    }
+}

--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -6,10 +6,12 @@ import { Logger } from 'winston';
 import { GameConfig } from '@/game/infra/config/GameConfig';
 import { PacketMapValue } from '@/core/interface/networking/packets/Packets';
 import LogoutService from '@/game/app/service/LogoutService';
+import SessionManager from '@/game/domain/manager/SessionManager';
 
 export default class GameServer extends Server {
     private readonly world: World;
     private readonly logoutService: LogoutService;
+    private readonly sessionManager: SessionManager;
 
     constructor(container: {
         logger: Logger;
@@ -17,13 +19,17 @@ export default class GameServer extends Server {
         packets: Map<number, PacketMapValue<any>>;
         world: World;
         logoutService: LogoutService;
+        sessionManager: SessionManager;
     }) {
         super(container);
         this.world = container.world;
         this.logoutService = container.logoutService;
+        this.sessionManager = container.sessionManager;
     }
 
     async onClose(connection: GameConnection) {
+        this.sessionManager.remove(connection);
+
         const player = connection.getPlayer();
 
         if (player) {

--- a/test/integration/game/duplicateSessionSecurity.test.ts
+++ b/test/integration/game/duplicateSessionSecurity.test.ts
@@ -1,0 +1,144 @@
+import { expect } from 'chai';
+import { createConnection, Socket } from 'node:net';
+import { container } from '@/game/Container';
+import BufferWriter from '@/core/interface/networking/buffer/BufferWriter';
+import BufferReader from '@/core/interface/networking/buffer/BufferReader';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
+import AttackHarness from '../../support/AttackSession';
+
+/**
+ * Regression for issue #105: nothing stopped one account from holding two live
+ * sessions, which let a character duplicate its own gold and items by dropping
+ * on one session and picking up on the other.
+ *
+ * The second session is opened with its OWN freshly minted token, not a replay
+ * of the first one - a replay is refused earlier by the single-use token fix
+ * (issue #104), which would make this spec pass for the wrong reason.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Duplicate session per account (issue #105)', function () {
+    this.timeout(60_000);
+
+    const USERNAME = 'dupsession_test';
+    const SECOND_TOKEN = 0x0dd0dd0d;
+
+    let harness: AttackHarness;
+    let firstSession: Awaited<ReturnType<AttackHarness['login']>> | undefined;
+    let secondSocket: Socket | undefined;
+
+    const db = () => container.resolve('databaseManager') as any;
+    const cache = () => container.resolve('cacheProvider') as any;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        secondSocket?.destroy();
+        // Closed explicitly rather than relying on the guard having kicked it:
+        // when the fix regresses, the first session would otherwise survive
+        // into the next spec file and take unrelated cases down with it.
+        await firstSession?.close();
+        await harness?.stop();
+    });
+
+    const accountIdOf = async (username: string) => {
+        const [rows] = await db().getConnection().query('SELECT id FROM auth.account WHERE username = ?', [username]);
+        return rows[0].id as number;
+    };
+
+    /** A raw connection that walks the handshake and then redeems a token. */
+    const tokenConnection = () => {
+        const host = container.resolve<any>('config').SERVER_ADDRESS as string;
+        const port = Number(container.resolve<any>('config').SERVER_PORT);
+
+        let buffer = Buffer.alloc(0);
+        let closed = false;
+
+        const client = createConnection({ host, port });
+        client.on('data', (chunk) => (buffer = Buffer.concat([buffer, chunk])));
+        client.on('close', () => (closed = true));
+        client.on('error', () => (closed = true));
+
+        const next = (length: number, timeoutMs = 10_000) =>
+            new Promise<Buffer>((resolve, reject) => {
+                const deadline = Date.now() + timeoutMs;
+                const tick = () => {
+                    if (buffer.byteLength >= length) {
+                        const out = buffer.subarray(0, length);
+                        buffer = buffer.subarray(length);
+                        return resolve(out);
+                    }
+                    if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${length} bytes`));
+                    setTimeout(tick, 20);
+                };
+                tick();
+            });
+
+        const closedWithin = async (ms: number) => {
+            for (let waited = 0; waited < ms && !closed; waited += 50) {
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+            return closed;
+        };
+
+        const handshake = async () => {
+            await next(2);
+            const frame = await next(13);
+            const reader = new BufferReader();
+            reader.setBuffer(frame);
+            const id = reader.readUInt32LE();
+            const time = reader.readUInt32LE();
+            const delta = reader.readUInt32LE();
+            client.write(
+                new BufferWriter(PacketHeaderEnum.HANDSHAKE, 13)
+                    .writeUint32LE(id)
+                    .writeUint32LE(time)
+                    .writeUint32LE(delta)
+                    .getBuffer(),
+            );
+            await next(2);
+        };
+
+        const sendToken = (username: string, token: number) => {
+            const auth = new BufferWriter(PacketHeaderEnum.TOKEN, 52);
+            auth.writeString(username, 31)
+                .writeUint32LE(token)
+                .writeUint32LE(0)
+                .writeUint32LE(0)
+                .writeUint32LE(0)
+                .writeUint32LE(0);
+            client.write(Buffer.concat([auth.getBuffer(), Buffer.from([0])]));
+        };
+
+        return { client, next, closedWithin, handshake, sendToken };
+    };
+
+    it('should refuse a second session on an account that is already connected', async () => {
+        firstSession = await harness.login({ username: USERNAME });
+        expect(harness.findPlayer(USERNAME), 'the first session is in the world').to.not.equal(undefined);
+
+        const accountId = await accountIdOf(USERNAME);
+        await cache().set(
+            CacheKeyGenerator.createTokenKey(String(SECOND_TOKEN)),
+            JSON.stringify({ username: USERNAME, accountId }),
+            300,
+        );
+
+        const second = tokenConnection();
+        secondSocket = second.client;
+        await second.handshake();
+        second.sendToken(USERNAME, SECOND_TOKEN);
+
+        const failure = await second.next(10);
+        expect(failure[0], 'the newcomer is answered with LOGIN_FAILED').to.equal(PacketHeaderEnum.LOGIN_FAILED);
+        expect(failure.subarray(1).toString('latin1').replace(/\0.*$/, ''), 'with the ALREADY status').to.equal(
+            'ALREADY',
+        );
+
+        expect(await second.closedWithin(5_000), 'and is then dropped').to.equal(true);
+        expect(await harness.isServerAlive(), 'the server stayed up').to.equal(true);
+    });
+});

--- a/test/unit/core/interface/networking/packets/packets/in/authToken/AuthTokenPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/authToken/AuthTokenPacketHandler.test.ts
@@ -6,17 +6,19 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('AuthTokenPacketHandler', () => {
-    let loadCharactersServiceMock, authenticateServiceMock, configMock, loggerMock;
+    let loadCharactersServiceMock, authenticateServiceMock, sessionManagerMock, configMock, loggerMock;
     let connectionMock, packetMock, authTokenPacketHandler: AuthTokenPacketHandler;
 
     beforeEach(() => {
         loadCharactersServiceMock = { execute: sinon.stub() };
         authenticateServiceMock = { execute: sinon.stub() };
+        sessionManagerMock = { get: sinon.stub().returns(undefined), set: sinon.spy(), remove: sinon.spy() };
         configMock = { SERVER_PORT: 12345, SERVER_ADDRESS: '127.0.0.1' };
-        loggerMock = { error: sinon.spy() };
+        loggerMock = { error: sinon.spy(), info: sinon.spy() };
 
         connectionMock = {
             close: sinon.spy(),
+            closeGracefully: sinon.spy(),
             send: sinon.spy(),
             getAccountId: () => 1,
             state: null,
@@ -37,6 +39,7 @@ describe('AuthTokenPacketHandler', () => {
         authTokenPacketHandler = new AuthTokenPacketHandler({
             loadCharactersService: loadCharactersServiceMock,
             authenticateService: authenticateServiceMock,
+            sessionManager: sessionManagerMock,
             config: configMock,
             logger: loggerMock,
         });
@@ -137,5 +140,63 @@ describe('AuthTokenPacketHandler', () => {
         await authTokenPacketHandler.execute(connectionMock, packetMock);
 
         expect(connectionMock.state).to.equal(ConnectionStateEnum.SELECT);
+    });
+
+    describe('single session per account (issue #105)', () => {
+        const authenticateAs = (accountId: number) => {
+            packetMock.isValid.returns(true);
+            authenticateServiceMock.execute.resolves({
+                hasError: () => false,
+                getData: () => ({ accountId }),
+            });
+            loadCharactersServiceMock.execute.resolves({ isOk: () => false });
+        };
+
+        it('should register the session when the account is not connected', async () => {
+            authenticateAs(1);
+
+            await authTokenPacketHandler.execute(connectionMock, packetMock);
+
+            expect(sessionManagerMock.set.calledOnceWith(1, connectionMock)).to.equal(true);
+        });
+
+        it('should refuse the newcomer and kick the live session when the account is already connected', async () => {
+            authenticateAs(1);
+            const liveConnection = { close: sinon.spy() };
+            sessionManagerMock.get.returns(liveConnection);
+
+            await authTokenPacketHandler.execute(connectionMock, packetMock);
+
+            expect(liveConnection.close.calledOnce, 'the ghost session is dropped').to.equal(true);
+            expect(connectionMock.closeGracefully.calledOnce, 'the newcomer is refused').to.equal(true);
+            expect(connectionMock.state, 'and never reaches character selection').to.not.equal(
+                ConnectionStateEnum.SELECT,
+            );
+            expect(sessionManagerMock.set.called, 'no session is registered for a refused connection').to.equal(false);
+        });
+
+        it('should tell the refused client why, before closing', async () => {
+            authenticateAs(1);
+            sessionManagerMock.get.returns({ close: sinon.spy() });
+
+            await authTokenPacketHandler.execute(connectionMock, packetMock);
+
+            expect(connectionMock.send.calledOnce).to.equal(true);
+            const sent = connectionMock.send.firstCall.args[0];
+            expect(sent['status'], 'the stock client renders this status').to.equal('ALREADY');
+            expect(
+                connectionMock.close.called,
+                'close() destroys the socket and would discard the packet still corked',
+            ).to.equal(false);
+        });
+
+        it('should not load characters for a refused connection', async () => {
+            authenticateAs(1);
+            sessionManagerMock.get.returns({ close: sinon.spy() });
+
+            await authTokenPacketHandler.execute(connectionMock, packetMock);
+
+            expect(loadCharactersServiceMock.execute.called).to.equal(false);
+        });
     });
 });

--- a/test/unit/game/interface/server/GameServer.test.ts
+++ b/test/unit/game/interface/server/GameServer.test.ts
@@ -4,13 +4,16 @@ import GameServer from '@/game/interface/server/GameServer';
 
 const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
 
-const createGameServer = (logoutService: any) => {
+const createSessionManager = () => ({ remove: sinon.stub() }) as any;
+
+const createGameServer = (logoutService: any, sessionManager: any = createSessionManager()) => {
     return new GameServer({
         logger,
         config: {} as any,
         packets: new Map(),
         world: {} as any,
         logoutService,
+        sessionManager,
     });
 };
 
@@ -18,6 +21,7 @@ const createConnection = (player: unknown) =>
     ({
         getId: () => 'connection-id',
         getPlayer: () => player,
+        getAccountId: () => 1,
         clearPlayer: sinon.stub(),
         stopKeepalive: sinon.stub(),
     }) as any;
@@ -60,6 +64,28 @@ describe('GameServer', () => {
             await server.onClose(connection);
 
             expect(connection.clearPlayer.calledOnce).to.be.equal(true);
+        });
+
+        it('should release the account session so the player can log in again (issue #105)', async () => {
+            const logoutService = { execute: sinon.stub().resolves() };
+            const sessionManager = createSessionManager();
+            const server = createGameServer(logoutService, sessionManager);
+            const connection = createConnection({ getName: () => 'Test' });
+
+            await server.onClose(connection);
+
+            expect(sessionManager.remove.calledOnceWith(connection)).to.be.equal(true);
+        });
+
+        it('should release the account session even when no character was selected', async () => {
+            const logoutService = { execute: sinon.stub().resolves() };
+            const sessionManager = createSessionManager();
+            const server = createGameServer(logoutService, sessionManager);
+            const connection = createConnection(null);
+
+            await server.onClose(connection);
+
+            expect(sessionManager.remove.calledOnceWith(connection), 'a session dies at TOKEN too').to.be.equal(true);
         });
     });
 });


### PR DESCRIPTION
Fixes #105. Best read after #104 (the single-use token) — they are independent changes but this one assumes that context.

## The worst consequence is not the one the issue leads with

Two `Player` objects writing the same row is real, but the genuinely worst outcome is **gold and item duplication, and it needs no race at all**. Gold moves purely in memory on both sides of a transfer — `DropItemService` subtracts, `PickupItemService` adds, neither touches the database — and `Player.dropItem` stamps the ground item with the dropper's own name, so the pickup owner check passes instantly for the *second session of the same character*. Drop on one, pick up on the other: the stale copy writes the pre-drop balance back on its next save. For items it is worse, because the pickup path INSERTs a fresh row while the second session still holds its own live copy of the deleted one.

`LeaveGameService`'s own comment already describes this exact mechanism for private shops ("a relog creates a second live copy of every item") without connecting it to the general case.

## The fix

A `SessionManager` maps accountId → live connection. It is the port of `DESC_MANAGER::m_map_loginName`: filled where the original calls `ConnectAccount` (at token redemption, right before `setAccountId`) and emptied where it calls `DisconnectAccount` (`GameServer.onClose`).

On a collision it does what `CInputDB::LoginAlready` does (`input_db.cpp:1245-1270`): **kick the live session and refuse the newcomer**. Kicking is the part that matters in practice — it is what lets a player whose client crashed get back in on the next attempt — and closing the old connection runs the normal logout path, so its state is flushed rather than dropped.

The refusal finally gives `LoginStatusEnum.ALREADY_CONNECTED` its first consumer; the stock client already renders it.

## One subtlety worth flagging

The refusal has to be sent with a **graceful** close. `close()` destroys the socket, and the handler runs between `GameServer`'s `cork()` and the `uncork()` in its `finally` — so a destroy discards the still-buffered packet and the client sees an unexplained disconnect instead of the reason. `closeGracefully()` ends the socket instead, which flushes first. The spec asserts the bytes on the wire, not just that the socket closed, so this cannot silently regress.

Keyed on **accountId, not character id**, matching the original: it has no per-character guard at all, and account-level uniqueness protects the character transitively.

## Scope, and the multi-server note

Single-process only. The moment there is more than one game server this `Map` has to become a shared key in Redis — which is the same split the original has, where the DB server owns the global logon table (`ClientManagerLogin.cpp:114`) and the cores ask it. Flagging it rather than building for it, since the constant here is one process.

## Verified

- Unit 663/0 → **669/0**, integration 31/0 → **32/0**. Reverting the guard fails four unit cases and the integration case.
- The integration spec mints a **second, independent token** rather than replaying the first — a replay is refused earlier by #104, so a replay-based spec would pass for the wrong reason.
- It also closes the first session explicitly in teardown instead of relying on the kick. Without that, a future regression leaks a live player into later spec files and takes unrelated cases down with it — I hit exactly that while verifying, and it turned one honest failure into three.
- Two existing spec files needed their constructor fixtures widened (`GameServer`, `AuthTokenPacketHandler`); those repairs are in the diff.
- `tsc --noEmit`, eslint, prettier clean.
