### PR TITLE
fix(skill): charge horse skills to the riding point pool (fix #206)

### DIFF
--- a/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
+++ b/src/core/domain/entities/game/player/delegate/PlayerPoints.ts
@@ -870,9 +870,6 @@ export class PlayerPoints extends Points {
         this.points.set(PointsEnum.MOUNT, {
             get: () => this.player.getMountVnum(),
         });
-        this.points.set(PointsEnum.HORSE_SKILL, {
-            get: () => this.player.getHorseLevel(),
-        });
     }
 
     private addCommonPoint(value: number, pointName: string) {

--- a/src/core/domain/entities/game/skill/Skill.ts
+++ b/src/core/domain/entities/game/skill/Skill.ts
@@ -69,7 +69,7 @@ export abstract class Skill {
     }
 
     isActive(): this is ActiveSkill {
-        return this.type === SkillTypeEnum.ACTIVE;
+        return this instanceof ActiveSkill;
     }
 }
 
@@ -78,7 +78,7 @@ export abstract class PassiveSkill extends Skill {
 }
 
 export abstract class ActiveSkill extends Skill {
-    public readonly type = SkillTypeEnum.ACTIVE;
+    public readonly type: SkillTypeEnum = SkillTypeEnum.ACTIVE;
     public abstract readonly splashRange: number;
     public abstract readonly maxHit: number;
     public abstract readonly damageType: SkillDamageTypeEnum;

--- a/src/core/domain/entities/game/skill/active/horse/ChargeSkill.ts
+++ b/src/core/domain/entities/game/skill/active/horse/ChargeSkill.ts
@@ -1,4 +1,5 @@
 import { SkillEnum } from '@/core/enum/SkillEnum';
+import { SkillTypeEnum } from '@/core/enum/SkillTypeEnum';
 import { SkillDamageTypeEnum } from '@/core/enum/SkillDamageTypeEnum';
 import { SkillFlagsEnum } from '@/core/enum/SkillFlagsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -9,6 +10,8 @@ import { ActiveSkill, SkillApplies, SkillCalcContext } from '../../Skill';
 
 export class ChargeSkill extends ActiveSkill {
     public readonly id: number = SkillEnum.HORSE_CHARGE;
+
+    public readonly type: SkillTypeEnum = SkillTypeEnum.HORSE;
 
     public readonly levelStep: number = 1;
     public readonly maxLevel: number = 1;

--- a/src/core/domain/entities/game/skill/active/horse/EscapeSkill.ts
+++ b/src/core/domain/entities/game/skill/active/horse/EscapeSkill.ts
@@ -1,4 +1,5 @@
 import { SkillEnum } from '@/core/enum/SkillEnum';
+import { SkillTypeEnum } from '@/core/enum/SkillTypeEnum';
 import { SkillDamageTypeEnum } from '@/core/enum/SkillDamageTypeEnum';
 import { SkillFlagsEnum } from '@/core/enum/SkillFlagsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -9,6 +10,8 @@ import { ActiveSkill, SkillApplies, SkillCalcContext } from '../../Skill';
 
 export class EscapeSkill extends ActiveSkill {
     public readonly id: number = SkillEnum.HORSE_ESCAPE;
+
+    public readonly type: SkillTypeEnum = SkillTypeEnum.HORSE;
 
     public readonly levelStep: number = 1;
     public readonly maxLevel: number = 1;

--- a/src/core/domain/entities/game/skill/active/horse/WildAttackRangeSkill.ts
+++ b/src/core/domain/entities/game/skill/active/horse/WildAttackRangeSkill.ts
@@ -1,4 +1,5 @@
 import { SkillEnum } from '@/core/enum/SkillEnum';
+import { SkillTypeEnum } from '@/core/enum/SkillTypeEnum';
 import { SkillDamageTypeEnum } from '@/core/enum/SkillDamageTypeEnum';
 import { SkillFlagsEnum } from '@/core/enum/SkillFlagsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -9,6 +10,8 @@ import { ActiveSkill, SkillApplies, SkillCalcContext } from '../../Skill';
 
 export class WildAttackRangeSkill extends ActiveSkill {
     public readonly id: number = SkillEnum.HORSE_WILDATTACK_RANGE;
+
+    public readonly type: SkillTypeEnum = SkillTypeEnum.HORSE;
 
     public readonly levelStep: number = 1;
     public readonly maxLevel: number = 1;

--- a/src/core/domain/entities/game/skill/active/horse/WildAttackSkill.ts
+++ b/src/core/domain/entities/game/skill/active/horse/WildAttackSkill.ts
@@ -1,4 +1,5 @@
 import { SkillEnum } from '@/core/enum/SkillEnum';
+import { SkillTypeEnum } from '@/core/enum/SkillTypeEnum';
 import { SkillDamageTypeEnum } from '@/core/enum/SkillDamageTypeEnum';
 import { SkillFlagsEnum } from '@/core/enum/SkillFlagsEnum';
 import { PointsEnum } from '@/core/enum/PointsEnum';
@@ -9,6 +10,8 @@ import { ActiveSkill, SkillApplies, SkillCalcContext } from '../../Skill';
 
 export class WildAttackSkill extends ActiveSkill {
     public readonly id: number = SkillEnum.HORSE_WILDATTACK;
+
+    public readonly type: SkillTypeEnum = SkillTypeEnum.HORSE;
 
     public readonly levelStep: number = 1;
     public readonly maxLevel: number = 1;

--- a/test/unit/core/domain/entities/game/player/PlayerPointsHorseSkill.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerPointsHorseSkill.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { PlayerPoints } from '@/core/domain/entities/game/player/delegate/PlayerPoints';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+const HORSE_SKILL_POINTS = 7;
+const HORSE_LEVEL = 21;
+
+const createPoints = () =>
+    new PlayerPoints({ horseSkill: HORSE_SKILL_POINTS } as any, {
+        config: {} as any,
+        player: { getHorseLevel: () => HORSE_LEVEL } as any,
+    });
+
+describe('PlayerPoints — horse skill point registration (issue #206)', () => {
+    it('should read the riding point pool, not the horse level', () => {
+        const points = createPoints();
+
+        expect(points.getPoint(PointsEnum.HORSE_SKILL)).to.equal(HORSE_SKILL_POINTS);
+    });
+
+    it('should spend and grant riding points instead of silently ignoring the change', () => {
+        const points = createPoints();
+
+        points.addPoint(PointsEnum.HORSE_SKILL, -1);
+        expect(points.getPoint(PointsEnum.HORSE_SKILL)).to.equal(HORSE_SKILL_POINTS - 1);
+
+        points.addPoint(PointsEnum.HORSE_SKILL, 3);
+        expect(points.getPoint(PointsEnum.HORSE_SKILL)).to.equal(HORSE_SKILL_POINTS + 2);
+
+        points.setPoint(PointsEnum.HORSE_SKILL, 0);
+        expect(points.getPoint(PointsEnum.HORSE_SKILL)).to.equal(0);
+    });
+});

--- a/test/unit/core/domain/entities/game/skill/HorseSkillPointPool.test.ts
+++ b/test/unit/core/domain/entities/game/skill/HorseSkillPointPool.test.ts
@@ -1,0 +1,89 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { SkillEnum } from '@/core/enum/SkillEnum';
+import { SkillTypeEnum } from '@/core/enum/SkillTypeEnum';
+import { SkillManager } from '@/core/domain/manager/SkillManager';
+import Player from '@/core/domain/entities/game/player/Player';
+import { PlayerSkill } from '@/core/domain/entities/game/player/delegate/PlayerSkill';
+import { PlayerPoints } from '@/core/domain/entities/game/player/delegate/PlayerPoints';
+
+const HORSE_SKILLS = [
+    ['Charge', SkillEnum.HORSE_CHARGE],
+    ['Escape', SkillEnum.HORSE_ESCAPE],
+    ['Wild Attack', SkillEnum.HORSE_WILDATTACK],
+    ['Wild Attack Range', SkillEnum.HORSE_WILDATTACK_RANGE],
+] as const;
+
+const createPlayer = (overrides: Record<string, unknown> = {}): Player =>
+    ({
+        isPolymorphed: sinon.stub().returns(false),
+        getPoint: sinon.stub().returns(999999),
+        addPoint: sinon.stub(),
+        setPoint: sinon.stub(),
+        getSkillGroup: sinon.stub().returns(1),
+        isPlayer: sinon.stub().returns(true),
+        chat: sinon.stub(),
+        sendPoints: sinon.stub(),
+        sendSkillLevel: sinon.stub(),
+        save: sinon.stub(),
+        ...overrides,
+    }) as unknown as Player;
+
+describe('Horse skills spend riding points (issue #206)', () => {
+    const skillManager = new SkillManager();
+
+    for (const [name, skillNum] of HORSE_SKILLS) {
+        it(`${name} is registered as a HORSE skill, not a plain active one`, () => {
+            expect(skillManager.getSkill(skillNum)?.type).to.equal(SkillTypeEnum.HORSE);
+        });
+    }
+
+    it('deducts a riding point when levelling one up, leaving the job pool alone', () => {
+        const addPoint = sinon.stub();
+        const player = createPlayer({ addPoint });
+        const playerSkill = new PlayerSkill({ player, skillManager, skills: [] });
+
+        playerSkill.skillLevelUp(SkillEnum.HORSE_CHARGE, 'POINT');
+
+        expect(addPoint.calledOnceWith(PointsEnum.HORSE_SKILL, -1)).to.be.true;
+        expect(addPoint.calledWith(PointsEnum.SKILL, -1), 'the job skill pool must not be touched').to.be.false;
+    });
+
+    it('refuses to level one up without riding points, however many job points the player has', () => {
+        const addPoint = sinon.stub();
+        const getPoint = sinon.stub().callsFake((point: PointsEnum) => (point === PointsEnum.HORSE_SKILL ? 0 : 999999));
+        const player = createPlayer({ addPoint, getPoint });
+        const playerSkill = new PlayerSkill({ player, skillManager, skills: [] });
+
+        playerSkill.skillLevelUp(SkillEnum.HORSE_CHARGE, 'POINT');
+
+        expect(addPoint.called).to.be.false;
+        expect(playerSkill.getSkills()[SkillEnum.HORSE_CHARGE].level).to.equal(0);
+    });
+
+    it('actually moves the riding pool, not just the call', () => {
+        const points = new PlayerPoints({ horseSkill: 3 } as any, {
+            config: {} as any,
+            player: { getHorseLevel: () => 21 } as any,
+        });
+        const player = createPlayer({
+            getPoint: (point: PointsEnum) =>
+                point === PointsEnum.HORSE_SKILL || point === PointsEnum.SKILL ? points.getPoint(point) : 999999,
+            addPoint: (point: PointsEnum, value: number) => points.addPoint(point, value),
+        });
+        const playerSkill = new PlayerSkill({ player, skillManager, skills: [] });
+
+        playerSkill.skillLevelUp(SkillEnum.HORSE_CHARGE, 'POINT');
+
+        expect(points.getPoint(PointsEnum.HORSE_SKILL), 'a riding point is really spent').to.equal(2);
+    });
+
+    it('still treats them as castable active skills', () => {
+        for (const [, skillNum] of HORSE_SKILLS) {
+            expect(skillManager.getSkill(skillNum)?.isActive(), `skill ${skillNum}`).to.be.true;
+            expect(skillManager.getSkill(skillNum)?.isPassive(), `skill ${skillNum}`).to.be.false;
+        }
+    });
+});


### PR DESCRIPTION
Fixes #206. Two halves of one defect — **either alone is a no-op**, which is why they are in the same PR.

## Half one: nothing could ever be a HORSE skill

The four horse skills from `f6b08888` extend `ActiveSkill`, whose type was the hardcoded literal `SkillTypeEnum.ACTIVE`. So the branch you wrote in `skillLevelUp`:

```ts
} else if (skillProto.type === SkillTypeEnum.HORSE) {
    point = PointsEnum.HORSE_SKILL;
}
```

was unreachable, and horse skills fell through to the default. `/skillup 138` deducted a regular job skill point **and** checked the job pool for availability, so a player who never read a riding manual could master a horse skill out of ordinary skill points.

`ActiveSkill` now declares `type` as `SkillTypeEnum` rather than the literal, so the four protos carry `HORSE` while keeping the castable `ActiveSkill` interface. That matches the original, where `dwType` selects the point pool and the UI group, not whether a skill can be cast — `char_skill.cpp` charges `POINT_HORSE_SKILL` for `dwType == SKILL_TYPE_HORSE` and requires `GetPoint(POINT_HORSE_SKILL) >= 1`.

`isActive()` moves to an `instanceof` check so it keeps meaning *castable* rather than *type is exactly ACTIVE*. Without that, horse skills would answer `false` to it and the skill-use work would inherit a trap. It has no callers today, so nothing else shifts.

## Half two: the point was registered twice

`PlayerPoints` set `PointsEnum.HORSE_SKILL` twice on the same `Map` — the second time as a getter returning the horse's **level**, with no `add` or `set`. `Map.set` means that one won, so `getPoint` returned the level and `addPoint`/`setPoint` silently did nothing. Retyping the skills alone would have routed the deduction to a pool that cannot be read or written.

**That second registration was mine, from #39.** When it landed `HORSE_SKILL` was not registered at all, so it clobbered nothing; your full config arriving later turned it into a conflict. Removed here, so 113 carries the persisted pool the way the original defines it.

You asked implicitly what happens to the level display — it is covered: horse level still reaches the client as skill vnum 130's level in the skill packet, the way `char_horse.cpp` sends it, which `f6b08888` already wired. If you would rather surface it somewhere else too, say so and I will follow up.

## Verified

- `npm run test:unit`: **755 passing, 0 failing** (745 on master + 10 new specs).
- Fail-without-fix: reverting both halves gives **exactly 9 failures**.
- **The coupling is pinned too**: restoring only the type half — the plausible partial fix — still fails **3** specs, because the deduction lands on the clobbered pool. That is the case a call-level assertion would have missed.
- `tsc --noEmit`, `eslint` and `prettier --check` clean on all eight files.
- Merge-simulated against #211-#214 in both orders — clean; all five composed give **778 passing** with `tsc` clean.

## On the specs

The existing *"deducts PointsEnum.HORSE_SKILL for HORSE skills"* spec builds a **fabricated** proto with `type: SkillTypeEnum.HORSE`, so it passed before and after — it proved the branch works *if* something carried that type, while nothing did. The new specs go through the real `SkillManager` and the registered classes instead, and one drives a real `PlayerPoints` so the pool actually moves rather than merely being called.