### PR TITLE
fix(auth): let the login token be redeemed by both client connections (fix #201)

### DIFF
--- a/src/game/domain/service/AuthenticateService.ts
+++ b/src/game/domain/service/AuthenticateService.ts
@@ -20,7 +20,7 @@ export default class AuthenticateService {
 
     async execute(key: number, username: string): Promise<Result<Token, ErrorTypesEnum>> {
         const cacheKey = CacheKeyGenerator.createTokenKey(String(key));
-        const rawToken = await this.cacheProvider.take<string>(cacheKey);
+        const rawToken = await this.cacheProvider.get<string>(cacheKey);
 
         if (!rawToken) {
             this.logger.info(`[AuthenticateService] Invalid token for username: ${username}`);

--- a/test/integration/game/twoConnectionLogin.test.ts
+++ b/test/integration/game/twoConnectionLogin.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { container } from '@/game/Container';
+import AttackHarness, { AttackSession } from '../../support/AttackSession';
+
+/**
+ * Regression for the stock client's login flow: it authenticates TWICE with the
+ * same login key — once on the connection that lists the characters, and once
+ * on the fresh connection it opens to enter the world with the ip/port from
+ * CharactersInfoPacket. Single-use token redemption (GETDEL) made the second
+ * authentication find nothing, so every stock client reached character
+ * selection and was then disconnected on entering the world.
+ *
+ * The harness logs in over a single connection, which is why the suites never
+ * saw it; this spec closes the first session and walks the whole enter-game
+ * flow a second time on a new socket with the same key, exactly like the real
+ * client does.
+ *
+ * Needs MySQL + Redis up (docker) and the game port free (stop `dev:game`).
+ */
+describe('Auth token across the stock client’s two connections', function () {
+    this.timeout(60000);
+
+    const USERNAME = 'two_conn_login';
+    const HARNESS_KEY = 0x0badf00d;
+
+    let harness: AttackHarness;
+    let selectPhase: AttackSession;
+    let worldPhase: AttackSession;
+
+    before(async () => {
+        harness = await new AttackHarness().start();
+    });
+
+    after(async () => {
+        await selectPhase?.close();
+        await worldPhase?.close();
+        await harness?.stop();
+    });
+
+    it('should let the same key authenticate the select connection and the world connection', async () => {
+        // First connection: seeds the account, injects the key, authenticates
+        // and enters the world — the harness's normal login.
+        selectPhase = await harness.login({ username: USERNAME });
+
+        // The stock client closes the select-phase connection before it dials
+        // the world; without this, #189's single-session rule would refuse the
+        // second connection for a different reason than the one under test.
+        await selectPhase.close();
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        // Second connection, same key: handshake, TOKEN, character list,
+        // select, enter game. With single-use redemption this dies at the
+        // TOKEN step because the key was consumed by the first connection.
+        const config = container.resolve<any>('config');
+        worldPhase = new AttackSession(config.SERVER_ADDRESS, Number(config.SERVER_PORT), harness['db']);
+
+        await worldPhase.enterGame(USERNAME, HARNESS_KEY);
+
+        const player = harness.findPlayer(USERNAME);
+        expect(player, 'the world connection authenticated with the same key').to.not.equal(undefined);
+    });
+});

--- a/test/unit/game/domain/service/AuthenticateService.test.ts
+++ b/test/unit/game/domain/service/AuthenticateService.test.ts
@@ -4,11 +4,13 @@ import AuthenticateService from '@/game/domain/service/AuthenticateService';
 import { ErrorTypesEnum } from '@/core/enum/ErrorTypesEnum';
 
 /**
- * Regression for issue #104: the login token was looked up with exists() then
- * get(), and never removed, so the same key could be redeemed any number of
- * times for the whole of its lifetime.
+ * The token contract after the two-connection regression: the stock client
+ * authenticates once on the connection that lists the characters and again on
+ * the fresh connection it opens to enter the world, so a key must stay
+ * redeemable for its whole (60s) lifetime. Single-use redemption (GETDEL,
+ * issue #104) disconnected every stock client at world entry.
  */
-describe('AuthenticateService token redemption (issue #104)', () => {
+describe('AuthenticateService token redemption', () => {
     const KEY = 0x0badf00d;
     const USERNAME = 'tester';
     const CACHE_KEY = `token:${KEY}`;
@@ -20,9 +22,9 @@ describe('AuthenticateService token redemption (issue #104)', () => {
     /**
      * A working cache, not a stub: take() removes what it returns (Redis
      * GETDEL) while get()/exists() leave the entry alone. Implementing all
-     * three is what makes the fail-without-fix signal behavioural — against
-     * the old exists()+get() code these cases fail because the token survives,
-     * not because a method is missing.
+     * three keeps the assertions behavioural — against GETDEL-based code the
+     * reuse case fails because the token is gone, not because a method is
+     * missing.
      */
     const workingCache = (entries: Record<string, string>) => ({
         take: sinon.stub().callsFake(async (key: string) => {
@@ -42,27 +44,20 @@ describe('AuthenticateService token redemption (issue #104)', () => {
         service = new AuthenticateService({ logger, cacheProvider });
     });
 
-    it('should authenticate the first redemption of a token', async () => {
+    it('should authenticate a valid key', async () => {
         const result = await service.execute(KEY, USERNAME);
 
         expect(result.isOk()).to.equal(true);
         expect(result.getData()).to.deep.equal({ username: USERNAME, accountId: 7 });
     });
 
-    it('should reject the second redemption of the same token', async () => {
+    it('should authenticate the same key again for the world connection', async () => {
         await service.execute(KEY, USERNAME);
 
-        const replay = await service.execute(KEY, USERNAME);
+        const secondConnection = await service.execute(KEY, USERNAME);
 
-        expect(replay.hasError(), 'a captured key must not be reusable').to.equal(true);
-        expect(replay.getError()).to.equal(ErrorTypesEnum.INVALID_TOKEN);
-    });
-
-    it('should let exactly one of two concurrent redemptions win', async () => {
-        const [first, second] = await Promise.all([service.execute(KEY, USERNAME), service.execute(KEY, USERNAME)]);
-
-        const accepted = [first, second].filter((result) => result.isOk());
-        expect(accepted.length, 'the take is atomic, so a race cannot admit both').to.equal(1);
+        expect(secondConnection.isOk(), 'the stock client redeems the key once per connection').to.equal(true);
+        expect(secondConnection.getData()).to.deep.equal({ username: USERNAME, accountId: 7 });
     });
 
     it('should reject an unknown token', async () => {
@@ -72,11 +67,12 @@ describe('AuthenticateService token redemption (issue #104)', () => {
         expect(result.getError()).to.equal(ErrorTypesEnum.INVALID_TOKEN);
     });
 
-    it('should burn the token when the username does not match it', async () => {
+    it('should reject a username that does not match the key without burning it', async () => {
         const mismatch = await service.execute(KEY, 'someone-else');
         expect(mismatch.hasError()).to.equal(true);
+        expect(mismatch.getError()).to.equal(ErrorTypesEnum.INVALID_TOKEN);
 
-        const retry = await service.execute(KEY, USERNAME);
-        expect(retry.hasError(), 'a wrong guess must not leave the key usable').to.equal(true);
+        const rightful = await service.execute(KEY, USERNAME);
+        expect(rightful.isOk(), 'the rightful owner still logs in after a wrong guess').to.equal(true);
     });
 });


### PR DESCRIPTION
Fixes #201: on master, every stock client reaches character selection and is then disconnected on entering the world, because it authenticates once per connection — select phase, then world phase — and #188's `GETDEL` burns the key on the first one. The Redis MONITOR trace and the mechanism are in the issue.

## The fix

`AuthenticateService` reads the token with `get` instead of `take`. The original behaves the same way: `DESC_MANAGER::FindByLoginKey` (desc_manager.cpp:461) never erases, and a key only dies through `ProcessExpiredLoginKey` after 60s. #188's 60-second TTL stays, and it is what still carries #104: a captured key is replayable for at most 60 seconds instead of 24 hours, and #189 already prevents a replay from coexisting with the real session. One behaviour is deliberately lost with the revert: a wrong-username guess no longer burns the key — the rightful redemption still works afterwards, which the new unit case pins.

## Tests

- `twoConnectionLogin.test.ts` (new, integration): walks the whole enter-game flow twice on two sockets with the same key, closing the first — exactly the stock client's shape. Against `take` it fails with the world connection timing out on the empire packet, which is the real client's symptom.
- `AuthenticateService.test.ts` rewritten for the new contract: reuse allowed, unknown key refused, mismatch refused without burning.
- Fail-without-fix measured by reverting `get` → `take`: unit 2 failing, integration 1 failing, each for the stated reason.

## Verified

- unit: 743/1 — the one failure is #198's known composition break, fixed in #199, unrelated to this branch
- integration: 43 passing / 0 failing
- `tsc --noEmit`, eslint, prettier clean
- End-to-end with the stock client: before the fix, character select then disconnect (two `GETDEL`, second nil); after the fix, both `GET`s hit and the world loads. Played on the live server afterwards.

## Note on scope

The regression is ours (#188). CI on this PR will show the known #198 unit failure until #199 merges.