### PR TITLE
fix(skill): refund skill points into the pool instead of overwriting it (fix #203)

### DIFF
--- a/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
@@ -408,7 +408,7 @@ export class PlayerSkill {
     }
 
     clearSkill() {
-        this.player.setPoint(
+        this.player.addPoint(
             PointsEnum.SKILL,
             4 + (this.player.getPoint(PointsEnum.LEVEL) - 5) - this.player.getPoint(PointsEnum.SKILL),
         );

--- a/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
+++ b/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
@@ -756,21 +756,57 @@ describe('PlayerSkill', () => {
     });
 
     describe('clearSkill', () => {
+        function createPlayerWithSkillPool(level: number, initialPool: number) {
+            const pool = { value: initialPool };
+            const player = createPlayer({
+                getPoint: sinon.stub().callsFake((point: PointsEnum) => {
+                    if (point === PointsEnum.LEVEL) return level;
+                    if (point === PointsEnum.SKILL) return pool.value;
+                    return 0;
+                }),
+                addPoint: sinon.stub().callsFake((point: PointsEnum, value: number) => {
+                    if (point === PointsEnum.SKILL) pool.value = Math.max(0, pool.value + value);
+                }),
+                setPoint: sinon.stub().callsFake((point: PointsEnum, value: number) => {
+                    if (point === PointsEnum.SKILL) pool.value = value;
+                }),
+            });
+            return { player, pool };
+        }
+
+        it('leaves the player with level - 1 points, keeping the ones already unspent', () => {
+            const { player, pool } = createPlayerWithSkillPool(30, 12);
+            const playerSkill = new PlayerSkill({ player, skillManager: createSkillManager(undefined), skills: [] });
+
+            playerSkill.clearSkill();
+
+            expect(pool.value).to.equal(29);
+        });
+
+        it('does not consume the pool of a player who never spent a point', () => {
+            const { player, pool } = createPlayerWithSkillPool(30, 29);
+            const playerSkill = new PlayerSkill({ player, skillManager: createSkillManager(undefined), skills: [] });
+
+            playerSkill.clearSkill();
+
+            expect(pool.value).to.equal(29);
+        });
+
         it('recalculates the SKILL point pool and resets every skill slot', () => {
             const getPoint = sinon.stub().callsFake((point: PointsEnum) => {
                 if (point === PointsEnum.LEVEL) return 30;
                 if (point === PointsEnum.SKILL) return 3;
                 return 0;
             });
-            const setPoint = sinon.stub();
-            const player = createPlayer({ getPoint, setPoint });
+            const addPoint = sinon.stub();
+            const player = createPlayer({ getPoint, addPoint });
             const playerSkill = new PlayerSkill({ player, skillManager: createSkillManager(undefined), skills: [] });
 
             setSkillState(playerSkill, TEST_SKILL, { rank: RANK.MASTER, level: 25, readCount: 4, timeToNextRead: 555 });
 
             playerSkill.clearSkill();
 
-            expect(setPoint.calledOnceWith(PointsEnum.SKILL, 26)).to.be.true;
+            expect(addPoint.calledOnceWith(PointsEnum.SKILL, 26)).to.be.true;
             expect(playerSkill.getSkills()[TEST_SKILL]).to.deep.equal({
                 rank: RANK.NORMAL,
                 level: 0,


### PR DESCRIPTION
Fixes #203.

## The bug

`clearSkill()` carried over the original's refund expression verbatim:

```
4 + (GetLevel() - 5) - GetPoint(POINT_SKILL)
```

In the original that is a **delta** handed to `PointChange`, which adds it to the current pool — `char.cpp` puts `POINT_SKILL` in the `SetPoint(type, GetPoint(type) + amount)` group — so a reset leaves the player with `level - 1` points.

Here it went to `setPoint`, whose `SKILL` handler assigns the raw value (`PlayerPoints.ts:855-859`). The player's unspent points were therefore subtracted from their own refund: with `s` points spent and `u` unspent, the pool ended at `s` instead of `level - 1`, and the `u` unspent points were destroyed — then persisted to `availableSkillPoints` on the next save.

## The fix

```diff
-        this.player.setPoint(
+        this.player.addPoint(
             PointsEnum.SKILL,
             4 + (this.player.getPoint(PointsEnum.LEVEL) - 5) - this.player.getPoint(PointsEnum.SKILL),
         );
```

One word, and it restores the original's arithmetic.

It also removes the negative-pool hazard for free: `addCommonPoint` clamps with `Math.max(0, ...)`, whereas the `setPoint` handler had no lower bound while `script.sql` declares the column `INT UNSIGNED NOT NULL`. `clearSkill` was the only `setPoint(PointsEnum.SKILL, ...)` caller in `src/`, so nothing else relied on the assigning semantics.

The correct translation already existed a few lines away: `PlayerPoints.setLevel` (`PlayerPoints.ts:1027-1032`) uses `addPoint` with the identical formula.

## On the spec

The existing spec asserted only `setPoint.calledOnceWith(PointsEnum.SKILL, 26)`. The delta is 26 either way, so that assertion could not tell the two semantics apart — it pinned the call, not the outcome, which is why the bug survived it. I retargeted it to `addPoint` and added two specs that pin the **outcome**, backed by a small pool that mirrors the real `Points` behaviour (`add` = `max(0, current + value)`, `set` = assign):

- level 30 with 12 unspent → pool must end at 29
- level 30 with nothing spent → pool must stay 29 (the issue's reproduction)

## Verified

- `npm run test:unit`: **747 passing, 0 failing** (745 on master + the 2 new specs).
- Fail-without-fix: reverting the one word gives **exactly 3 failures**, all in `clearSkill` — `expected 17 to equal 29`, `expected +0 to equal 29`, and the retargeted call assertion. The second one is the issue's repro: all 29 points destroyed.
- `npx tsc -p tsconfig.build.json --noEmit` clean, `eslint` and `prettier --check` clean on both files.

## Note on scope

One-word behaviour change plus specs; no schema change, no packet change. Found while auditing the skill system — the rest of that sweep is filed as #204-#210, and the sibling defect in the `resetSkill` this function calls (the original's sub-skill preserve list) is #210, deliberately kept out of this PR so the two can be reviewed apart.