### PR TITLE
test: give the dead-state fake victim the attack-cooldown surface (fix #198)

### DIFF
--- a/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerDeadState.test.ts
@@ -95,6 +95,8 @@ const createVictim = (virtualId: number) =>
         getVirtualId: () => virtualId,
         getPositionX: () => 0,
         getPositionY: () => 0,
+        wasAttackedRecentlyBy: () => false,
+        recordAttackedBy: () => {},
     }) as unknown as Monster;
 
 const kill = (player: Player) => {


### PR DESCRIPTION
Fixes the red master unit run (744 passing / 1 failing on `fa7c8a63`) — issue #198.

## What broke

#187 added the victim-side speed-hack log to `Player.attack`: the attacker calls `victim.wasAttackedRecentlyBy(...)` / `victim.recordAttackedBy(...)` before entering battle (`Player.ts:661-665`). The `PlayerDeadState.test.ts` specs merged today (through the stacked #130/#132 branches, both cut before #187 landed) drive `Player.attack` with a minimal victim fake that predates that surface, so the living-attacker spec throws before asserting. Each PR was green in isolation; the composition was first measured on master today.

## The fix

Two stubs on the fake: `wasAttackedRecentlyBy: () => false` (no recent attacker) and `recordAttackedBy: () => {}` (no-op). The attack then proceeds exactly as it did when the spec was written and the spec asserts what it always asserted. The dead-attacker spec is unaffected — it returns at the `isDead()` gate before the cooldown block.

## Verified

- unit: 745 passing / 0 failing (was 744/1)
- integration: 42 passing / 0 failing
- `tsc --noEmit`, eslint and prettier all clean

## Note on scope

Test-only; no `src/` change. Both sides of the composition are ours. The fake could instead be replaced by a real `Monster`, but the minimal-fake idiom matches the rest of the file — happy to switch if you prefer.