### PR TITLE
fix(net): send CharacterMoveOutPacket at the client struct size of 24 bytes

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -121,7 +121,7 @@
 
 **Header:** 0x03
 
-**Size:** 25 bytes
+**Size:** 24 bytes
 
 **Description:** Is used to replicate the movement of a character (player, mobs) to other nearby players.
 
@@ -138,7 +138,6 @@
 | positionY | `int` | 4 | Position Y of character in game |
 | time | `int` | 4 | unknown |
 | duration | `int` | 4 | Number which indicates the duration of movement |
-| unknown | `byte` | 1 | filled with 0 |
 
 ---
 

--- a/src/core/interface/networking/packets/packet/out/CharacterMoveOutPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/CharacterMoveOutPacket.ts
@@ -6,7 +6,7 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  * @type Out
  * @name CharacterMoveOutPacket
  * @header 0x03
- * @size 25
+ * @size 24
  * @description Is used to replicate the movement of a character (player, mobs) to other nearby players.
  * @fields
  *   - {byte} header 1 Packet header
@@ -18,7 +18,6 @@ import PacketOut from '@/core/interface/networking/packets/packet/out/PacketOut'
  *   - {int} positionY 4 Position Y of character in game
  *   - {int} time 4 unknown
  *   - {int} duration 4 Number which indicates the duration of movement
- *   - {byte} unknown 1 filled with 0
  */
 
 export default class CharacterMoveOutPacket extends PacketOut {
@@ -53,7 +52,7 @@ export default class CharacterMoveOutPacket extends PacketOut {
         super({
             header: PacketHeaderEnum.CHARACTER_MOVE_OUT,
             name: 'CharacterMoveOutPacket',
-            size: 25,
+            size: 24,
         });
         this.vid = vid;
         this.movementType = movementType;
@@ -74,7 +73,6 @@ export default class CharacterMoveOutPacket extends PacketOut {
         this.bufferWriter.writeUint32LE(this.positionY);
         this.bufferWriter.writeUint32LE(this.time);
         this.bufferWriter.writeUint32LE(this.duration);
-        this.bufferWriter.writeUint8(0);
 
         return this.bufferWriter.getBuffer();
     }

--- a/test/unit/core/interface/networking/packets/packets/out/CharacterMoveOutPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/out/CharacterMoveOutPacket.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import CharacterMoveOutPacket from '@/core/interface/networking/packets/packet/out/CharacterMoveOutPacket';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+/**
+ * The wire layout is TPacketGCMove (client Packet.h, #pragma pack(1)):
+ * header 1 + bFunc 1 + bArg 1 + bRot 1 + dwVID 4 + lX 4 + lY 4 + dwTime 4 +
+ * dwDuration 4 = 24 bytes. The client's RecvCharacterMovePacket consumes
+ * exactly sizeof(TPacketGCMove); the offsets below are that struct's offsets.
+ */
+describe('CharacterMoveOutPacket', () => {
+    const packet = () =>
+        new CharacterMoveOutPacket({
+            vid: 123456,
+            movementType: 5,
+            arg: 7,
+            rotation: 9,
+            positionX: 358400,
+            positionY: 153600,
+            time: 987654,
+            duration: 300,
+        });
+
+    it('initializes with the CHARACTER_MOVE_OUT header', () => {
+        expect(packet().getHeader()).to.equal(PacketHeaderEnum.CHARACTER_MOVE_OUT);
+        expect(packet().getName()).to.equal('CharacterMoveOutPacket');
+    });
+
+    it('packs to the client struct size of 24 bytes', () => {
+        expect(packet().pack()).to.have.lengthOf(24);
+    });
+
+    it('packs every field at the client struct offsets', () => {
+        const buffer = packet().pack();
+
+        expect(buffer.readUInt8(0), 'header').to.equal(PacketHeaderEnum.CHARACTER_MOVE_OUT);
+        expect(buffer.readUInt8(1), 'movementType').to.equal(5);
+        expect(buffer.readUInt8(2), 'arg').to.equal(7);
+        expect(buffer.readUInt8(3), 'rotation').to.equal(9);
+        expect(buffer.readUInt32LE(4), 'vid').to.equal(123456);
+        expect(buffer.readUInt32LE(8), 'positionX').to.equal(358400);
+        expect(buffer.readUInt32LE(12), 'positionY').to.equal(153600);
+        expect(buffer.readUInt32LE(16), 'time').to.equal(987654);
+        expect(buffer.readUInt32LE(20), 'duration').to.equal(300);
+    });
+
+    it('ends exactly at the duration field, with no trailing padding byte', () => {
+        const buffer = packet().pack();
+
+        expect(buffer.readUInt32LE(buffer.length - 4), 'last 4 bytes are the duration').to.equal(300);
+    });
+});


### PR DESCRIPTION
Fixes #222.

## What changes

`CharacterMoveOutPacket` (header `0x03`) declared 25 bytes and `pack()` ended with an explicit `writeUint8(0)` — a padding byte that exists on neither side of the wire. The client's `RecvCharacterMovePacket` consumes `sizeof(TPacketGCMove)` = **24** (`PythonNetworkStreamPhaseGameActor.cpp:349-356`), the compiled header map registers header 3 as 24-byte static, and the original server's `packet_move` (`packet.h:1331-1342`) is the identical 24-byte struct.

```diff
         this.bufferWriter.writeUint32LE(this.duration);
-        this.bufferWriter.writeUint8(0);
```

plus `size: 25` → `24`, the docblock (which listed the byte as `unknown 1 filled with 0`), and the regenerated `docs/packets.md`.

## Why it matters despite being one byte

This is the highest-frequency packet in the game — one per movement step per nearby viewer, players and monsters alike (`Player.updateOtherEntity`, called from `Area.onMonsterMove` / `Area.onCharacterMove`). Every step shipped a dead byte that only survives because the client's `CheckPacket` silently discards zero bytes before resolving the next header — the same leniency that masked #152, #219 and #223, exercised orders of magnitude more often.

## Verification

- `tsc --noEmit` clean; unit **749 passing / 0 failing** (745 on master + 4 new).
- New `CharacterMoveOutPacket.test.ts` reads every field back at the client struct's offsets and asserts the buffer ends exactly at the `duration` field. Fail-without-fix: exactly **2 of 4** cases fail (25 vs 24; trailing byte present); the offsets case passes both ways by design — the first 24 bytes were always correct, which is the control that the fix cannot move any field.
- Merge simulation: clean vs master; pairwise clean in both orders vs all 23 open PRs and vs #223/#224 (submitted together); the three composed on a throwaway branch give 753/0 + clean tsc.

## Note on scope

Pre-existing on master `9df6b684`; no open PR touches this packet. Same sweep as #223/#224: every out-packet's declared size compared against the client's compiled header-map table — 34 packets confirmed exact, these were the only static-size disagreements left after #152/#219.
