### PR TITLE
test(integration): make character spawning deterministic instead of lucky

### DIFF
--- a/test/integration/game/aggressiveMobVictimScan.test.ts
+++ b/test/integration/game/aggressiveMobVictimScan.test.ts
@@ -40,7 +40,8 @@ describe('Security — aggressive monster victim scan (issue #107)', function ()
                     (monster) =>
                         monster.isAggresive() &&
                         monster.getPoint(PointsEnum.HEALTH) > 0 &&
-                        monster.getNearbyEntities().size === 0,
+                        monster.getNearbyEntities().size === 0 &&
+                        harness.areaAt(monster.getPositionX(), monster.getPositionY()) === monster.getArea(),
                 );
 
             if (candidate) return candidate;

--- a/test/integration/game/attackRangeSecurity.test.ts
+++ b/test/integration/game/attackRangeSecurity.test.ts
@@ -37,16 +37,21 @@ describe('Security — melee attack range (issue #68)', function () {
     });
 
     it('ignores a melee attack from out of range, and still lands one up close', async () => {
-        // Mobs reach the world through the area spawn queue, so it takes a few
-        // ticks before there is a live one to hit.
-        let monster = harness.findMonster();
-        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
-            await new Promise((resolve) => setTimeout(resolve, 250));
-            monster = harness.findMonster();
-        }
+        // Both the monster's own spot and the sniper's spot have to be owned by
+        // the monster's area, or the character is dropped on spawn.
+        await harness.awaitMonsterInPlace();
+        const monster = harness
+            .findMonsters()
+            .find(
+                (candidate) =>
+                    candidate.getPoint(PointsEnum.HEALTH) > 0 &&
+                    candidate.getArea() &&
+                    harness.areaAt(candidate.getPositionX(), candidate.getPositionY()) === candidate.getArea() &&
+                    harness.areaAt(candidate.getPositionX() + OUT_OF_RANGE, candidate.getPositionY()) ===
+                        candidate.getArea(),
+            );
 
-        expect(monster, 'setup: the world spawned a monster to attack').to.not.equal(undefined);
-        expect(monster!.getPoint(PointsEnum.HEALTH), 'setup: the monster is alive').to.be.greaterThan(0);
+        expect(monster, 'setup: the world spawned a monster with room to stand back from').to.not.equal(undefined);
 
         const virtualId = monster!.getVirtualId();
 
@@ -55,6 +60,19 @@ describe('Security — melee attack range (issue #68)', function () {
             x: monster!.getPositionX() + OUT_OF_RANGE,
             y: monster!.getPositionY(),
         });
+
+        expect(harness.findPlayer(SNIPER), 'setup: the sniper is in the world').to.not.equal(undefined);
+
+        // Both characters log in before either attacks: a provoked monster
+        // charges off its spawn cell, and the cell next to it belongs to no
+        // area, so a later login at its position would be dropped.
+        brawler = await harness.login({
+            username: BRAWLER,
+            x: monster!.getPositionX(),
+            y: monster!.getPositionY(),
+        });
+
+        expect(harness.findPlayer(BRAWLER), 'setup: the brawler is in the world').to.not.equal(undefined);
 
         // The damage line is debug output now, so it has to be switched on or
         // both assertions below would be vacuously false.
@@ -69,12 +87,6 @@ describe('Security — melee attack range (issue #68)', function () {
 
         // Positive control: the same packet from a character standing on the
         // monster does land, so the rejection above was the range check.
-        brawler = await harness.login({
-            username: BRAWLER,
-            x: monster!.getPositionX(),
-            y: monster!.getPositionY(),
-        });
-
         brawler.command('/debug');
         await brawler.settle(400);
 

--- a/test/integration/game/harnessSpawnGuard.test.ts
+++ b/test/integration/game/harnessSpawnGuard.test.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import AttackHarness from '../../support/AttackSession';
+
+/**
+ * Regression for issue #148: World.spawn drops a character whose coordinates no
+ * area owns, logging at info level and returning, so the harness used to hand
+ * back a session for a character that was never in the world. Specs then
+ * asserted against undefined and failed far from the cause - or passed
+ * vacuously.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Harness spawn guard (issue #148)', function () {
+    this.timeout(60_000);
+
+    const NOWHERE = { x: 99_000_000, y: 99_000_000 };
+
+    let harness: AttackHarness;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await harness?.stop();
+    });
+
+    it('should report the coordinates when a character cannot enter the world', async () => {
+        expect(harness.areaAt(NOWHERE.x, NOWHERE.y), 'setup: no area owns these coordinates').to.equal(undefined);
+
+        const failure = await harness
+            .login({ username: 'nowhere_test', ...NOWHERE })
+            .then(() => undefined)
+            .catch((error: Error) => error);
+
+        expect(failure, 'login fails instead of returning a session for a ghost').to.be.instanceOf(Error);
+        expect(failure!.message).to.contain('never entered the world');
+        expect(failure!.message, 'and names the coordinates that were refused').to.contain(String(NOWHERE.x));
+    });
+
+    it('should only offer monsters whose position their own area still owns', async () => {
+        const monster = await harness.awaitMonsterInPlace();
+
+        expect(monster, 'setup: at least one monster is standing on its own area').to.not.equal(undefined);
+        expect(harness.areaAt(monster!.getPositionX(), monster!.getPositionY())).to.equal(monster!.getArea());
+    });
+});

--- a/test/integration/game/itemPickupEntityTypeSecurity.test.ts
+++ b/test/integration/game/itemPickupEntityTypeSecurity.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { PointsEnum } from '@/core/enum/PointsEnum';
 import AttackHarness, { AttackSession } from '../../support/AttackSession';
 import { container } from '@/game/Container';
 
@@ -69,15 +68,9 @@ describe('Security — item pickup entity type (issue #83)', function () {
     });
 
     it('ignores a pickup aimed at a monster, without throwing', async () => {
-        // Mobs reach the world through the area spawn queue, so it takes a few
-        // ticks before there is a live one to aim at.
-        let monster = harness.findMonster();
-        for (let attempt = 0; attempt < 20 && !monster?.getPoint(PointsEnum.HEALTH); attempt++) {
-            await new Promise((resolve) => setTimeout(resolve, 250));
-            monster = harness.findMonster();
-        }
+        const monster = await harness.awaitMonsterInPlace();
 
-        expect(monster, 'setup: the world spawned a monster').to.not.equal(undefined);
+        expect(monster, 'setup: a monster spawned and is standing on its own area').to.not.equal(undefined);
 
         hunter = await harness.login({
             username: HUNTER,
@@ -85,7 +78,7 @@ describe('Security — item pickup entity type (issue #83)', function () {
             y: monster!.getPositionY(),
         });
 
-        expect(harness.findPlayer(HUNTER)?.getArea(), 'setup: standing on the monster').to.equal(monster!.getArea());
+        expect(harness.findPlayer(HUNTER)!.getArea(), 'setup: standing on the monster').to.equal(monster!.getArea());
 
         hunter.pickup(monster!.getVirtualId());
         await hunter.settle(800);

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -7,6 +7,7 @@ import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
 import CacheKeyGenerator from '@/core/util/CacheKeyGenerator';
 import Monster from '@/core/domain/entities/game/mob/Monster';
 import DroppedItem from '@/core/domain/entities/game/item/DroppedItem';
+import { PointsEnum } from '@/core/enum/PointsEnum';
 
 /**
  * A "malicious client" test harness: it speaks the raw game protocol against a
@@ -89,6 +90,10 @@ export default class AttackHarness {
         return container.resolve<any>('entityManager');
     }
 
+    private get world() {
+        return container.resolve<any>('world');
+    }
+
     /**
      * Every live entity in the world. Tests use this to learn virtual ids the
      * attacker is not supposed to know — which is exactly the attacker's own
@@ -105,6 +110,37 @@ export default class AttackHarness {
     /** Every live monster, for specs that need one with particular surroundings. */
     findMonsters(): Array<Monster> {
         return this.entities().filter((entity) => entity instanceof Monster);
+    }
+
+    /** The area owning these coordinates, or undefined where none does. */
+    areaAt(x: number, y: number) {
+        return this.world.getArea(x, y);
+    }
+
+    /**
+     * A monster still standing on the area that spawned it. An entity's area is
+     * stamped once and never re-evaluated, so a monster that charged a target
+     * can sit on coordinates no area owns — and seeding a character there makes
+     * World.spawn drop it silently.
+     */
+    findMonsterInPlace(): Monster | undefined {
+        return this.findMonsters().find(
+            (monster) =>
+                monster.getPoint(PointsEnum.HEALTH) > 0 &&
+                monster.getArea() &&
+                this.areaAt(monster.getPositionX(), monster.getPositionY()) === monster.getArea(),
+        );
+    }
+
+    /** Retried across ticks: mobs reach the world through the area spawn queue. */
+    async awaitMonsterInPlace(timeoutMs = 8_000): Promise<Monster | undefined> {
+        const deadline = Date.now() + timeoutMs;
+        do {
+            const monster = this.findMonsterInPlace();
+            if (monster) return monster;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        } while (Date.now() < deadline);
+        return undefined;
     }
 
     /** The most recently spawned ground item, so earlier specs cannot shadow it. */
@@ -172,8 +208,36 @@ export default class AttackHarness {
         );
 
         const session = new AttackSession(this.host, this.port, this.db);
-        await session.enterGame(username, key);
+        try {
+            await session.enterGame(username, key);
+            await this.awaitInWorld(username, x, y);
+        } catch (error) {
+            // An orphaned socket keeps the server's close() waiting for the
+            // rest of the run, so it has to go before the failure propagates.
+            await session.close();
+            throw error;
+        }
         return session;
+    }
+
+    /**
+     * Spawns are queued to the next area tick, so the character is not in the
+     * world when enterGame resolves — and World.spawn drops it outright when no
+     * area owns (x, y). Failing by name here stops every spec from going on to
+     * assert against an undefined entity.
+     */
+    private async awaitInWorld(username: string, x: number, y: number) {
+        const deadline = Date.now() + 5_000;
+        do {
+            if (this.findPlayer(username)) return;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        } while (Date.now() < deadline);
+
+        const area = this.areaAt(x, y);
+        throw new Error(
+            `[harness] ${username} never entered the world at (${x}, ${y}); ` +
+                `World.getArea says ${area ? area.getName() : 'no area owns that spot'}`,
+        );
     }
 }
 
@@ -196,13 +260,19 @@ export class AttackSession {
         });
     }
 
-    private next(length: number): Promise<Buffer> {
-        return new Promise((resolve) => {
+    private next(length: number, timeoutMs = 10_000): Promise<Buffer> {
+        return new Promise((resolve, reject) => {
+            const deadline = Date.now() + timeoutMs;
             const tick = () => {
                 if (this.buffer.length >= length) {
                     const out = this.buffer.subarray(0, length);
                     this.buffer = this.buffer.subarray(length);
                     return resolve(out);
+                }
+                if (Date.now() > deadline) {
+                    return reject(
+                        new Error(`[harness] timed out waiting for ${length} bytes, got ${this.buffer.length}`),
+                    );
                 }
                 setTimeout(tick, 20);
             };
@@ -329,6 +399,7 @@ export class AttackSession {
     }
 
     async close() {
+        if (!this.client || this.client.destroyed) return;
         return new Promise<void>((resolve) => this.client.end(() => resolve()));
     }
 }


### PR DESCRIPTION
Fixes #148. Test-only — no `src/` changes at all.

## The trigger, measured rather than guessed

The first monster in the entity manager is deterministically the one at **(358400, 153600)** — the origin corner of `map_n_snowm_01`. That corner is the only grid cell covered for some distance: one unit west or south and `World.getArea` returns nothing. The mob is stationary until something aggroes it, at which point it charges off that cell and never returns. Traced live: `(358400,153600)` → `(358447,153556)` → parked at `(358833,153193)`, while its own registered area stays `map_n_snowm_01` the whole time.

So whether the suite passes depends on whether an earlier spec happened to provoke that mob — which is exactly why it survives a short suite and breaks a long one.

**This corrects my own guess in the issue.** I suggested random wander. Five full-suite runs on master were green with the case taking 1554–1575 ms every time; the displacement only appears after aggro. Please don't take the "3 runs in 4" framing from the issue at face value — it was wrong.

## What changed in the harness

- `areaAt(x, y)` plus `findMonsterInPlace()` / `awaitMonsterInPlace()`, which require the monster's position to still resolve to **the area that spawned it**. An entity's area is stamped once at spawn and never re-evaluated (`Area.processSpawnQueue`), so `getArea(monster.x, monster.y)` and `monster.getArea()` genuinely disagree once it moves — that disagreement is the predicate.
- `login()` now verifies the character actually reached the world and throws naming the coordinates and what `getArea` says about them. This also removes the unwritten assumption that the entity is live the instant `login()` resolves — spawns are queued to the next area tick.
- **It closes the socket when that check fails**, and this one is load-bearing beyond tidiness. See below.
- `next()` gets a deadline. It polled every 20 ms forever with no rejection path and no socket-state check, so a server that stopped writing wedged the run instead of failing it.

## On the hang the issue could not explain

I did not reproduce the 200 s / 447 s hangs, and I am not claiming to have explained them. But there is one concrete, reproducible piece: **with the login check disabled but everything else in place, the ghost connection stalls the root teardown until mocha's 30 s hook timeout fires.** A character that fails to enter leaves a connected socket nobody closes, and `Server.close()` waits on it. That is consistent with the reported signature and is why the `catch` closes the session — but a 30 s cap does not by itself account for the figures in the issue, so something else is likely also involved.

## `attackRangeSecurity` needed real changes, not cosmetic ones

- Its monster pick now requires **both** the monster's spot and the sniper's spot to belong to the monster's area.
- **Both characters log in before either attacks.** Previously the brawler's coordinates were read *after* the sniper had already provoked the mob — I hit this while verifying, and the new error message named it precisely.
- It now asserts the sniper is in the world. Without that, a sniper that failed to spawn made `no damage dealt from out of range` **trivially true** — the spec could pass while testing nothing.

## Answering the question I left open in the issue

I asked whether this should live in the harness or stay local to one spec. **Harness**, on evidence: `loginPacketReplaySecurity.test.ts:38-45` already hand-rolls the exact `livePlayer()` helper being proposed, and ten call sites across the suite log in and then immediately reach for the entity — four of them with no delay at all. I checked all 22 `login()` call sites: 19 use the default coordinates or a small offset, none expects a login to fail, so making `login()` strict breaks nothing.

## Verified

- Integration **31/0 → 33/0**; unit suite untouched at 663/0.
- With the login check disabled: the guard case fails **and** the root teardown times out. Reverting the harness outright also fails the four specs that use the new helpers.
- New `harnessSpawnGuard` spec pins the guard itself, since the other specs only exercise it when they are unlucky.

## Scope note

These specs still assume the monster stays put for the duration of a case — a narrower assumption than the one fixed here, and one a determined interferer can still break. I left that alone rather than widening the change.
