### PR TITLE
fix(net): send ItemPacket at the client struct size of 51 bytes

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -566,7 +566,7 @@
 
 **Header:** 0x15
 
-**Size:** 54 bytes
+**Size:** 51 bytes
 
 **Description:** Sets an item into a client window cell (inventory, equipment, ...). The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
 
@@ -581,7 +581,7 @@
 | count | `byte` | 1 | Stack size of the item |
 | flags | `int` | 4 | Item flags, currently always sent as 0 |
 | antiFlags | `int` | 4 | Item anti flags, currently always sent as 0 |
-| highlight | `int` | 4 | Non zero highlights the cell in the client, currently always sent as 0 |
+| highlight | `byte` | 1 | Non zero highlights the cell in the client, currently always sent as 0 |
 | sockets | `int[3]` | 12 | Metin socket values, 3 slots of 4 bytes |
 | bonusId | `byte` | 1 | Attribute type of the bonus slot, repeated 7x |
 | bonusValue | `short` | 2 | Attribute value of the bonus slot, repeated 7x |

--- a/src/core/interface/networking/packets/packet/out/ItemPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ItemPacket.ts
@@ -15,7 +15,7 @@ class ItemBonus {
  * @type Out
  * @name ItemPacket
  * @header 0x15
- * @size 54
+ * @size 51
  * @description Sets an item into a client window cell (inventory, equipment, ...). The bonusId/bonusValue pair is repeated 7x, one per item attribute slot.
  * @fields
  *   - {byte} header 1 Packet header
@@ -25,7 +25,7 @@ class ItemBonus {
  *   - {byte} count 1 Stack size of the item
  *   - {int} flags 4 Item flags, currently always sent as 0
  *   - {int} antiFlags 4 Item anti flags, currently always sent as 0
- *   - {int} highlight 4 Non zero highlights the cell in the client, currently always sent as 0
+ *   - {byte} highlight 1 Non zero highlights the cell in the client, currently always sent as 0
  *   - {int[3]} sockets 12 Metin socket values, 3 slots of 4 bytes
  *   - {byte} bonusId 1 Attribute type of the bonus slot, repeated 7x
  *   - {short} bonusValue 2 Attribute value of the bonus slot, repeated 7x
@@ -74,7 +74,7 @@ export default class ItemPacket extends PacketOut {
         super({
             header: PacketHeaderEnum.ITEM,
             name: 'ItemPacket',
-            size: 54,
+            size: 51,
         });
         this.window = window;
         this.position = position;
@@ -105,7 +105,7 @@ export default class ItemPacket extends PacketOut {
         this.bufferWriter.writeUint8(this.count);
         this.bufferWriter.writeUint32LE(this.flags);
         this.bufferWriter.writeUint32LE(this.antiFlags);
-        this.bufferWriter.writeUint32LE(this.highlight);
+        this.bufferWriter.writeUint8(this.highlight);
         this.sockets.forEach((socket) => this.bufferWriter.writeUint32LE(socket));
         this.bonuses.forEach(({ id, value }) => {
             this.bufferWriter.writeUint8(id);

--- a/test/unit/core/interface/networking/packets/packets/out/ItemPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/out/ItemPacket.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import ItemPacket from '@/core/interface/networking/packets/packet/out/ItemPacket';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+/**
+ * The wire layout is TPacketGCItemSet2 (client Packet.h, #pragma pack(1)):
+ * header 1 + Cell(BYTE+WORD) 3 + vnum 4 + count 1 + flags 4 + anti_flags 4 +
+ * highlight 1 (bool) + alSockets[3] 12 + aAttr[7] 21 = 51 bytes.
+ * The offsets asserted below are the client struct's offsets; reading the
+ * sockets and attributes back from those exact positions is what pins the
+ * 1-byte highlight — a wider highlight shifts everything after it.
+ */
+describe('ItemPacket', () => {
+    const packet = () =>
+        new ItemPacket({
+            window: 1,
+            position: 7,
+            id: 50431,
+            count: 3,
+            flags: 0,
+            antiFlags: 0,
+            highlight: 0,
+            sockets: [111, 222, 333],
+            bonuses: [
+                { id: 5, value: 1500 },
+                { id: 6, value: 20 },
+            ],
+        });
+
+    it('initializes with the ITEM header', () => {
+        expect(packet().getHeader()).to.equal(PacketHeaderEnum.ITEM);
+        expect(packet().getName()).to.equal('ItemPacket');
+    });
+
+    it('packs to the client struct size of 51 bytes', () => {
+        expect(packet().pack()).to.have.lengthOf(51);
+    });
+
+    it('packs the fields up to highlight at the client struct offsets', () => {
+        const buffer = packet().pack();
+
+        expect(buffer.readUInt8(0), 'header').to.equal(PacketHeaderEnum.ITEM);
+        expect(buffer.readUInt8(1), 'window').to.equal(1);
+        expect(buffer.readUInt16LE(2), 'position').to.equal(7);
+        expect(buffer.readUInt32LE(4), 'vnum').to.equal(50431);
+        expect(buffer.readUInt8(8), 'count').to.equal(3);
+        expect(buffer.readUInt32LE(9), 'flags').to.equal(0);
+        expect(buffer.readUInt32LE(13), 'antiFlags').to.equal(0);
+        expect(buffer.readUInt8(17), 'highlight').to.equal(0);
+    });
+
+    it('packs the sockets right after the 1-byte highlight, where the client reads alSockets', () => {
+        const buffer = packet().pack();
+
+        expect(buffer.readUInt32LE(18), 'socket 0').to.equal(111);
+        expect(buffer.readUInt32LE(22), 'socket 1').to.equal(222);
+        expect(buffer.readUInt32LE(26), 'socket 2').to.equal(333);
+    });
+
+    it('packs the attributes where the client reads aAttr', () => {
+        const buffer = packet().pack();
+
+        expect(buffer.readUInt8(30), 'attr 0 type').to.equal(5);
+        expect(buffer.readUInt16LE(31), 'attr 0 value').to.equal(1500);
+        expect(buffer.readUInt8(33), 'attr 1 type').to.equal(6);
+        expect(buffer.readUInt16LE(34), 'attr 1 value').to.equal(20);
+    });
+
+    it('leaves omitted sockets and attributes as zeroes up to the last byte', () => {
+        const buffer = new ItemPacket({
+            window: 1,
+            position: 0,
+            id: 0,
+            count: 0,
+            flags: 0,
+            antiFlags: 0,
+            highlight: 0,
+        }).pack();
+
+        expect(buffer).to.have.lengthOf(51);
+        expect(
+            buffer.subarray(18).every((byte) => byte === 0),
+            'sockets and attrs are zero-filled',
+        ).to.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #219.

## What changes

`ItemPacket` (header `0x15`, `HEADER_GC_ITEM_SET2`) declared and wrote **54 bytes**; the client's `RecvItemSetPacket2` consumes `sizeof(TPacketGCItemSet2)` = **51**. The whole difference is `highlight`: we wrote it with `writeUint32LE` where the client struct declares a 1-byte `bool`.

```diff
-        this.bufferWriter.writeUint32LE(this.highlight);
+        this.bufferWriter.writeUint8(this.highlight);
```

plus the declared size 54 → 51, the `@packet` docblock, and the regenerated `docs/packets.md`.

This matches the original server field for field: `packet_item_set` in the 40250 source declares `bool highlight` and sends `sizeof(TPacketGCItemSet)` = 51 (`char_item.cpp`, the `pack.highlight = (Cell.window_type == DRAGON_SOUL_INVENTORY)` site).

## Why the 3 extra bytes look harmless today — and why that is luck, not safety

While writing this I found the exact mechanism that hides the bug, in the client's `CheckPacket` (`PythonNetworkStream.cpp`): before resolving a header it **silently discards leading zero bytes** —

```cpp
if (0 == header)
{
    if (!Recv(sizeof(TPacketHeader), &header))
        return false;
    while (Peek(sizeof(TPacketHeader), &header)) { ... }
```

Our 3 stray bytes are the tail of the zeroed attribute region, so today the client swallows them as "leading zeros" of the next packet. Both protections are coincidences that expire together:

- the moment `sockets`/`bonuses` are actually populated (`Player.sendItemAdded` has them as `//todo`, and #125/#139 already went that direction for shop listings), the client reads `alSockets` and `aAttr` **3 bytes misaligned**;
- and if the last attribute value has a non-zero low byte, the leftover is no longer zero — `CheckPacket` then resolves it as an unknown header, and that path is `ClearRecvBuffer()` + `PostQuitMessage(0)`: **the client closes**.

## Verification

- `tsc --noEmit` clean; unit **751 passing / 0 failing** (745 on master + 6 new).
- New `ItemPacket.test.ts` reads every field back at the **client struct's offsets** with non-zero socket and attribute values — that is what pins the 1-byte highlight, since a wider field shifts everything after it. Fail-without-fix: reverting only the packet change fails **exactly 4 of the 6** cases (54 vs 51; socket 0 read at offset 18 comes back shifted; attribute type at 30 likewise; tail not zero-filled).
- Merge simulation: clean against master, and pairwise clean in both orders against all 22 open PRs (only #200 shares `docs/packets.md`, in a distant region).

## Note on scope

Same family as #152 (declared size disagrees with the client struct) but on the hot path — every item add/remove during normal play. Deliberately **not** touched here: the constructor accepts `flags`/`antiFlags`/`highlight` and then overwrites all three with `0` (the original sends the real flags and sets `highlight` for dragon-soul cells) — that is a behaviour change, not a size fix, so I left it alone; happy to take it separately if you want the real flags on the wire.
