### PR TITLE
feat(battle): give MAGIC monsters their attack (fix #51)

### DIFF
--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -42,7 +42,7 @@ export default class MonsterBattle {
                 break;
 
             case BattleTypeEnum.MAGIC:
-                //TODO
+                this.magicAttack(victim);
                 break;
         }
     }
@@ -54,6 +54,11 @@ export default class MonsterBattle {
     private rangeAttack(victim: Player) {
         this.attacker.createFlyTargeting(victim);
         this.resolveAttack(victim, DamageTypeEnum.NORMAL_RANGE, victim.getPoint(PointsEnum.RESIST_BOW));
+    }
+
+    private magicAttack(victim: Player) {
+        this.attacker.createFlyTargeting(victim);
+        this.resolveAttack(victim, DamageTypeEnum.MAGIC, victim.getPoint(PointsEnum.RESIST_MAGIC));
     }
 
     private resolveAttack(victim: Player, damageType: DamageTypeEnum, resistance: number) {
@@ -108,6 +113,7 @@ export default class MonsterBattle {
                 break;
             case DamageTypeEnum.NORMAL:
             case DamageTypeEnum.NORMAL_RANGE:
+            case DamageTypeEnum.MAGIC:
                 //TODO: apply terror skill
 
                 if (this.isBlocked(victim, damageType)) {

--- a/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
@@ -821,6 +821,9 @@ export class PlayerPoints extends Points {
         this.points.set(PointsEnum.RESIST_BOW, {
             get: () => this.resistBow,
         });
+        this.points.set(PointsEnum.RESIST_MAGIC, {
+            get: () => this.resistMagic,
+        });
         this.points.set(PointsEnum.REFLECT_MELEE, {
             get: () => this.reflectMelee,
         });

--- a/test/integration/game/magicMobAttack.test.ts
+++ b/test/integration/game/magicMobAttack.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Covers issue #51: a MAGIC monster must cast at the character it is chasing.
+ * Mirrors the ranged-mob spec — the projectile packet and the damage that
+ * follows it — because the original routes both through the same FlyTarget +
+ * Shoot path, differing only in the damage type and resistance.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Feature — magic monster attacks (issue #51)', function () {
+    this.timeout(60000);
+
+    const TARGET = 'magic_target_test';
+    const VILE_DEMON_SHAMAN = 1034;
+    const DAMAGE_MESSAGE = 'Damage received';
+
+    let harness: AttackHarness;
+    let session: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await session?.close();
+        await harness?.stop();
+    });
+
+    // Taken from the character's own view rather than the whole world, so it is
+    // the invoked monster and not one another spec left lying around.
+    async function invokedMagicMonster(player: any): Promise<Monster | undefined> {
+        for (let attempt = 0; attempt < 40; attempt++) {
+            const candidate = [...player.getNearbyEntities().values()].find(
+                (entity: any) =>
+                    entity instanceof Monster &&
+                    entity.getBattleType() === BattleTypeEnum.MAGIC &&
+                    entity.getPoint(PointsEnum.HEALTH) > 0,
+            );
+
+            if (candidate) return candidate as Monster;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        return undefined;
+    }
+
+    it('casts at the character it is chasing and lands damage', async () => {
+        session = await harness.login({ username: TARGET });
+
+        const player = harness.findPlayer(TARGET);
+        expect(player, 'setup: the character reached the world').to.not.equal(undefined);
+
+        // The damage line is debug output, so it has to be switched on or the
+        // assertion below would be vacuously false.
+        session.command('/debug');
+        await session.settle(400);
+
+        session.command(`/invoke ${VILE_DEMON_SHAMAN}`);
+        await session.settle(800);
+
+        const monster = await invokedMagicMonster(player);
+        expect(monster, 'setup: a MAGIC monster spawned and saw the character').to.not.equal(undefined);
+
+        const healthBefore = player.getPoint(PointsEnum.HEALTH);
+        session.flush();
+
+        for (let attempt = 0; attempt < 40 && !session.received().includes(DAMAGE_MESSAGE); attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+
+        expect(session.received().includes(DAMAGE_MESSAGE), 'the magic monster dealt damage').to.equal(true);
+        expect(player.getPoint(PointsEnum.HEALTH), 'the character lost health').to.be.lessThan(healthBefore);
+
+        // The projectile the client draws: header, then shooter and target vid.
+        const projectile = Buffer.alloc(9);
+        projectile.writeUInt8(PacketHeaderEnum.FLY_TARGETING, 0);
+        projectile.writeUInt32LE(monster!.getVirtualId(), 1);
+        projectile.writeUInt32LE(player.getVirtualId(), 5);
+
+        expect(session.received().includes(projectile), 'the projectile was broadcast').to.equal(true);
+    });
+});

--- a/test/unit/core/domain/entities/game/mob/delegate/battle/MonsterBattle.test.ts
+++ b/test/unit/core/domain/entities/game/mob/delegate/battle/MonsterBattle.test.ts
@@ -2,28 +2,36 @@ import { expect } from 'chai';
 import MonsterBattle from '@/core/domain/entities/game/mob/delegate/battle/MonsterBattle';
 import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
 import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+import { DamageFlagEnum } from '@/core/enum/DamageFlagEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
 
 const REFLECT_PERCENTAGE = 50;
 
-const createVictim = (points: Partial<Record<PointsEnum, number>>) => ({
-    getPoint: (point: PointsEnum) => points[point] ?? 0,
-    getAttackRating: () => 0,
-    getDefense: () => 0,
-    getPositionX: () => 0,
-    getPositionY: () => 0,
-    isAffectByFlag: () => false,
-    setAffectFlag: () => {},
-    removeAffectFlag: () => {},
-    updateView: () => {},
-    addEventTimer: () => {},
-    addPoint: () => {},
-    debugChat: () => {},
-    sendDamageReceived: () => {},
-    takeDamage: () => {},
-});
+const createVictim = (points: Partial<Record<PointsEnum, number>>) => {
+    const received: Array<{ damage: number; damageFlags: number }> = [];
+    const taken: Array<number> = [];
 
-const createAttacker = (battleType: BattleTypeEnum, reflected: Array<number>) => ({
+    return {
+        received,
+        taken,
+        getPoint: (point: PointsEnum) => points[point] ?? 0,
+        getAttackRating: () => 0,
+        getDefense: () => 0,
+        getPositionX: () => 0,
+        getPositionY: () => 0,
+        isAffectByFlag: () => false,
+        setAffectFlag: () => {},
+        removeAffectFlag: () => {},
+        updateView: () => {},
+        addEventTimer: () => {},
+        addPoint: () => {},
+        debugChat: () => {},
+        sendDamageReceived: (packet: { damage: number; damageFlags: number }) => received.push(packet),
+        takeDamage: (_attacker: unknown, damage: number) => taken.push(damage),
+    };
+};
+
+const createAttacker = (battleType: BattleTypeEnum, reflected: Array<number>, projectiles: Array<unknown> = []) => ({
     getBattleType: () => battleType,
     getAttackRange: () => 1000,
     getAttack: () => 500,
@@ -37,7 +45,7 @@ const createAttacker = (battleType: BattleTypeEnum, reflected: Array<number>) =>
     getPositionY: () => 0,
     isDeathBlower: () => false,
     isImmuneByFlag: () => false,
-    createFlyTargeting: () => {},
+    createFlyTargeting: (target: unknown) => projectiles.push(target),
     takeDamage: (_victim: unknown, damage: number) => reflected.push(damage),
 });
 
@@ -61,6 +69,76 @@ describe('MonsterBattle', () => {
 
         it('should not reflect damage back at a ranged monster, which never gets close enough to be hit back', () => {
             expect(attack(BattleTypeEnum.RANGE)).to.have.lengthOf(0);
+        });
+    });
+
+    describe('magic attacks (issue #51)', () => {
+        const magicAttack = (points: Partial<Record<PointsEnum, number>> = {}) => {
+            const projectiles: Array<unknown> = [];
+            const attacker = createAttacker(BattleTypeEnum.MAGIC, [], projectiles);
+            const victim = createVictim(points);
+
+            new MonsterBattle(attacker as any, createLogger() as any).execute(AttackTypeEnum.NORMAL, victim as any);
+
+            return { victim, projectiles };
+        };
+
+        it('should land damage instead of hitting the TODO branch', () => {
+            const { victim } = magicAttack();
+
+            expect(victim.taken, 'the victim took damage').to.have.lengthOf(1);
+            expect(victim.taken[0]).to.be.greaterThan(0);
+        });
+
+        it('should draw a projectile, like the original FlyTarget for BATTLE_TYPE_MAGIC', () => {
+            const { victim, projectiles } = magicAttack();
+
+            expect(projectiles).to.deep.equal([victim]);
+        });
+
+        it('should reduce the damage by the resist magic point, not resist bow', () => {
+            const { victim: unresisted } = magicAttack();
+            const { victim: resisted } = magicAttack({ [PointsEnum.RESIST_MAGIC]: 50 });
+            const { victim: wrongResist } = magicAttack({ [PointsEnum.RESIST_BOW]: 50 });
+
+            expect(resisted.taken[0], 'resist magic halves it').to.equal(Math.round(unresisted.taken[0] / 2));
+            expect(wrongResist.taken[0], 'resist bow is for arrows').to.equal(unresisted.taken[0]);
+        });
+
+        it('should not be blockable or dodgeable, matching the original', () => {
+            const { victim } = magicAttack({ [PointsEnum.BLOCK]: 100, [PointsEnum.DODGE]: 100 });
+
+            expect(victim.taken, 'block and dodge only gate physical hits').to.have.lengthOf(1);
+            expect(victim.received[0].damageFlags & DamageFlagEnum.BLOCK).to.equal(0);
+            expect(victim.received[0].damageFlags & DamageFlagEnum.DODGE).to.equal(0);
+        });
+
+        it('should carry the NORMAL damage flag, so the client renders the hit', () => {
+            const { victim } = magicAttack();
+
+            expect(victim.received[0].damageFlags & DamageFlagEnum.NORMAL).to.not.equal(0);
+        });
+
+        it('should be absorbed by a mana shield, the way every skill-type hit is in the original', () => {
+            const shielded = (() => {
+                const projectiles: Array<unknown> = [];
+                const attacker = createAttacker(BattleTypeEnum.MAGIC, [], projectiles);
+                const victim = {
+                    ...createVictim({ [PointsEnum.MANASHIELD]: 100, [PointsEnum.MANA]: 10_000 }),
+                    isAffectByFlag: () => true,
+                };
+
+                new MonsterBattle(attacker as any, createLogger() as any).execute(AttackTypeEnum.NORMAL, victim as any);
+
+                return victim;
+            })();
+            const { victim: unshielded } = magicAttack();
+
+            expect(shielded.taken[0], 'a third of the hit went to mana').to.be.lessThan(unshielded.taken[0]);
+        });
+
+        it('should not reflect back at the caster, who is never in melee reach', () => {
+            expect(attack(BattleTypeEnum.MAGIC)).to.have.lengthOf(0);
         });
     });
 });

--- a/test/unit/core/domain/entities/game/player/PlayerPointsResistMagic.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerPointsResistMagic.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { PlayerPoints } from '@/core/domain/entities/game/player/delegate/PlayerPoints';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+const RESIST = 30;
+
+const createPoints = () =>
+    new PlayerPoints({ resistMagic: RESIST, resistBow: RESIST } as any, { config: {} as any, player: {} as any });
+
+describe('PlayerPoints — resist magic registration (issue #51)', () => {
+    it('should expose resist magic through getPoint, the way resist bow already is', () => {
+        const points = createPoints();
+
+        expect(points.getPoint(PointsEnum.RESIST_MAGIC), 'an unregistered point reads 0').to.equal(RESIST);
+        expect(points.getPoint(PointsEnum.RESIST_BOW)).to.equal(RESIST);
+    });
+});


### PR DESCRIPTION
Closes #51.

## What was missing

`BattleTypeEnum.MAGIC` ended in a `//TODO`, so all **50 MAGIC mobs** in `mobs.json` (Vile Demon Shaman, Ghost of Chaos, Mighty Ice Witch, the White Oath line...) chased their victim and then stood there doing nothing. The approach half already worked — `Behavior.ts` keeps MAGIC mobs at ranged follow distance since #111 — the attack itself was the hole.

## The fix, from the original

`char_battle.cpp:236` dispatches magic as **the range attack with a different payload**: the same `FlyTarget` projectile, then `Shoot(1)` instead of `Shoot(0)`. Inside `CFuncShoot`, case 1 computes `CalcMagicDamage`, which for an NPC reduces to `CalcMeleeDamage` plus a party bonus mobs never have (`battle.cpp:197`), applies `POINT_RESIST_MAGIC`, and delivers `DAMAGE_TYPE_MAGIC`.

So `magicAttack` mirrors `rangeAttack` and differs in exactly the two things the original differs in:

```ts
private magicAttack(victim: Player) {
    this.attacker.createFlyTargeting(victim);
    this.resolveAttack(victim, DamageTypeEnum.MAGIC, victim.getPoint(PointsEnum.RESIST_MAGIC));
}
```

In `applyDamage`, MAGIC joins the NORMAL/NORMAL_RANGE group. That is where the original puts it: the skill-type block in `CHARACTER::Damage` (`char_battle.cpp:1714`) applies crit, penetrate and the mana shield to MELEE, RANGE and MAGIC alike. The existing block/dodge gates are keyed on the specific damage types, so a magic bolt is neither blockable nor dodgeable — also matching the original. Reflect stays melee-only.

## The second half: RESIST_MAGIC was a dead point

`PlayerPoints` has a `resistMagic` field, loads it, and never registered it in the points map — so `getPoint(RESIST_MAGIC)` hit the unregistered-point fallback and returned **0** no matter what. Registered now, next to `RESIST_BOW`. (Nothing feeds either field yet — item applies are a separate gap — but the pipeline reads correctly.)

## Verified

- `tsc --noEmit` clean. Unit **724 passing** (716 on master plus 8 new), integration **39 passing** (38 plus 1 new).
- The integration spec mirrors the ranged-mob one: logs in a real client, invokes a **Vile Demon Shaman (1034)** — MAGIC, aggressive — and asserts the `FLY_TARGETING` projectile bytes and the damage on the wire.
- Fail-without-fix: restoring the `//TODO` branch fails 4 of the new unit cases; removing the `RESIST_MAGIC` registration fails its spec.
- Mutation pass, each failing at least one spec and nothing else: no projectile (1), resistance read from `RESIST_BOW` (1), magic delivered as NORMAL — blockable (2), MAGIC dropped from the `applyDamage` group (2 — caught by the NORMAL-flag and mana-shield cases, added after this mutant initially survived).
- Merges clean on master `013d8bd3`, and clean after each of the 2 open PRs that also touch `MonsterBattle.ts` (#169, #134), simulated pairwise.

## Scope

- Mob-side `resist_magic` (the column every mob row carries) is not consulted by player skills yet — that is the skill-damage path, outside this issue.
- The mob skill columns (`skill_vnum0-4`) are a different feature: those are cast skills. This PR is the basic magic bolt, which is what `BATTLE_TYPE_MAGIC` does in the original's normal attack path.
- Pre-existing gap, not a regression.
