### PR TITLE
fix(networking): step over the unimplemented skill and bow packets instead of discarding the buffer (fix #207)

### DIFF
--- a/src/core/interface/networking/packets/UnimplementedPackets.ts
+++ b/src/core/interface/networking/packets/UnimplementedPackets.ts
@@ -2,6 +2,17 @@ const SEQUENCE_BYTE_LENGTH = 1;
 const SYNC_POSITION_HEADER = 0x08;
 const SYNC_POSITION_FIXED_SIZE = 3;
 
+const FLY_TARGETING_HEADER = 51;
+const USE_SKILL_HEADER = 52;
+const ADD_FLY_TARGETING_HEADER = 53;
+const SHOOT_HEADER = 54;
+const PARTY_USE_SKILL_HEADER = 76;
+
+const FLY_TARGETING_STRUCT_SIZE = 13;
+const USE_SKILL_STRUCT_SIZE = 9;
+const SHOOT_STRUCT_SIZE = 2;
+const PARTY_USE_SKILL_STRUCT_SIZE = 6;
+
 /** On-wire length, or null while the buffer is too short to tell. */
 type FrameLengthResolver = (buffer: Buffer) => number | null;
 
@@ -11,7 +22,19 @@ const syncPositionFrameLength: FrameLengthResolver = (buffer) => {
     return buffer.readUInt16LE(1) + SEQUENCE_BYTE_LENGTH;
 };
 
-const unimplementedPackets = new Map<number, FrameLengthResolver>([[SYNC_POSITION_HEADER, syncPositionFrameLength]]);
+const fixedFrameLength =
+    (structSize: number): FrameLengthResolver =>
+    () =>
+        structSize + SEQUENCE_BYTE_LENGTH;
+
+const unimplementedPackets = new Map<number, FrameLengthResolver>([
+    [SYNC_POSITION_HEADER, syncPositionFrameLength],
+    [FLY_TARGETING_HEADER, fixedFrameLength(FLY_TARGETING_STRUCT_SIZE)],
+    [USE_SKILL_HEADER, fixedFrameLength(USE_SKILL_STRUCT_SIZE)],
+    [ADD_FLY_TARGETING_HEADER, fixedFrameLength(FLY_TARGETING_STRUCT_SIZE)],
+    [SHOOT_HEADER, fixedFrameLength(SHOOT_STRUCT_SIZE)],
+    [PARTY_USE_SKILL_HEADER, fixedFrameLength(PARTY_USE_SKILL_STRUCT_SIZE)],
+]);
 
 export const isUnimplementedHeader = (header: number) => unimplementedPackets.has(header);
 

--- a/test/unit/core/interface/server/Server.test.ts
+++ b/test/unit/core/interface/server/Server.test.ts
@@ -240,6 +240,78 @@ describe('Sequence byte exemptions', () => {
     });
 });
 
+describe('Unimplemented skill and bow headers (issue #207)', () => {
+    let server: FrameRecorder;
+    let socket: any;
+
+    beforeEach(() => {
+        logged.length = 0;
+        server = new FrameRecorder({ logger, config: {} as any, packets: makePackets() });
+        socket = createFakeSocket();
+        server.onListener(socket);
+    });
+
+    afterEach(() => {
+        server.lastConnection?.stopKeepalive();
+    });
+
+    /** header, client struct size; the wire also carries the trailing sequence byte. */
+    const skipped = [
+        ['CG_FLY_TARGETING', 51, 13],
+        ['CG_USE_SKILL', 52, 9],
+        ['CG_ADD_FLY_TARGETING', 53, 13],
+        ['CG_SHOOT', 54, 2],
+        ['CG_PARTY_USE_SKILL', 76, 6],
+    ] as const;
+
+    const unimplementedPacket = (header: number, structSize: number) => {
+        const buffer = Buffer.alloc(structSize + 1);
+        buffer[0] = header;
+        return buffer;
+    };
+
+    for (const [name, header, structSize] of skipped) {
+        it(`should step over ${name} instead of discarding the packets behind it`, async () => {
+            socket.emit(
+                'data',
+                Buffer.concat([attackPacket(), unimplementedPacket(header, structSize), chatPacket('kept')]),
+            );
+            await settle();
+
+            expect(server.frames, 'the packets around it must survive').to.have.lengthOf(2);
+            expect(server.frames[0]).to.have.lengthOf(9);
+            expect(server.frames[1]).to.deep.equal(chatPacket('kept'));
+            expect(logged.filter((line) => line.message.includes('Unknown header'))).to.have.lengthOf(0);
+            expect(socket.destroy.called).to.be.equal(false);
+        });
+
+        it(`should hold a ${name} split across reads until it is complete`, async () => {
+            const packet = unimplementedPacket(header, structSize);
+            socket.emit('data', Buffer.concat([packet.subarray(0, 1), chatPacket('not yet').subarray(0, 0)]));
+            await settle();
+            expect(server.frames).to.have.lengthOf(0);
+
+            socket.emit('data', Buffer.concat([packet.subarray(1), chatPacket('arrived')]));
+            await settle();
+
+            expect(server.frames).to.have.lengthOf(1);
+            expect(server.frames[0]).to.deep.equal(chatPacket('arrived'));
+        });
+    }
+
+    it('should step over several of them queued back to back', async () => {
+        const stream = Buffer.concat([
+            ...skipped.map(([, header, structSize]) => unimplementedPacket(header, structSize)),
+            chatPacket('survivor'),
+        ]);
+        socket.emit('data', stream);
+        await settle();
+
+        expect(server.frames).to.have.lengthOf(1);
+        expect(server.frames[0]).to.deep.equal(chatPacket('survivor'));
+    });
+});
+
 describe('Variable-length frame sizes', () => {
     it('should size a shop packet by its subheader', () => {
         const frameFor = (subHeader: number) => new ShopPacket().getFrameLength(Buffer.from([0x32, subHeader]));


### PR DESCRIPTION
Fixes #207.

## The bug

Five headers the stock client sends during ordinary play are registered nowhere, and `extractFrame`'s unknown-header path does `state.buffer = Buffer.alloc(0)` — so every valid packet already queued behind one of them goes with it. The repo's own spec names the behaviour: *"should discard the buffer on an unknown header without closing the connection"*.

This is not gated on the skill system being finished. The client emits the bytes either way, and two of the five come from a plain **bow auto-attack** (`CNormalBowAttack_FlyEventHandler` sends 51 on target, 54 on shoot) with no skill involved. The loss is deterministic for area and fly skills, where `SendAddFlyTargetingPacket` (53) is written *before* the movement and use-skill packets of the same client frame, so the server discards both. It compounds with `handleData`, which concatenates chunks arriving while a handler is still awaiting.

## The fix

Data only, in the file you created for exactly this in #92 / PR #95 — these five were simply never added:

| header | packet | struct | on the wire |
|---|---|---|---|
| 51 | `CG_FLY_TARGETING` | 13 | 14 |
| 52 | `CG_USE_SKILL` | 9 | 10 |
| 53 | `CG_ADD_FLY_TARGETING` | 13 | 14 |
| 54 | `CG_SHOOT` | 2 | 3 |
| 76 | `CG_PARTY_USE_SKILL` | 6 | 7 |

Sizes are the packed client structs (`Packet.h`, inside the `#pragma pack(1)` region) plus the sequence byte each sender appends via `SendSequence()`. They agree with the original server, which registers all five at `sizeof(...)` with the sequence flag set (`packet_info.cpp`), and 53 deliberately reuses `TPacketCGFlyTargeting` — the client fills the same struct for both.

Worth flagging since it looks alarming: **76 is `0x4c`, which our `PacketHeaderEnum` also defines as `SKILL_LEVEL`**. No conflict — that one is outbound only, and I confirmed none of the five is registered as an inbound packet (the inbound map holds 29 headers; 50 and 55 are taken, 51-54 are the gap between them).

## Verified

- `npm run test:unit`: **756 passing, 0 failing** (745 on master + 11 new specs).
- Fail-without-fix: reverting the registration gives **exactly 11 failures**, the whole new block.
- **Mutation-checked**, because a wrong size is worse than the bug — it desynchronises the stream permanently. Changing one constant by a single byte (`CG_USE_SKILL` 9 → 8) kills **3** specs, including the back-to-back one.
- `npx tsc -p tsconfig.build.json --noEmit` clean; `eslint` and `prettier --check` clean on both files.

## On the specs, and their limit

Each header gets two: one proving the packets **around** it survive, and one proving a packet split across TCP reads is held rather than mis-parsed. Plus one for all five queued back to back.

Being straight about the limit: the specs build fixtures from their own copy of the five sizes. The mutation shows they catch the implementation drifting from that table, but if table and implementation were wrong *the same way* they would still pass. The numbers rest on the source review, not on the suite.

## Two things worth knowing

1. **These headers are now shadowed.** `extractFrame` consults `isUnimplementedHeader` *before* `this.packets`, so when you implement `CG_USE_SKILL`, registering it in `Packets.ts` will silently do nothing until its entry here is removed — no handler, no warning. Given skill use is next on #38, that is a trap with your name on it. Happy to add a guard keeping the two maps disjoint.
2. **It also applies to the auth server and precedes any phase check**, since the map lives on the base `Server`. There, and on an unauthenticated socket, these headers now get stepped over where they used to clear the buffer. Nothing is dispatched either way, `MAX_RECEIVE_BUFFER` still caps growth, and `CG_SYNC_POSITION` already behaves this way — it changes disposal, not reach.

## Note on scope

Nothing here implements the packets — they stay ignored, exactly as `CG_SYNC_POSITION` is. It only stops the framing from taking neighbouring traffic down with them, so it is independent of #38.