### PR TITLE
feat(chat): deliver player chat to the map and to the empire (fix #56)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1273,13 +1273,23 @@ export default class Player extends Character {
         return this.createTimedEvent('SELECT', 'Back to Select');
     }
 
-    chat({ message, messageType }: { message: string; messageType: ChatMessageTypeEnum }) {
+    chat({
+        message,
+        messageType,
+        vid = this.getVirtualId(),
+        empireId = this.getEmpire(),
+    }: {
+        message: string;
+        messageType: ChatMessageTypeEnum;
+        vid?: number;
+        empireId?: number;
+    }) {
         this.connection?.send(
             new ChatOutPacket({
                 messageType,
                 message,
-                vid: this.getVirtualId(),
-                empireId: this.getEmpire(),
+                vid,
+                empireId,
             }),
         );
     }

--- a/src/core/interface/networking/packets/packet/in/chat/ChatInPacketHandler.ts
+++ b/src/core/interface/networking/packets/packet/in/chat/ChatInPacketHandler.ts
@@ -4,15 +4,26 @@ import ChatInPacket from './ChatInPacket';
 import GameConnection from '@/game/interface/networking/GameConnection';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 import CommandManager from '@/game/app/command/CommandManager';
+import ChatService from '@/game/app/service/ChatService';
 
 export default class ChatInPacketHandler extends PacketHandler<ChatInPacket> {
     private readonly logger: Logger;
     private readonly commandManager: CommandManager;
+    private readonly chatService: ChatService;
 
-    constructor({ logger, commandManager }: { logger: Logger; commandManager: CommandManager }) {
+    constructor({
+        logger,
+        commandManager,
+        chatService,
+    }: {
+        logger: Logger;
+        commandManager: CommandManager;
+        chatService: ChatService;
+    }) {
         super();
         this.logger = logger;
         this.commandManager = commandManager;
+        this.chatService = chatService;
     }
 
     async execute(connection: GameConnection, packet: ChatInPacket) {
@@ -45,11 +56,12 @@ export default class ChatInPacketHandler extends PacketHandler<ChatInPacket> {
         switch (messageType) {
             case ChatMessageTypeEnum.NORMAL:
                 this.logger.debug(`[ChatInPacketHandler] NORMAL CHAT: ${message}`);
-                if (message.startsWith('/')) {
+                if (message.length > 1 && message.startsWith('/')) {
                     await this.commandManager.execute({ message, player });
+                    return;
                 }
 
-                //TODO: send normal message to other players in map
+                this.chatService.talk(player, message);
 
                 break;
             case ChatMessageTypeEnum.SHOUT:
@@ -65,7 +77,7 @@ export default class ChatInPacketHandler extends PacketHandler<ChatInPacket> {
 
                 if (!player.isShoutAllowed()) return;
 
-                //TODO: send shout to every player in the empire
+                this.chatService.shout(player, message);
 
                 break;
             case ChatMessageTypeEnum.COMMAND:
@@ -75,9 +87,19 @@ export default class ChatInPacketHandler extends PacketHandler<ChatInPacket> {
             case ChatMessageTypeEnum.GROUP:
                 this.logger.debug(`[ChatInPacketHandler] GROUP CHAT: ${message}`);
 
+                player.chat({
+                    messageType: ChatMessageTypeEnum.INFO,
+                    message: '[SYSTEM] You are not in a party',
+                });
+
                 break;
             case ChatMessageTypeEnum.GUILD:
                 this.logger.debug(`[ChatInPacketHandler] GUILD CHAT: ${message}`);
+
+                player.chat({
+                    messageType: ChatMessageTypeEnum.INFO,
+                    message: '[SYSTEM] You are not in a guild',
+                });
 
                 break;
             case ChatMessageTypeEnum.INFO:

--- a/src/game/Container.ts
+++ b/src/game/Container.ts
@@ -13,6 +13,7 @@ import CommandManager from './app/command/CommandManager';
 import CharacterAttackService from './app/service/CharacterAttackService';
 import CharacterMoveService from './app/service/CharacterMoveService';
 import CharacterUpdateTargetService from './app/service/CharacterUpdateTargetService';
+import ChatService from './app/service/ChatService';
 import CreateCharacterService from './app/service/CreateCharacterService';
 import DeleteCharacterService from './app/service/DeleteCharacterService';
 import DropItemService from './app/service/DropItemService';
@@ -85,6 +86,7 @@ container.register({
     spawnManager: asClass(SpawnManager).singleton(),
     characterAttackService: asClass(CharacterAttackService).singleton(),
     characterUpdateTargetService: asClass(CharacterUpdateTargetService).singleton(),
+    chatService: asClass(ChatService).singleton(),
     dropManager: asClass(DropManager).singleton(),
     privilegeManager: asClass(PrivilegeManager).singleton(),
     questManager: asClass(QuestManager).singleton(),

--- a/src/game/app/service/ChatService.ts
+++ b/src/game/app/service/ChatService.ts
@@ -1,0 +1,54 @@
+import World from '@/core/domain/World';
+import Player from '@/core/domain/entities/game/player/Player';
+import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+
+const CHAT_MAX_LEN = 512;
+const CHARACTER_NAME_MAX_LEN = 24;
+const MESSAGE_MAX_LEN = CHAT_MAX_LEN - (CHARACTER_NAME_MAX_LEN + 3);
+const NO_SPEAKER_VID = 0;
+
+export default class ChatService {
+    private readonly world: World;
+
+    constructor({ world }: { world: World }) {
+        this.world = world;
+    }
+
+    talk(speaker: Player, message: string) {
+        const text = this.format(speaker, message);
+
+        speaker.chat({ messageType: ChatMessageTypeEnum.NORMAL, message: text });
+
+        for (const entity of speaker.getNearbyEntities().values()) {
+            if (!(entity instanceof Player)) continue;
+
+            entity.chat({
+                messageType: ChatMessageTypeEnum.NORMAL,
+                message: text,
+                vid: speaker.getVirtualId(),
+                empireId: speaker.getEmpire(),
+            });
+        }
+    }
+
+    shout(speaker: Player, message: string) {
+        const text = this.format(speaker, message);
+
+        for (const player of this.world.getPlayers().values()) {
+            if (player.getEmpire() !== speaker.getEmpire()) continue;
+
+            // A shout carries no speaker vid on purpose: the client resolves a
+            // non-zero vid to a character instance and drops the message when
+            // it has none, which is every receiver outside the shouter's view.
+            player.chat({
+                messageType: ChatMessageTypeEnum.SHOUT,
+                message: text,
+                vid: NO_SPEAKER_VID,
+            });
+        }
+    }
+
+    private format(speaker: Player, message: string) {
+        return `${speaker.getName()} : ${message.slice(0, MESSAGE_MAX_LEN)}`.slice(0, CHAT_MAX_LEN);
+    }
+}

--- a/test/integration/game/chatBroadcast.test.ts
+++ b/test/integration/game/chatBroadcast.test.ts
@@ -1,0 +1,125 @@
+import { expect } from 'chai';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Feature test for issue #56: chat never left the sender. NORMAL and SHOUT both
+ * ended in a TODO, so two players standing on the same tile could not see each
+ * other talk.
+ *
+ * The assertions decode CHAT_OUT off the wire rather than reaching into the
+ * server, because the fields the client needs are exactly what was missing: a
+ * relayed line carries the speaker's vid, and a shout carries none at all.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Chat broadcast (issue #56)', function () {
+    this.timeout(60000);
+
+    const SPEAKER = 'chat_speaker';
+    const LISTENER = 'chat_listener';
+
+    let harness: AttackHarness;
+    let speaker: AttackSession;
+    let listener: AttackSession;
+
+    type ChatPacket = { messageType: number; vid: number; message: string };
+
+    /** Every well-formed CHAT_OUT packet sitting in a session's read buffer. */
+    const chatPackets = (buffer: Buffer): Array<ChatPacket> => {
+        const packets: Array<ChatPacket> = [];
+
+        for (let at = 0; at + 10 <= buffer.length; at++) {
+            if (buffer[at] !== PacketHeaderEnum.CHAT_OUT) continue;
+
+            const size = buffer.readUInt16LE(at + 1);
+            if (size < 10 || at + size > buffer.length) continue;
+            if (buffer[at + size - 1] !== 0) continue;
+
+            const message = buffer.toString('ascii', at + 9, at + size - 1);
+            if (!/^[\x20-\x7e]*$/.test(message)) continue;
+
+            packets.push({ messageType: buffer[at + 3], vid: buffer.readUInt32LE(at + 4), message });
+            at += size - 1;
+        }
+
+        return packets;
+    };
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+        speaker = await harness.login({ username: SPEAKER });
+        listener = await harness.login({ username: LISTENER });
+        await listener.settle(600);
+        speaker.flush();
+        listener.flush();
+    });
+
+    after(async () => {
+        await speaker?.close();
+        await listener?.close();
+        await harness?.stop();
+    });
+
+    it('relays an ordinary message to a nearby player under the speaker vid', async () => {
+        const speakerVid = harness.findPlayer(SPEAKER)?.getVirtualId();
+        expect(speakerVid, 'the speaker is in the world').to.be.a('number');
+
+        speaker.chat('hello there');
+        await speaker.settle(600);
+
+        const heard = chatPackets(listener.received()).filter(
+            (packet) => packet.messageType === ChatMessageTypeEnum.NORMAL,
+        );
+
+        expect(
+            heard.map((packet) => packet.message),
+            'the listener heard the line',
+        ).to.include(`${SPEAKER} : hello there`);
+        expect(heard[0].vid, 'the client needs the speaker vid to draw the bubble').to.equal(speakerVid);
+
+        const echoed = chatPackets(speaker.received()).filter(
+            (packet) => packet.messageType === ChatMessageTypeEnum.NORMAL,
+        );
+        expect(
+            echoed.map((packet) => packet.message),
+            'the speaker sees their own line',
+        ).to.include(`${SPEAKER} : hello there`);
+    });
+
+    it('never puts a command on the wire', async () => {
+        speaker.flush();
+        listener.flush();
+
+        speaker.command('/item 27001 1');
+        await speaker.settle(600);
+
+        const leaked = chatPackets(listener.received()).filter((packet) => packet.message.includes('/item'));
+
+        expect(leaked, 'a command is not chat').to.deep.equal([]);
+    });
+
+    it('sends a shout to the empire with no speaker vid', async () => {
+        speaker.flush();
+        listener.flush();
+
+        speaker.chat('trading here', ChatMessageTypeEnum.SHOUT);
+        await speaker.settle(600);
+
+        const shouts = chatPackets(listener.received()).filter(
+            (packet) => packet.messageType === ChatMessageTypeEnum.SHOUT,
+        );
+
+        expect(shouts.map((packet) => packet.message)).to.include(`${SPEAKER} : trading here`);
+        // A non-zero vid would make the client look the shouter up and discard
+        // the line whenever it has no instance for them, which is the normal
+        // case for a shout.
+        expect(shouts[0].vid, 'a shout carries no vid').to.equal(0);
+    });
+
+    it('keeps the server up and leaks no rejection', async () => {
+        expect(await harness.isServerAlive(), 'server still accepting connections').to.equal(true);
+        expect(harness.capturedRejections(), 'no unhandled rejection escaped').to.deep.equal([]);
+    });
+});

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -247,12 +247,17 @@ export class AttackSession {
 
     /** Fire a raw command through the chat channel (e.g. "/item 27001 5"). */
     command(message: string) {
+        this.chat(message);
+    }
+
+    /** Fire a raw chat packet; the type defaults to NORMAL, 6 is SHOUT. */
+    chat(message: string, messageType = 0) {
         const size = 1 + 2 + 1 + message.length + 1;
         const w = new BufferWriter(PacketHeaderEnum.CHAT_IN, size);
         this.sendSequenced(
             w
                 .writeUint16LE(size)
-                .writeUint8(0)
+                .writeUint8(messageType)
                 .writeString(message, message.length + 1)
                 .getBuffer(),
         );

--- a/test/unit/core/interface/networking/packets/packets/in/chat/ChatInPacketHandler.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/chat/ChatInPacketHandler.test.ts
@@ -4,7 +4,7 @@ import ChatInPacketHandler from '@/core/interface/networking/packets/packet/in/c
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 
 describe('ChatInPacketHandler', () => {
-    let loggerMock, commandManagerMock, connectionMock, packetMock, playerMock;
+    let loggerMock, commandManagerMock, chatServiceMock, connectionMock, packetMock, playerMock;
     let chatInPacketHandler: ChatInPacketHandler;
 
     beforeEach(() => {
@@ -16,6 +16,11 @@ describe('ChatInPacketHandler', () => {
 
         commandManagerMock = {
             execute: sinon.stub(),
+        };
+
+        chatServiceMock = {
+            talk: sinon.spy(),
+            shout: sinon.spy(),
         };
 
         playerMock = {
@@ -42,6 +47,7 @@ describe('ChatInPacketHandler', () => {
         chatInPacketHandler = new ChatInPacketHandler({
             logger: loggerMock,
             commandManager: commandManagerMock,
+            chatService: chatServiceMock,
         });
     });
 
@@ -96,6 +102,75 @@ describe('ChatInPacketHandler', () => {
         await chatInPacketHandler.execute(connectionMock, packetMock).catch((error) => (rejection = error));
 
         expect(rejection, 'GameServer.onData can only log a rejection the handler awaited').to.equal(failure);
+    });
+
+    it('should broadcast an ordinary message instead of dropping it (issue #56)', async () => {
+        packetMock.getMessage = () => 'hello there';
+
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(chatServiceMock.talk.calledOnceWith(playerMock, 'hello there')).to.be.true;
+        expect(commandManagerMock.execute.called, 'a plain message is not a command').to.be.false;
+    });
+
+    it('should never broadcast a command, which would publish it to the whole map (issue #56)', async () => {
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(commandManagerMock.execute.calledOnce).to.be.true;
+        expect(chatServiceMock.talk.called, 'the command text stays private').to.be.false;
+    });
+
+    it('should treat a lone slash as chat, the way the original does', async () => {
+        packetMock.getMessage = () => '/';
+
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(commandManagerMock.execute.called).to.be.false;
+        expect(chatServiceMock.talk.calledOnceWith(playerMock, '/')).to.be.true;
+    });
+
+    it('should send a shout to the empire once it passes both gates (issue #56)', async () => {
+        packetMock.getMessageType = () => ChatMessageTypeEnum.SHOUT;
+        packetMock.getMessage = () => 'trading here';
+
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(chatServiceMock.shout.calledOnceWith(playerMock, 'trading here')).to.be.true;
+    });
+
+    it('should not shout for a player below the minimum level', async () => {
+        packetMock.getMessageType = () => ChatMessageTypeEnum.SHOUT;
+        playerMock.hasShoutLevel.returns(false);
+
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(chatServiceMock.shout.called).to.be.false;
+    });
+
+    it('should not shout while the cooldown is running', async () => {
+        packetMock.getMessageType = () => ChatMessageTypeEnum.SHOUT;
+        playerMock.isShoutAllowed.returns(false);
+
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(chatServiceMock.shout.called).to.be.false;
+    });
+
+    it('should answer party and guild chat the way the original answers a player in neither', async () => {
+        packetMock.getMessageType = () => ChatMessageTypeEnum.GROUP;
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        packetMock.getMessageType = () => ChatMessageTypeEnum.GUILD;
+        await chatInPacketHandler.execute(connectionMock, packetMock);
+
+        expect(playerMock.chat.getCall(0).args[0]).to.deep.equal({
+            messageType: ChatMessageTypeEnum.INFO,
+            message: '[SYSTEM] You are not in a party',
+        });
+        expect(playerMock.chat.getCall(1).args[0]).to.deep.equal({
+            messageType: ChatMessageTypeEnum.INFO,
+            message: '[SYSTEM] You are not in a guild',
+        });
     });
 
     it('should log an error and close the connection if the packet is invalid', async () => {

--- a/test/unit/game/app/service/ChatService.test.ts
+++ b/test/unit/game/app/service/ChatService.test.ts
@@ -1,0 +1,131 @@
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import Player from '@/core/domain/entities/game/player/Player';
+import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+import ChatService from '@/game/app/service/ChatService';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const RED = 1;
+const BLUE = 2;
+
+const makePlayer = ({ name = 'Someone', vid = 1, empire = RED } = {}) => {
+    const player = sinon.createStubInstance(Player);
+    player.getName.returns(name);
+    player.getVirtualId.returns(vid);
+    player.getEmpire.returns(empire);
+    player.getNearbyEntities.returns(new Map());
+    return player;
+};
+
+const nearby = (...entities: Array<{ getVirtualId: () => number }>) =>
+    new Map(entities.map((entity) => [entity.getVirtualId(), entity]));
+
+describe('ChatService', function () {
+    let worldMock: any;
+    let chatService: ChatService;
+
+    beforeEach(function () {
+        worldMock = {
+            getPlayers: sinon.stub().returns(new Map()),
+        };
+
+        chatService = new ChatService({ world: worldMock });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('talk', function () {
+        it('should send the message to the speaker so they see their own line', function () {
+            const speaker = makePlayer({ name: 'Speaker', vid: 7 });
+
+            chatService.talk(speaker as unknown as Player, 'hello');
+
+            expect(speaker.chat.calledOnce).to.be.true;
+            expect(speaker.chat.firstCall.args[0]).to.deep.equal({
+                messageType: ChatMessageTypeEnum.NORMAL,
+                message: 'Speaker : hello',
+            });
+        });
+
+        it('should relay the message to nearby players under the speaker vid', function () {
+            const speaker = makePlayer({ name: 'Speaker', vid: 7, empire: BLUE });
+            const listener = makePlayer({ name: 'Listener', vid: 8 });
+            speaker.getNearbyEntities.returns(nearby(listener) as any);
+
+            chatService.talk(speaker as unknown as Player, 'hello');
+
+            expect(listener.chat.calledOnce).to.be.true;
+            expect(listener.chat.firstCall.args[0]).to.deep.equal({
+                messageType: ChatMessageTypeEnum.NORMAL,
+                message: 'Speaker : hello',
+                vid: 7,
+                empireId: BLUE,
+            });
+        });
+
+        it('should skip nearby entities that are not players', function () {
+            const speaker = makePlayer({ vid: 7 });
+            const monster = sinon.createStubInstance(Monster);
+            monster.getVirtualId.returns(9);
+            speaker.getNearbyEntities.returns(nearby(monster) as any);
+
+            expect(() => chatService.talk(speaker as unknown as Player, 'hello')).to.not.throw();
+            expect(speaker.chat.calledOnce, 'only the speaker was written to').to.be.true;
+        });
+
+        it('should cut a message down to the length the original allows', function () {
+            const speaker = makePlayer({ name: 'Speaker', vid: 7 });
+            const listener = makePlayer({ name: 'Listener', vid: 8 });
+            speaker.getNearbyEntities.returns(nearby(listener) as any);
+
+            chatService.talk(speaker as unknown as Player, 'x'.repeat(5000));
+
+            const { message } = listener.chat.firstCall.args[0];
+            expect(message.length).to.equal('Speaker : '.length + 485);
+        });
+    });
+
+    describe('shout', function () {
+        it('should reach every player of the same empire, the shouter included', function () {
+            const shouter = makePlayer({ name: 'Shouter', vid: 7, empire: RED });
+            const sameEmpire = makePlayer({ name: 'Ally', vid: 8, empire: RED });
+            worldMock.getPlayers.returns(
+                new Map([
+                    ['Shouter', shouter],
+                    ['Ally', sameEmpire],
+                ]),
+            );
+
+            chatService.shout(shouter as unknown as Player, 'hello');
+
+            expect(shouter.chat.calledOnce).to.be.true;
+            expect(sameEmpire.chat.calledOnce).to.be.true;
+            expect(sameEmpire.chat.firstCall.args[0].message).to.equal('Shouter : hello');
+        });
+
+        it('should not reach a player of another empire', function () {
+            const shouter = makePlayer({ name: 'Shouter', vid: 7, empire: RED });
+            const otherEmpire = makePlayer({ name: 'Stranger', vid: 8, empire: BLUE });
+            worldMock.getPlayers.returns(new Map([['Stranger', otherEmpire]]));
+
+            chatService.shout(shouter as unknown as Player, 'hello');
+
+            expect(otherEmpire.chat.called).to.be.false;
+        });
+
+        it('should carry no speaker vid, which is what makes it visible off screen', function () {
+            const shouter = makePlayer({ name: 'Shouter', vid: 7, empire: RED });
+            worldMock.getPlayers.returns(new Map([['Shouter', shouter]]));
+
+            chatService.shout(shouter as unknown as Player, 'hello');
+
+            expect(shouter.chat.firstCall.args[0]).to.deep.equal({
+                messageType: ChatMessageTypeEnum.SHOUT,
+                message: 'Shouter : hello',
+                vid: 0,
+            });
+        });
+    });
+});


### PR DESCRIPTION
Closes #56.

## What was missing

`ChatInPacketHandler` ran commands and then fell into `//TODO: send normal message to other players in map`. The shout branch passed the level and cooldown gates and then hit `//TODO: send shout to every player in the empire`. Party and guild chat were empty `case`s. Two players standing on the same tile could not see each other talk: chat only ever carried commands and `[SYSTEM]` lines back to the sender.

## The fix

A new `ChatService` does the fan-out, following `CInputMain::Chat` in `input_main.cpp`:

- **Ordinary chat** composes `"<name> : <message>"` and relays it to the speaker and to every nearby player. The separator is not cosmetic, the client does `strchr(buf, ':')` and then skips two characters to find the text.
- **Shout** goes to every online player of the speaker's empire, the shouter included.
- Both are cut to the original's bounds: 485 characters of text, 512 for the composed line.

Two details come from the client rather than the server source (`RecvChatPacket`, `PythonNetworkStreamPhaseGame.cpp`):

- A relayed line carries the **speaker's vid**, because the client resolves a non-zero vid to a character instance and returns early when it has none.
- A shout therefore carries **vid 0**, which is exactly what makes it readable by players nowhere near the shouter. Sent under the shouter's vid, a shout would be silently dropped by every client that cannot see them.

Commands now `return` instead of falling through. Without that, `/item 27001 1` would publish the command text to everyone in view.

## Trade-off: nearby set vs whole map

The original sends ordinary chat to **every player on the map index** and lets the client discard what it cannot render. I fan out over the speaker's **nearby set** instead, because that set is precisely the set of clients that have the speaker spawned: a map-wide send would only add packets the client throws away, at O(players on map) per message. Observable behaviour is identical. Happy to switch to the literal map-wide form if you prefer.

## Length cap

The inbound message is bounded only by the packet frame (`readString` over a u16 length), so a crafted client can send ~64KB. That was harmless while chat was logged and dropped; broadcasting multiplies it by the number of receivers. The cap is the original's, 485 and 512.

## Verified

- `tsc --noEmit` clean. Unit **677 passing** (663 on master plus 14 new), integration **35 passing** (31 plus 4 new).
- Fail-without-fix, unit: reverting the handler wiring fails 4 of the new cases; removing only the early `return` fails the command-leak case; five separate mutations of `ChatService` (speaker vid on shout, no empire filter, no length cap, no `Player` filter, no self-copy) each fail exactly their own case and nothing else.
- Fail-without-fix, integration: without the two broadcast calls 2 of 4 fail; without the early `return` the command-leak case fails.
- The integration spec logs in two real clients on the same tile and decodes `CHAT_OUT` off the wire rather than reaching into the server.
- Merges clean on master, and clean after each of the 8 open PRs that share a file with it (`Player.ts` x6, `Container.ts`, `AttackSession.ts`).

## Scope

- Party and guild chat now answer the way the original answers a player who is in neither, instead of doing nothing. Say the word and I drop those two branches.
- `Player.chat` takes an optional `vid`/`empireId` defaulting to the sender's, so relaying somebody else's line does not need a second method.
- **Left alone, adjacent:** every `[SYSTEM]` message still goes out under the player's own vid, so the client draws it as a speech bubble over their head. The original sends those with vid 0. Separate PR if you want it swept.
- Not touched: empire language garbling (`ConvertEmpireText`), banword filtering, whisper, and GM cross-empire shout visibility, which needs the authority system of #64.
