### PR TITLE
feat(net): log outgoing packets on the game server, as the auth server already does (refs #219)

### DIFF
--- a/src/game/interface/networking/GameConnection.ts
+++ b/src/game/interface/networking/GameConnection.ts
@@ -54,7 +54,8 @@ export default class GameConnection extends Connection {
         this.setState(ConnectionStateEnum.LOGIN);
     }
 
-    send<T>(packet: T & { pack: () => Buffer }) {
+    send<T>(packet: T & { pack: () => Buffer; getName: () => string }) {
+        this.logger.debug(`[OUT][PACKET] name: ${packet.getName()}`);
         this.socket.write(packet.pack());
     }
 }

--- a/test/unit/game/interface/networking/GameConnectionOutgoingLog.test.ts
+++ b/test/unit/game/interface/networking/GameConnectionOutgoingLog.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import GameConnection from '@/game/interface/networking/GameConnection';
+import PingPacket from '@/core/interface/networking/packets/packet/out/PingPacket';
+
+type LogLine = { level: string; message: string };
+
+const createLogger = (logged: Array<LogLine>): any => ({
+    info: (message: string) => logged.push({ level: 'info', message }),
+    error: (message: string) => logged.push({ level: 'error', message }),
+    debug: (message: string) => logged.push({ level: 'debug', message }),
+});
+
+describe('GameConnection outgoing packet log (issue #219)', () => {
+    let logged: Array<LogLine>;
+    let socket: any;
+    let connection: GameConnection;
+
+    beforeEach(() => {
+        logged = [];
+        socket = { write: sinon.spy(), destroy: sinon.spy(), setNoDelay: () => {} };
+        connection = new GameConnection({ socket, logger: createLogger(logged) });
+    });
+
+    afterEach(() => {
+        connection.stopKeepalive();
+    });
+
+    it('names every packet it puts on the wire, the way the auth server already does', () => {
+        connection.send(new PingPacket());
+
+        const out = logged.filter((line) => line.message.includes('[OUT][PACKET]'));
+        expect(out, 'the send must leave a record').to.have.lengthOf(1);
+        expect(out[0].level).to.be.equal('debug');
+        expect(out[0].message).to.be.equal('[OUT][PACKET] name: PingPacket');
+    });
+
+    it('still writes the packed buffer', () => {
+        connection.send(new PingPacket());
+
+        expect(socket.write.calledOnce).to.be.equal(true);
+        expect(socket.write.firstCall.args[0]).to.be.instanceOf(Buffer);
+    });
+
+    it('logs one line per packet, in send order', () => {
+        connection.send(new PingPacket());
+        connection.send(new PingPacket());
+
+        const out = logged.filter((line) => line.message.includes('[OUT][PACKET]'));
+        expect(out).to.have.lengthOf(2);
+        expect(socket.write.callCount).to.be.equal(2);
+    });
+});


### PR DESCRIPTION
Takes the small side note from #219.

## Why

`GameConnection.send` was a bare `socket.write(packet.pack())`, so the game server kept **no record of anything it sent, at any log level**. `AuthConnection.send` has logged `[OUT][PACKET] name: <packet>` at debug since it was written, so the two servers disagreed on exactly the thing that matters when a bug is client-visible.

That gap cost real time yesterday. A skill book was consumed server-side but stayed drawn in the client's inventory for eleven seconds, and the obvious suspect was the socket cork `GameServer.onData` holds across the awaited handler. With no record of when the packet was written, there was no way to separate *a withheld write* from *a client that had not repainted* — the question had to be settled indirectly, off the timestamp of an unrelated `ItemManager` flush line.

## The change

```diff
-    send<T>(packet: T & { pack: () => Buffer }) {
+    send<T>(packet: T & { pack: () => Buffer; getName: () => string }) {
+        this.logger.debug(`[OUT][PACKET] name: ${packet.getName()}`);
         this.socket.write(packet.pack());
     }
```

Deliberately identical to the auth server — same prefix, same level, same `packet.getName()` — so both sides of a session read the same way with `dev:game:debug`. It stays at **debug**, so it never reaches `logs/info.log`: the file transports are pinned at info and error, and only the console carries debug.

Tightening the parameter to require `getName()` compiled with **no other change**, which is a nice incidental confirmation that every packet already sent through this connection has it.

## Verified

- `npm run test:unit`: **748 passing, 0 failing** (745 on master + 3 new).
- Fail-without-fix: **2** failures. The third spec — that the packed buffer is still written — is a **control that passes both ways**; it is there so the log line cannot be added at the cost of the send itself.
- `tsc --noEmit`, `eslint` and `prettier --check` clean. Merge-simulated against my six other open PRs in both orders — clean.

## The one judgement call

This is a hot path, so I considered guarding the string build behind a level check. I did not, for two reasons: `Logger` exposes no such check, and adding one would touch the interface, the adapter and every test fake for a concat that is dwarfed by `pack()`'s `Buffer.alloc` and the `socket.write` beside it. Consistency with the auth server seemed worth more than the nanoseconds. If you would rather it were gated — or gated only for the highest-frequency packets — say so and I will change it.

## Note on scope

Independent of my other open PRs; nothing behavioural changes with the default `LOG_LEVEL=info`.