### PR TITLE
fix(net): refuse a packet this server cannot serve instead of killing the connection (refs #217)

### DIFF
--- a/src/auth/interface/server/AuthServer.ts
+++ b/src/auth/interface/server/AuthServer.ts
@@ -19,9 +19,10 @@ export default class AuthServer extends Server {
 
         if (!this.isAllowedInPhase(connection, header, packetBuilder)) return;
 
-        const { createPacket, createHandler } = packetBuilder;
+        const { createPacket } = packetBuilder;
         const packet = createPacket({});
-        const handler = createHandler(this.container);
+        const handler = this.createHandlerFor(connection, header, packetBuilder);
+        if (!handler) return;
         this.logger.debug(`[IN][PACKET] name: ${handler.constructor.name}`);
 
         const unpacked = this.unpackPacket(connection, packet, data);

--- a/src/core/interface/server/Server.ts
+++ b/src/core/interface/server/Server.ts
@@ -1,4 +1,5 @@
 import { createServer, Server as SocketServer, Socket } from 'node:net';
+import { AwilixResolutionError } from 'awilix';
 import Connection from '@/core/interface/networking/Connection';
 import Logger from '@/core/infra/logger/Logger';
 import { PacketMapValue } from '@/core/interface/networking/packets/Packets';
@@ -43,6 +44,20 @@ export default abstract class Server {
 
     abstract createConnection(socket: Socket): Connection;
     abstract onData(connection: Connection, data: Buffer): Promise<void>;
+
+    /** The packet map is shared by both servers but the containers are not, so an unservable handler is refused, not fatal. */
+    protected createHandlerFor(connection: Connection, header: number, packetBuilder: PacketMapValue<any>) {
+        try {
+            return packetBuilder.createHandler(this.container);
+        } catch (error) {
+            if (!(error instanceof AwilixResolutionError)) throw error;
+
+            this.logger.error(
+                `[IN][PACKET] Header ${header} is not served by this server from connection: ID: ${connection.getId()}, ignoring. ${error.message}`,
+            );
+            return null;
+        }
+    }
 
     protected isAllowedInPhase(connection: Connection, header: number, packetBuilder: PacketMapValue<any>): boolean {
         if (packetBuilder.phases.has(connection.getState())) return true;

--- a/src/game/interface/server/GameServer.ts
+++ b/src/game/interface/server/GameServer.ts
@@ -55,9 +55,10 @@ export default class GameServer extends Server {
 
         if (!this.isAllowedInPhase(connection, header, packetBuilder)) return;
 
-        const { createPacket, createHandler } = packetBuilder;
+        const { createPacket } = packetBuilder;
         const packet = createPacket({});
-        const handler = createHandler(this.container);
+        const handler = this.createHandlerFor(connection, header, packetBuilder);
+        if (!handler) return;
         this.logger.debug(`[IN][PACKET] processing packet: ${handler.constructor.name}`);
 
         const unpacked = this.unpackPacket(connection, packet, data);

--- a/test/unit/core/interface/server/Server.test.ts
+++ b/test/unit/core/interface/server/Server.test.ts
@@ -11,6 +11,7 @@ import MyShopPacket from '@/core/interface/networking/packets/packet/in/myshop/M
 import EmpirePacket from '@/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket';
 import { ShopSubHeaderCG } from '@/core/enum/ShopSubHeaderEnum';
 import AuthServer from '@/auth/interface/server/AuthServer';
+import { asValue, createContainer } from 'awilix';
 
 type LogLine = { level: string; message: string };
 const logged: Array<LogLine> = [];
@@ -214,6 +215,77 @@ describe('Unknown header log level', () => {
         expect(unknown).to.have.lengthOf(1);
         expect(unknown[0].level).to.be.equal('debug');
 
+        socket.emit('close');
+    });
+});
+
+describe('Packets the server cannot serve (issue #217)', () => {
+    /**
+     * A real awilix container, so resolving a service it does not register throws
+     * the way it does in production. A plain object would silently inject
+     * undefined and never reproduce the failure.
+     */
+    const authLikeServer = (packets = makePackets()) => {
+        const containerInstance = createContainer();
+        containerInstance.register({
+            logger: asValue(logger),
+            config: asValue({}),
+            packets: asValue(packets),
+            containerInstance: asValue({ createScope: () => {} }),
+        });
+        return new AuthServer(containerInstance.cradle as any);
+    };
+
+    /** The auth container has no selectEmpireService, so EMPIRE cannot be built there. */
+    const empirePacket = () => sequenced(new BufferWriter(PacketHeaderEnum.EMPIRE, 2).writeUint8(1).getBuffer());
+
+    it('should ignore the packet instead of killing the connection', async () => {
+        logged.length = 0;
+        const server = authLikeServer();
+        const socket = createFakeSocket();
+        server.onListener(socket);
+
+        socket.emit('data', empirePacket());
+        await settle();
+
+        expect(socket.destroy.called, 'the connection must survive an unroutable packet').to.be.equal(false);
+        const refused = logged.filter((line) => String(line.message).includes('is not served by this server'));
+        expect(refused, 'the refusal is logged loudly').to.have.lengthOf(1);
+        expect(refused[0].level).to.be.equal('error');
+
+        socket.emit('close');
+    });
+
+    it('should keep serving the connection afterwards', async () => {
+        const server = authLikeServer();
+        const socket = createFakeSocket();
+        server.onListener(socket);
+
+        socket.emit('data', Buffer.concat([empirePacket(), empirePacket()]));
+        await settle();
+
+        expect(socket.destroy.called).to.be.equal(false);
+        socket.emit('close');
+    });
+
+    it('should still propagate a handler constructor failure that is not a resolution error', async () => {
+        const packets = makePackets();
+        const entry = packets.get(PacketHeaderEnum.EMPIRE)!;
+        packets.set(PacketHeaderEnum.EMPIRE, {
+            ...entry,
+            createHandler: () => {
+                throw new TypeError('a real defect in the handler');
+            },
+        });
+
+        const server = authLikeServer(packets);
+        const socket = createFakeSocket();
+        server.onListener(socket);
+
+        socket.emit('data', empirePacket());
+        await settle();
+
+        expect(socket.destroy.called, 'a genuine defect must not be swallowed').to.be.equal(true);
         socket.emit('close');
     });
 });


### PR DESCRIPTION
Takes the half of #217 that **cannot change any working path** — it only alters what happens on a failure that currently closes the connection. The deeper half is still yours to call, see the end.

## What was happening

`Packets.ts` is one map shared by both servers; the containers are not. `createHandler(this.container)` builds the handler with the local container, and awilix resolves the destructured constructor arguments eagerly in its default PROXY mode — so a packet whose handler needs a service this container does not register throws **at construction**. Both servers call `createHandler` before `unpackPacket`, so no validation can intervene, and the throw reaches `Server.handleData`, which discards the buffer and closes the socket.

Seven packets, and it is symmetric. On auth, whose connections only ever hold `HANDSHAKE` and `AUTH` — both inside `LOGIN_PHASES`: `TOKEN`, `EMPIRE`, `CREATE_CHARACTER`, `DELETE_CHARACTER`, `SELECT_CHARACTER`, `ENTER_GAME`. On game: `LOGIN_REQUEST`, whose `loginService` lives only in the auth container — that one is the older `Could not resolve 'loginService'` failure in my logs.

`isAllowedInPhase` cannot prevent it: it tests the packet's phase set against the *connection state*, which says nothing about which server owns the connection.

## The change

Handler construction now goes through `Server.createHandlerFor`, which treats a resolution failure exactly the way an unroutable header is already treated — logged and ignored, connection left alive:

```ts
try {
    return packetBuilder.createHandler(this.container);
} catch (error) {
    if (!(error instanceof AwilixResolutionError)) throw error;
    this.logger.error(`... Header ${header} is not served by this server ... ignoring`);
    return null;
}
```

The narrow catch is deliberate. Anything that is **not** an `AwilixResolutionError` is a genuine defect in a handler constructor and still propagates, so this narrows the failure mode rather than swallowing errors.

## Verified

- `npm run test:unit`: **748 passing, 0 failing** (745 on master + 3 new).
- Fail-without-fix: reverting gives **2** failures. The third spec is a **control, not a regression test** — it asserts that a non-resolution constructor error still closes the connection, and it passes both with and without the change. That is the point: it is what stops this from becoming a blanket `catch`.
- `tsc --noEmit` and `prettier --check` clean. Merge-simulated against all five of my open PRs in both orders — clean.

## On the specs

Worth flagging, because my first attempt was wrong: the specs build a **real awilix container** rather than a plain object. With a plain object, destructuring an unregistered service yields `undefined` and never throws, so the spec passed while reproducing nothing. Only a real cradle produces the production failure.

## What I have deliberately not done

The deeper fix — splitting `LOGIN_PHASES` into per-server phase sets so the existing gate can refuse foreign packets outright. I posted the 40250 comparison on #217: the original keeps `PHASE_AUTH` and `PHASE_LOGIN` distinct and sets one or the other by role right after the handshake, while our `LOGIN_PHASES` is the union of both state machines. That is the real root cause, but it changes which packets are accepted, so it needs your answer and a real-client run before I would trust it. This PR is safe without it.

## Note on scope

Pre-existing, and independent of my other open PRs. Found while driving the stock client.