### PR TITLE
fix(skill): put the skill book read delay back on the wall clock (fix #204)

### DIFF
--- a/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
@@ -296,7 +296,7 @@ export class PlayerSkill {
             return false;
         }
 
-        const time = performance.now();
+        const time = Math.floor(Date.now() / 1000);
 
         if (time < this.skills[skillNum].timeToNextRead) {
             //TODO: verify AFFECT_SKILL_NO_BOOK_DELAY caused by Exorcism Scroll (we need to impl PlayerAffect class)

--- a/src/game/app/service/UseItemService.ts
+++ b/src/game/app/service/UseItemService.ts
@@ -448,7 +448,7 @@ export default class UseItemService {
         if (player.learnSkillByBook(skillNum)) {
             await this.removeItemByQuantity(player, item, 1);
             const delay = MathUtil.getRandomInt(SKILLBOOK_DELAY_MIN, SKILLBOOK_DELAY_MAX);
-            player.setSkillNextReadTime(skillNum, performance.now() + delay);
+            player.setSkillNextReadTime(skillNum, Math.floor(Date.now() / 1000) + delay);
         }
     }
 }

--- a/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
+++ b/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
@@ -21,6 +21,7 @@ const RANK = {
 
 const SKILL_MAX_LEVEL = 40;
 const TEST_SKILL = SkillEnum.THREE_WAY_CUT;
+const NOW_SECONDS = 1_750_000_000;
 
 function createSkillProto(overrides: Record<string, unknown> = {}): Skill {
     return {
@@ -528,7 +529,7 @@ describe('PlayerSkill', () => {
                 readCount: 0,
                 ...overrides.skillState,
             });
-            sandbox.stub(performance, 'now').returns(1000);
+            sandbox.stub(Date, 'now').returns(NOW_SECONDS * 1000);
 
             return { player, skillProto, skillManager, playerSkill };
         }
@@ -605,8 +606,9 @@ describe('PlayerSkill', () => {
         });
 
         it('returns false and chats a wait message when timeToNextRead has not elapsed', () => {
-            const { player, playerSkill } = createHappyPathContext({ skillState: { timeToNextRead: 1100 } });
-            (performance.now as SinonStub).returns(1000);
+            const { player, playerSkill } = createHappyPathContext({
+                skillState: { timeToNextRead: NOW_SECONDS + 100 },
+            });
 
             const result = playerSkill.learnSkillByBook(TEST_SKILL, 50);
 
@@ -618,6 +620,36 @@ describe('PlayerSkill', () => {
                     message: 'I am burning inside, but it is calming down my body. My Chi has to stabilise.',
                 }),
             ).to.be.true;
+        });
+
+        it('allows the read once the stored deadline has passed in wall-clock time', () => {
+            const { player, playerSkill } = createHappyPathContext({
+                skillState: { timeToNextRead: NOW_SECONDS - 1 },
+            });
+            sandbox.stub(MathUtil, 'getRandomInt').returns(10);
+
+            const result = playerSkill.learnSkillByBook(TEST_SKILL, 50);
+
+            expect(result).to.be.true;
+            expect(
+                (player.chat as SinonStub)
+                    .getCalls()
+                    .some((call) => String(call.args[0].message).includes('My Chi has to stabilise')),
+            ).to.be.false;
+        });
+
+        it('picks the wait message from the remaining seconds, not milliseconds', () => {
+            const { player, playerSkill } = createHappyPathContext({
+                skillState: { timeToNextRead: NOW_SECONDS + 4 * 3600 },
+            });
+
+            playerSkill.learnSkillByBook(TEST_SKILL, 50);
+
+            const messages = (player.chat as SinonStub).getCalls().map((call) => call.args[0].message);
+            expect(messages).to.deep.equal([
+                `Only a few more pages and then I'll have read everything.`,
+                'I feel refreshed.',
+            ]);
         });
 
         describe('probability !== 0 path', () => {

--- a/test/unit/game/app/service/UseItemService.test.ts
+++ b/test/unit/game/app/service/UseItemService.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
+import { SkillEnum } from '@/core/enum/SkillEnum';
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 import WinstonLoggerAdapter from '@/core/infra/logger/WinstonLoggerAdapter';
 import UseItemService from '@/game/app/service/UseItemService';
@@ -246,5 +248,37 @@ describe('UseItemService', () => {
                 expect(playerStub.getItem.calledOnceWith(2)).to.be.true;
             });
         }
+    });
+
+    describe('skill book read delay (issue #204)', () => {
+        const NOW_SECONDS = 1_750_000_000;
+        const EIGHTEEN_HOURS = 18 * 3600;
+        const THIRTY_HOURS = 30 * 3600;
+
+        it('should schedule the next read 18 to 30 hours ahead on the wall clock', async () => {
+            sinon.stub(Date, 'now').returns(NOW_SECONDS * 1000);
+            const mockItem = {
+                getType: sinon.stub().returns(ItemTypeEnum.ITEM_SKILLBOOK),
+                getValues: sinon.stub().returns([SkillEnum.THREE_WAY_CUT]),
+                getCount: sinon.stub().returns(1),
+                getPosition: sinon.stub().returns(2),
+                getSize: sinon.stub().returns(1),
+            };
+            playerStub.getItem.returns(mockItem);
+            playerStub.isWearable.returns(false);
+            playerStub.isPolymorphed = sinon.stub().returns(false);
+            playerStub.learnSkillByBook = sinon.stub().returns(true);
+            playerStub.setSkillNextReadTime = sinon.stub();
+            playerStub.getInventory.returns({ removeItem: sinon.stub() });
+            itemManagerStub.delete = sinon.stub().resolves();
+
+            await service.execute(playerStub, WindowTypeEnum.INVENTORY, 2);
+
+            expect(playerStub.setSkillNextReadTime.calledOnce).to.be.true;
+            const [skillNum, deadline] = playerStub.setSkillNextReadTime.firstCall.args;
+            expect(skillNum).to.equal(SkillEnum.THREE_WAY_CUT);
+            expect(deadline).to.be.at.least(NOW_SECONDS + EIGHTEEN_HOURS);
+            expect(deadline).to.be.at.most(NOW_SECONDS + THIRTY_HOURS);
+        });
     });
 });


### PR DESCRIPTION
Fixes #204.

## The bug

`SKILLBOOK_DELAY_MIN`/`MAX` are the original's values in **seconds** (`common/length.h`: 64800 = 18 h, 108000 = 30 h), and the original adds them to `get_global_time()`, an epoch clock in seconds:

```cpp
SetSkillNextReadTime(dwVnum, get_global_time() + iReadDelay);   // char_item.cpp
```

Here they were added to `performance.now()`, which is **milliseconds**, so the anti-farm delay between skill book reads was **64.8 to 108 seconds instead of 18 to 30 hours**.

`performance.now()` is also milliseconds *since process start*, and `timeToNextRead` is persisted in the `skills` JSON column and read back verbatim, then compared against the **new** process's `performance.now()`. A deadline written after ten days of uptime locked that skill until the new process itself reached ten days of uptime, however much real time had passed.

## The fix

Both sites now use epoch seconds:

```diff
-        const time = performance.now();
+        const time = Math.floor(Date.now() / 1000);
```
```diff
-            player.setSkillNextReadTime(skillNum, performance.now() + delay);
+            player.setSkillNextReadTime(skillNum, Math.floor(Date.now() / 1000) + delay);
```

That fixes the wait-message tiers for free. `getNeedToWaitMoreTimeMessages` compares its argument against `3 * 60` up to `18 * 3600` — which is exactly what the original's `SkillLearnWaitMoreTimeMessage` does with a seconds delta (`char_skill.cpp` feeds it `GetSkillNextReadTime - get_global_time()`). It had been receiving milliseconds, so it always landed in the last tier.

**Seconds rather than milliseconds is deliberate**, and worth flagging since `Date.now()` is the obvious reflex: `SkillLevelPacket` writes this field with `writeInt32LE`, and epoch milliseconds (~1.75e12) exceed int32, so `Date.now()` alone would throw for **every** player on **every** skill packet. Epoch seconds are ~1.75e9, fit until 2038, and match the client, whose `tNextRead` is a `time_t` in seconds. As a side effect the ~24.9-day uptime overflow of the old monotonic value disappears too.

## Verified

- `npm run test:unit`: **748 passing, 0 failing** (745 on master + 3 new specs).
- Fail-without-fix: reverting both lines gives **exactly 4 failures** — the retargeted wait-message spec, plus the three new ones. The clearest is the write side: `expected 107105.7926 to be at least 1750064800`, which is the bug in one line.
- `npx tsc -p tsconfig.build.json --noEmit` clean; `eslint` and `prettier --check` clean on all four files.
- Merge-simulated against #211 in both orders — clean, even though both touch `PlayerSkill.ts` and its spec.

## On the specs

The write side had no coverage at all, so `UseItemService.test.ts` gets one: after a successful read the stored deadline must be between 18 and 30 hours ahead **on the wall clock**. On the read side, one existing spec pinned the old clock (`performance.now()` stubbed to 1000, deadline 1100) and is retargeted; two new ones cover what actually broke — a deadline that has passed in real time lets the read through, and the wait message is chosen from a seconds delta.

## Note on scope

No migration: the values already stored are offsets into a dead process's uptime and mean nothing, and there are no production databases here.

Left alone deliberately: the commented-out `learnHorseSkillByBook` block (`PlayerSkill.ts:208-246`) carries the same `performance.now()` pattern. It is dead code behind a `//TODO verify if this is used`, so I did not touch it — say the word if you would rather it were fixed or removed in this PR.

Found while auditing the skill system; the rest of that sweep is #203, #205-#210, and #203 is already up as #211.