### PR TITLE
fix(item): ignore an item use addressed to a window that has no backing store

### DIFF
--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -77,13 +77,15 @@ export default class UseItemService {
     async execute(player: Player, window: number, position: number) {
         this.logger.debug(`[UseItemService] using item in window: ${window}, position: ${position}`);
 
+        if (window !== WindowTypeEnum.INVENTORY && window !== WindowTypeEnum.EQUIPMENT) return;
+
         const item = player.getItem(position);
 
         if (!item) return;
         if (player.isItemLockedInPrivateShop(item)) return;
 
         if (player.isWearable(item)) {
-            await this.useWearableItem(player, item, position, window);
+            await this.useWearableItem(player, item, position);
         } else {
             const equipFailureReason = player.getEquipFailureReason(item);
             if (equipFailureReason) {
@@ -98,14 +100,14 @@ export default class UseItemService {
         }
     }
 
-    private async useWearableItem(player: Player, item: Item, position: number, window: number) {
+    private async useWearableItem(player: Player, item: Item, position: number) {
         if (player.getInventory().isEquipmentPosition(position)) {
             player.getInventory().removeItem(position, item.getSize());
             const addedPosition = player.getInventory().addItem(item);
 
             if (addedPosition >= 0) {
                 player.sendItemRemoved({
-                    window,
+                    window: WindowTypeEnum.EQUIPMENT,
                     position,
                 });
 

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -47,7 +47,7 @@ describe('UseItemService', () => {
         expect(itemManagerStub.update.notCalled).to.be.true;
     });
 
-    it('should equip a wearable item from inventory', async () => {
+    it('should unequip a worn item back into the inventory', async () => {
         const mockItem = { getSize: () => 1, isWearable: true };
         playerStub.getItem.returns(mockItem);
         playerStub.isWearable.returns(true);
@@ -67,7 +67,10 @@ describe('UseItemService', () => {
         expect(inventoryStub.isEquipmentPosition.calledOnceWith(2)).to.be.true;
         expect(inventoryStub.removeItem.calledOnceWith(2, 1)).to.be.true;
         expect(inventoryStub.addItem.calledOnceWith(mockItem)).to.be.true;
-        expect(playerStub.sendItemRemoved.calledOnceWith({ window: 1, position: 2 })).to.be.true;
+        expect(
+            playerStub.sendItemRemoved.calledOnceWith({ window: WindowTypeEnum.EQUIPMENT, position: 2 }),
+            'the removal is echoed for the window the item actually left',
+        ).to.be.true;
         expect(
             playerStub.sendItemAdded.calledOnceWith({ window: WindowTypeEnum.INVENTORY, position: 3, item: mockItem }),
         ).to.be.true;
@@ -202,5 +205,46 @@ describe('UseItemService', () => {
 
         expect(playerStub.chat.notCalled).to.be.true;
         expect(mockItem.getType.called).to.be.true;
+    });
+
+    describe('window validation (issue #103)', () => {
+        const unimplementedWindows = [
+            ['SAFEBOX', WindowTypeEnum.SAFEBOX],
+            ['MALL', WindowTypeEnum.MALL],
+            ['DRAGON_SOUL_INVENTORY', WindowTypeEnum.DRAGON_SOUL_INVENTORY],
+            ['BELT_INVENTORY', WindowTypeEnum.BELT_INVENTORY],
+            ['RESERVED_WINDOW', WindowTypeEnum.RESERVED_WINDOW],
+        ] as const;
+
+        for (const [name, window] of unimplementedWindows) {
+            it(`should ignore a use addressed to ${name}, which has no backing store`, async () => {
+                playerStub.getItem.returns({ getSize: () => 1 });
+
+                await service.execute(playerStub, window, 2);
+
+                expect(playerStub.getItem.notCalled, 'the position must not be resolved against the inventory').to.be
+                    .true;
+                expect(playerStub.sendItemRemoved.notCalled, 'and nothing is echoed back').to.be.true;
+            });
+        }
+
+        it('should not disconnect a client that names an unimplemented window', async () => {
+            await service.execute(playerStub, WindowTypeEnum.DRAGON_SOUL_INVENTORY, 2);
+
+            expect(playerStub.chat.notCalled, 'the original returns false silently').to.be.true;
+        });
+
+        for (const [name, window] of [
+            ['INVENTORY', WindowTypeEnum.INVENTORY],
+            ['EQUIPMENT', WindowTypeEnum.EQUIPMENT],
+        ] as const) {
+            it(`should still handle a use addressed to ${name}`, async () => {
+                playerStub.getItem.returns(undefined);
+
+                await service.execute(playerStub, window, 2);
+
+                expect(playerStub.getItem.calledOnceWith(2)).to.be.true;
+            });
+        }
     });
 });


### PR DESCRIPTION
Closes #103 — this is part 3, the last of that issue's three. Part 1 shipped as #184; part 2 was withdrawn as mechanically wrong (details in #184's body).

## What the code does today

The ITEM_USE packet carries a `window` byte that is accepted, forwarded to `UseItemService` and then never validated. The item is looked up by **position alone**, so naming `SAFEBOX`, `MALL` or `DRAGON_SOUL_INVENTORY` still acts on the inventory slot at that index — and the removal echo sends the attacker's byte straight back, telling the client to clear a slot in a window the item was never in.

## The fix, and why it is where it is

This ports the first half of the original's guard. `CHARACTER::UseItem` opens with `if (!IsValidItemPosition(Cell) || !(item = GetItem(Cell))) return false;` (`char_item.cpp:5183`), where `IsValidItemPosition` switches on `window_type` and `GetItem` resolves the **(window, cell) pair**. We cannot do the second half until a second window actually exists, so this does the first: a use naming a window with no backing store returns without touching anything.

The guard sits in the **service**, and returns **silently**. Both details matter:

- `ItemUsePacketHandler` closes the connection on an invalid packet, and the original does not disconnect here — it returns `false`.
- **A stock client legitimately sends a non-inventory window on this packet.** `uidragonsoul.py` calls `net.SendItemUsePacket(*self.srcItemPos)`, unpacking a `(window, cell)` tuple that carries `DRAGON_SOUL_INVENTORY`. Putting a whitelist in the validator would disconnect a stock client that merely opens the dragon-soul UI. Ordinary use is unaffected either way, since `SItemPos` defaults `window_type` to `INVENTORY` (`length.h:711`).

## The echo is now derived instead of reflected

The only site reading the caller's byte was the unequip branch — whose sibling three lines below already hardcodes `EQUIPMENT`. It is now consistent with it.

Worth noting for review: the item cannot be asked for its own window at that point. `addItem` has already run and set it to `INVENTORY`, so `item.getWindow()` would have shipped a *new* desync in place of the old one. The value comes from the branch instead, which is only reached when `isEquipmentPosition(position)` is true. With the byte no longer read, the parameter is dropped from `useWearableItem`.

## One existing spec changed

`UseItemService.test.ts` pinned the echo to the caller's byte, so it is updated. Its name said "should equip a wearable item from inventory" while stubbing `isEquipmentPosition` to `true` — i.e. it was exercising the **unequip** branch. Renamed to match what it actually does.

## Verified

- Unit suite 663/0 → **671/0**: five cases for the unimplemented windows, one asserting no disconnect, two confirming `INVENTORY` and `EQUIPMENT` still route through.
- Fail-without-fix: reverting fails the five window cases plus the echo assertion.
- `tsc --noEmit`, eslint, prettier clean.

## Note on scope

Pre-existing, and latent rather than exploitable today — no second window is implemented, so the impact is a client-side desync. It stops being latent the moment safebox or mall lands, at which point this is the line that would let an inventory position act on a safebox slot.
