### PR TITLE
fix(battle): stop a stunned character mid-move and sync the client (fix #52)

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -311,13 +311,27 @@ export default abstract class Character extends GameEntity {
     }
 
     protected stun() {
-        //TODO: verify the necessity to send sync packet
-        if (this.targetPositionX === this.positionX || this.targetPositionY === this.positionY) {
-            this.startPositionX = this.targetPositionX = this.positionX;
-            this.startPositionY = this.targetPositionY = this.positionY;
-            if (this.pos === PositionEnum.FIGHTING) {
-                this.setPos(PositionEnum.STANDING);
+        if (this.targetPositionX === this.positionX && this.targetPositionY === this.positionY) return;
+
+        this.startPositionX = this.targetPositionX = this.positionX;
+        this.startPositionY = this.targetPositionY = this.positionY;
+
+        if (this.pos === PositionEnum.FIGHTING) {
+            this.setPos(PositionEnum.STANDING);
+        }
+
+        this.syncPosition();
+    }
+
+    protected syncPosition() {
+        for (const entity of this.nearbyEntities.values()) {
+            if (entity.isPlayer()) {
+                entity.sendSyncPosition(this);
             }
+        }
+
+        if (this.isPlayer()) {
+            this.sendSyncPosition(this);
         }
     }
 

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -282,7 +282,6 @@ export default class MonsterBattle {
     }
 
     private applyStun(victim: Player) {
-        //TODO: reset player future position
         if (victim.isAffectByFlag(AffectBitsTypeEnum.STUN)) return;
         //If the player has stun immune, they will only have a 20% chance of being stunned.
         if (victim.getPoint(PointsEnum.IMMUNE_STUN) && MathUtil.getRandomInt(1, 100) <= 80) return;

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -736,13 +736,7 @@ export default class Player extends Character {
         // the only packet the client applies to its own character, so a
         // desynced client self-recovers instead of rubber-banding forever.
         this.lastReportedPosition = null;
-        this.connection?.send(
-            new SyncPositionPacket({
-                virtualId: this.virtualId,
-                positionX: this.getPositionX(),
-                positionY: this.getPositionY(),
-            }),
-        );
+        this.sendSyncPosition(this);
         return false;
     }
 
@@ -871,6 +865,16 @@ export default class Player extends Character {
 
         super.setTarget(target);
         this.sendTargetUpdated(target);
+    }
+
+    sendSyncPosition(entity: Character) {
+        this.connection?.send(
+            new SyncPositionPacket({
+                virtualId: entity.getVirtualId(),
+                positionX: entity.getPositionX(),
+                positionY: entity.getPositionY(),
+            }),
+        );
     }
 
     sendTargetUpdated(target?: Character) {

--- a/test/unit/core/domain/entities/game/CharacterStun.test.ts
+++ b/test/unit/core/domain/entities/game/CharacterStun.test.ts
@@ -1,0 +1,145 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Character from '@/core/domain/entities/game/Character';
+import Player from '@/core/domain/entities/game/player/Player';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { PositionEnum } from '@/core/enum/PositionEnum';
+
+class TestCharacter extends Character {
+    private readonly testPoints = new Map<PointsEnum, number>();
+
+    readonly sendSyncPosition = sinon.spy();
+
+    addPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, (this.testPoints.get(point) ?? 0) + value);
+    }
+    setPoint(point: PointsEnum, value: number): void {
+        this.testPoints.set(point, value);
+    }
+    getPoint(point: PointsEnum): number {
+        return this.testPoints.get(point) ?? 0;
+    }
+    getHealthPercentage(): number {
+        return 100;
+    }
+    getAttack(): number {
+        return 0;
+    }
+    getDefense(): number {
+        return 0;
+    }
+    onSpawn(): void {}
+    onDespawn(): void {}
+
+    /** stun() is protected; specs drive it the way the battle code does. */
+    applyStun() {
+        this.stun();
+    }
+
+    walkTowards(x: number, y: number) {
+        this.targetPositionX = x;
+        this.targetPositionY = y;
+        this.startPositionX = this.positionX;
+        this.startPositionY = this.positionY;
+    }
+
+    futurePosition() {
+        return { x: this.targetPositionX, y: this.targetPositionY };
+    }
+
+    startPosition() {
+        return { x: this.startPositionX, y: this.startPositionY };
+    }
+
+    getPos() {
+        return this.pos;
+    }
+}
+
+const AT_X = 100;
+const AT_Y = 200;
+
+const createCharacter = (entityType: EntityTypeEnum = EntityTypeEnum.MONSTER) =>
+    new TestCharacter(
+        {
+            id: 1,
+            classId: 1,
+            virtualId: 7,
+            entityType,
+            positionX: AT_X,
+            positionY: AT_Y,
+            name: 'test',
+            empire: 1,
+        },
+        {
+            animationManager: {} as any,
+            questManager: {} as any,
+            eventTimerManager: {} as any,
+        },
+    );
+
+const nearbyPlayer = (virtualId: number) => {
+    const player = sinon.createStubInstance(Player);
+    player.getVirtualId.returns(virtualId);
+    player.getEntityType.returns(EntityTypeEnum.PLAYER);
+    player.isPlayer.returns(true);
+    return player;
+};
+
+describe('Character stun (issue #52)', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('drops the future position of a character that was moving', function () {
+        const character = createCharacter();
+        character.walkTowards(5000, 6000);
+
+        character.applyStun();
+
+        expect(character.futurePosition()).to.deep.equal({ x: AT_X, y: AT_Y });
+        expect(character.startPosition()).to.deep.equal({ x: AT_X, y: AT_Y });
+    });
+
+    it('syncs the new position to every nearby player', function () {
+        const character = createCharacter();
+        const watcher = nearbyPlayer(8);
+        character.addNearbyEntity(watcher as unknown as Player);
+        character.walkTowards(5000, 6000);
+
+        character.applyStun();
+
+        expect(watcher.sendSyncPosition.calledOnceWith(character as unknown as Character)).to.be.true;
+    });
+
+    it('syncs to the stunned player as well, the way PacketView includes self', function () {
+        const character = createCharacter(EntityTypeEnum.PLAYER);
+        character.walkTowards(5000, 6000);
+
+        character.applyStun();
+
+        expect(character.sendSyncPosition.calledOnceWith(character)).to.be.true;
+    });
+
+    it('leaves a character that was standing still untouched', function () {
+        const character = createCharacter(EntityTypeEnum.PLAYER);
+        const watcher = nearbyPlayer(8);
+        character.addNearbyEntity(watcher as unknown as Player);
+
+        character.applyStun();
+
+        expect(watcher.sendSyncPosition.called, 'nothing to snap the client to').to.be.false;
+        expect(character.sendSyncPosition.called).to.be.false;
+    });
+
+    it('takes a fighting character out of the fighting position', function () {
+        const character = createCharacter();
+        character.walkTowards(5000, 6000);
+        character.setPos(PositionEnum.FIGHTING);
+
+        character.applyStun();
+
+        expect(character.getPos()).to.equal(PositionEnum.STANDING);
+    });
+});


### PR DESCRIPTION
Closes #52.

## The condition was backwards

`Character.stun()` already tried to do this, with the test inverted. The original, `char_affect.cpp:558`:

```cpp
if (m_posDest.x != GetX() || m_posDest.y != GetY())   // reset when it DIFFERS
{
    m_posDest.x = m_posStart.x = GetX();
    ...
    SyncPacket();
}
```

versus master:

```ts
if (this.targetPositionX === this.positionX || this.targetPositionY === this.positionY) {  // when it MATCHES
```

The original resets when the destination differs from the current position, because that is when there is something to reset. Ours reset when they were equal, making it a no-op exactly when it mattered: a character stunned mid-walk kept its future position and carried on to the destination. Standing still, it reset values that already matched.

## The sync was missing

The second half of what the issue asks for was absent, with `//TODO: verify the necessity to send sync packet` sitting where it belonged. It is necessary: `SYNC_POSITION` is the only packet the client applies to its own character, so without it the stunned player's client keeps walking towards a destination the server has already dropped.

`Character.syncPosition()` sends it to nearby players **and to the character themselves**, matching `CEntity::PacketView` (`entity.cpp`), which walks the view set and then explicitly appends self:

```cpp
if (!m_bIsObserver)
    for_each(m_map_view.begin(), m_map_view.end(), f);
f(std::make_pair(this, 0));
```

Monsters go through the same path, as they do in the original — `stun()` lives on `Character`, and `PacketAround` is on `CEntity`, not on the player.

## Not duplicating the packet

`Player.sendSyncPosition(entity)` is the sender. The move-rate snap-back at the old `Player.ts:739` already built the identical packet inline, so that call site now routes through the new method instead of constructing its own. Net effect on that path: none, and it is covered by the existing `moveSpeedSecurity` integration spec, which still passes.

## Verified

- `tsc --noEmit` clean. Unit **668 passing** (663 on master plus 5 new), integration **31 passing**, unchanged from master.
- Fail-without-fix: dropping master's exact `stun()` body back in fails **4 of the 5** new cases. The fifth ("standing still is left untouched") is pinned separately — it fails under the inverted-condition mutation below, so it is not vacuous.
- Five mutations, each failing exactly its own case and nothing else: inverted condition (5 fail), no sync at all (2), no self sync (1), no nearby sync (1), no position reset (1).
- Merges clean on master, and clean after each of the **9 open PRs that share a file** with it (`Player.ts` x7, `Character.ts` x2, `MonsterBattle.ts` x2), simulated pairwise rather than only against master.

## Scope

- **No integration spec.** Reaching this path from the wire needs a monster with `enchant_stun > 0` to win a random roll against a moving player; that would be a flaky spec pinned to spawn contents. The logic is covered by the unit cases, and the refactored sender by an existing integration spec. Happy to add one if you would rather have it.
- `MonsterBattle.applyStun` and `PlayerBattleAgainstMobStrategy.applyStun` need no change: both already call `victim.stun()`, so both get the fix. The only edit in `MonsterBattle` is deleting `//TODO: reset player future position`, which this PR does.
- The neighbouring `//TODO: use antislow ...` is left alone; that one is #53.
- Pre-existing, not a regression from anything recent.
