### PR TITLE
fix(horse): store the clamped horse level in the riding skill slot and resend it (fix #205)

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -2188,7 +2188,8 @@ export default class Player extends Character {
 
     setHorseLevel(level: number): void {
         this.horse.setLevel(level);
-        this.skills.setSkillLevel(SkillEnum.HORSE, level);
+        this.skills.setSkillLevel(SkillEnum.HORSE, this.horse.getLevel());
+        this.sendSkillLevel();
     }
 
     getHorseHealth(): number {

--- a/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerSkill.ts
@@ -58,7 +58,7 @@ export class PlayerSkill {
             };
         }
 
-        this.skills[skillNum].level = Math.min(level, SKILL_MAX_LEVEL);
+        this.skills[skillNum].level = Math.max(0, Math.min(level, SKILL_MAX_LEVEL));
 
         switch (true) {
             case level >= 40:

--- a/src/game/domain/command/command/horseLevel/HorseLevelCommandValidator.ts
+++ b/src/game/domain/command/command/horseLevel/HorseLevelCommandValidator.ts
@@ -1,8 +1,9 @@
+import { HORSE_MAX_LEVEL } from '@/core/domain/entities/game/horse/HorseStats';
 import CommandValidator from '../../CommandValidator';
 
 export default class HorseLevelCommandValidator extends CommandValidator {
     build() {
         this.createRule(this.command.getArgs()[0], 'name').isString().build();
-        this.createRule(this.command.getArgs()[1], 'level').isNumber().build();
+        this.createRule(this.command.getArgs()[1], 'level').isNumber().isBetween(0, HORSE_MAX_LEVEL).build();
     }
 }

--- a/test/unit/core/domain/entities/game/player/PlayerHorseSkillSlot.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerHorseSkillSlot.test.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+import { PlayerFactory } from '@/core/domain/factories/PlayerFactory';
+import Player from '@/core/domain/entities/game/player/Player';
+import { SkillEnum } from '@/core/enum/SkillEnum';
+import { HORSE_MAX_LEVEL } from '@/core/domain/entities/game/horse/HorseStats';
+
+const logger: any = { info: () => {}, error: () => {}, debug: () => {} };
+
+const config: any = {
+    empire: { red: { startPosX: 100, startPosY: 200 } },
+    jobs: {
+        warrior: {
+            common: {
+                st: 10,
+                ht: 10,
+                dx: 10,
+                iq: 10,
+                initialHp: 100,
+                initialMp: 50,
+                initialStamina: 30,
+                hpPerLvl: 10,
+                hpPerHtPoint: 2,
+                mpPerLvl: 5,
+                mpPerIqPoint: 1,
+                initialAttackSpeed: 100,
+                initialMovementSpeed: 100,
+                defensePerHtPoint: 1,
+                attackPerDXPoint: 1,
+                attackPerIQPoint: 1,
+                attackPerStPoint: 1,
+            },
+        },
+    },
+};
+
+const createFactoryDeps = () => ({
+    config,
+    animationManager: { getAnimation: () => undefined } as any,
+    experienceManager: { getNeededExperience: () => 1000 } as any,
+    logger,
+    saveCharacterService: { execute: async () => {} } as any,
+    questManager: { getQuestsByEvent: () => [], onKill: () => {} } as any,
+    eventTimerManager: {
+        addTimer: () => {},
+        removeTimer: () => {},
+        isTimerActive: () => false,
+        clearTimersByOwner: () => {},
+    } as any,
+    mobManager: { getMobProto: () => undefined } as any,
+});
+
+const SKILL_ENTRY_SIZE = 6;
+const HEADER_SIZE = 1;
+
+const createConnection = () => {
+    const sentPackets: Array<{ name: string; buffer: Buffer }> = [];
+    return {
+        sentPackets,
+        connection: {
+            send: (packet: any) => {
+                sentPackets.push({ name: packet.constructor.name, buffer: packet.pack() });
+            },
+            setState: () => {},
+        } as any,
+    };
+};
+
+const createPlayer = (connection: any): Player => {
+    const player = PlayerFactory.create(
+        {
+            playerClass: 0,
+            accountId: 1,
+            appearance: 0,
+            slot: 0,
+            virtualId: 1,
+            id: 1,
+            empire: 1,
+            skillGroup: 0,
+            playTime: 0,
+            level: 60,
+            experience: 0,
+            gold: 0,
+            name: 'Rider',
+            givenStatusPoints: 0,
+            availableStatusPoints: 0,
+            horseLevel: 11,
+            horseHealth: 100,
+            horseStamina: 100,
+            horseName: 'Pony',
+        } as any,
+        createFactoryDeps(),
+    );
+    player.setConnection(connection);
+    return player;
+};
+
+const readSkillLevelFromPacket = (buffer: Buffer, skillNum: number) =>
+    buffer.readUInt8(HEADER_SIZE + skillNum * SKILL_ENTRY_SIZE + 1);
+
+const storedRidingLevel = (player: Player) => (player.toDatabase() as any).skills[SkillEnum.HORSE].level;
+
+describe('Player.setHorseLevel skill slot (issue #205)', () => {
+    it('stores the clamped horse level in the riding skill slot', () => {
+        const { connection } = createConnection();
+        const player = createPlayer(connection);
+
+        player.setHorseLevel(-1);
+
+        expect(storedRidingLevel(player)).to.equal(0);
+        expect(player.getHorseLevel()).to.equal(0);
+    });
+
+    it('keeps the riding slot and the horse level in agreement above the cap', () => {
+        const { connection } = createConnection();
+        const player = createPlayer(connection);
+
+        player.setHorseLevel(99);
+
+        expect(storedRidingLevel(player)).to.equal(HORSE_MAX_LEVEL);
+        expect(player.getHorseLevel()).to.equal(HORSE_MAX_LEVEL);
+    });
+
+    it('sends the skill levels so the client does not keep the old riding level', () => {
+        const { sentPackets, connection } = createConnection();
+        const player = createPlayer(connection);
+        sentPackets.length = 0;
+
+        player.setHorseLevel(12);
+
+        const skillPacket = sentPackets.find((packet) => packet.name === 'SkillLevelPacket');
+        expect(skillPacket, 'setHorseLevel must resend the skill levels').to.not.be.undefined;
+        expect(readSkillLevelFromPacket(skillPacket.buffer, SkillEnum.HORSE)).to.equal(12);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
+++ b/test/unit/core/domain/entities/game/player/delegate/PlayerSkills.test.ts
@@ -128,6 +128,11 @@ describe('PlayerSkill', () => {
             expect(playerSkill.getSkills()[TEST_SKILL].level).to.equal(SKILL_MAX_LEVEL);
         });
 
+        it('clamps a negative level to zero, which the skill packet cannot encode', () => {
+            playerSkill.setSkillLevel(TEST_SKILL, -1);
+            expect(playerSkill.getSkills()[TEST_SKILL].level).to.equal(0);
+        });
+
         it('sets rank to NORMAL when level < 20', () => {
             playerSkill.setSkillLevel(TEST_SKILL, 10);
             expect(playerSkill.getSkills()[TEST_SKILL].rank).to.equal(RANK.NORMAL);

--- a/test/unit/game/domain/command/horseLevel/HorseLevelCommandValidator.test.ts
+++ b/test/unit/game/domain/command/horseLevel/HorseLevelCommandValidator.test.ts
@@ -1,0 +1,37 @@
+import HorseLevelCommandValidator from '@/game/domain/command/command/horseLevel/HorseLevelCommandValidator';
+import { HORSE_MAX_LEVEL } from '@/core/domain/entities/game/horse/HorseStats';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('HorseLevelCommandValidator (issue #205)', () => {
+    let commandValidator: HorseLevelCommandValidator;
+    let commandMock: any;
+
+    beforeEach(() => {
+        commandMock = { getArgs: sinon.stub() };
+        commandValidator = new HorseLevelCommandValidator(commandMock);
+    });
+
+    it('accepts a level inside the horse range', () => {
+        commandMock.getArgs.returns(['playerName', 10]);
+
+        commandValidator.build();
+
+        expect(commandValidator.getErrors()).to.have.lengthOf(0);
+    });
+
+    for (const [name, level] of [
+        ['negative', -1],
+        ['above the horse cap', HORSE_MAX_LEVEL + 1],
+    ] as const) {
+        it(`refuses a ${name} level instead of silently clamping it`, () => {
+            commandMock.getArgs.returns(['playerName', level]);
+
+            commandValidator.build();
+            const errors = commandValidator.getErrors();
+
+            expect(errors).to.have.lengthOf(1);
+            expect(errors[0].errors).to.deep.equal([{ error: `level value must be between 0 and ${HORSE_MAX_LEVEL}` }]);
+        });
+    }
+});


### PR DESCRIPTION
Fixes #205.

## The bug

`setHorseLevel` clamped the horse itself but handed the **raw** argument to the skill slot:

```ts
this.horse.setLevel(level);                          // clamps to [0, 30]
this.skills.setSkillLevel(SkillEnum.HORSE, level);   // raw
```

`setSkillLevel` clamped only the upper bound, so a negative level was stored verbatim. `SkillLevelPacket` writes that field with `writeUint8`, and `Buffer.writeUInt8(-1)` throws `ERR_OUT_OF_RANGE`, so every later skill packet for that player failed to pack. `skillLevelUp` saves *before* it sends, so the negative value reached the database, and `SelectCharacterService` then threw while sending skill levels at every login — the character never finished entering the world. `GameServer`'s dispatch handler catches it, so there is no process crash; the damage is the lost packet plus the persisted value.

The original reads the already-clamped value (`char_horse.cpp`: `SetSkillLevel(SKILL_HORSE, GetHorseLevel())`), so level and slot can never diverge there. That also fixes the milder form: the horse caps at 30 while the slot accepted up to 40, so `/horse_level x 99` left the two disagreeing at 30 and 40.

## The missing resend

The same function never resent the skill levels. `PlayerHorse.setLevel` sends only the points packet and `setSkillLevel` sends nothing, so none of the four callers — the training and upgrade quests, the horse level command, and `giveHorse` — updated the client. The client keeps skill levels in an array written **only** by the skill-level packet (`CPythonPlayer::SetSkillLevel_`, fed by `RecvSkillLevelNew`), so its skill window and riding gates kept the old level until relog. The original resends at exactly this point (`questlua_horse.cpp` calls `SkillLevelPacket()` right after `SetHorseLevel`).

Worth flagging: the comment on `PlayerHorse.setLevel` and the interface doc above it both claim the points packet covers this. It does not — `Player.sendPoints` only builds `CharacterPointsPacket`. I left the comments alone; happy to correct them here if you prefer.

## The fix

```diff
     setHorseLevel(level: number): void {
         this.horse.setLevel(level);
-        this.skills.setSkillLevel(SkillEnum.HORSE, level);
+        this.skills.setSkillLevel(SkillEnum.HORSE, this.horse.getLevel());
+        this.sendSkillLevel();
     }
```

`setSkillLevel` now clamps below as well (`Math.max(0, Math.min(level, SKILL_MAX_LEVEL))`) so no caller can poison a slot.

And `HorseLevelCommandValidator` only checked `isNumber`, which is how an arbitrary value reached `setHorseLevel` in the first place. It now takes a level between 0 and `HORSE_MAX_LEVEL`, refusing the input with a clear error rather than silently clamping it. Per #64 that command is available to every player, so this is the gate that matters most in practice.

## Verified

- `npm run test:unit`: **752 passing, 0 failing** (745 on master + 7 new specs).
- Fail-without-fix: reverting the three source changes gives **exactly 6 failures**, one per defect — `expected -1 to equal +0` twice (the slot, and the same through `setHorseLevel`), `expected 40 to equal 30` (the above-cap divergence), `setHorseLevel must resend the skill levels`, and the two validator cases.
- `npx tsc -p tsconfig.build.json --noEmit` clean; `prettier --check` clean. `eslint` reports only the three pre-existing `no-floating-promises` warnings in `Player.ts`, none of them near this change.
- Merge-simulated against #211 and #212 across **all six orderings — clean**, and the three composed together give **757 passing with `tsc` clean**, so they do not break each other.

## On the specs

New `PlayerHorseSkillSlot.test.ts` drives a real `Player` from `PlayerFactory` and asserts on the bytes: the riding entry decoded out of the sent `SkillLevelPacket`. The validator gets its own spec. `setSkillLevel`'s lower clamp is pinned next to the existing upper-clamp spec.

## Note on scope

From `f6b08888`. Both halves live in the same three lines, so one PR covers them. Found while auditing the skill system — #203 and #204 are up as #211 and #212, and #206-#210 are still open.