### PR TITLE
fix(net): send the empire packet at the client TPacketGCEmpire size of 2 bytes

### DIFF
--- a/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
+++ b/src/core/interface/networking/packets/packet/bidirectional/empire/EmpirePacket.ts
@@ -9,7 +9,7 @@ export default class EmpirePacket extends PacketBidirectional {
         super({
             header: PacketHeaderEnum.EMPIRE,
             name: 'EmpirePacket',
-            size: 3,
+            size: 2,
             validator: EmpirePacketValidator,
         });
         this.empireId = empireId;
@@ -19,13 +19,13 @@ export default class EmpirePacket extends PacketBidirectional {
         return this.empireId;
     }
 
-    // The declared size (3) sizes the outgoing buffer; inbound is header + empire.
+    // The declared size (2) sizes the outgoing buffer; inbound is header + empire + sequence.
     getFrameLength(): number | null {
         return 2 + this.getSequenceLength();
     }
 
     pack() {
-        this.bufferWriter.writeUint8(this.empireId).writeUint8(0);
+        this.bufferWriter.writeUint8(this.empireId);
         return this.bufferWriter.getBuffer();
     }
 

--- a/test/performance/gameFlow.ts
+++ b/test/performance/gameFlow.ts
@@ -192,7 +192,7 @@ export default class GameFlow {
         const authPacket = createAuthPacket(this.#user, this.#token);
         this.#client.sendMessage(authPacket);
 
-        const empirePacket = await this.#client.nextMessage(3);
+        const empirePacket = await this.#client.nextMessage(2);
         const empireId = unpackEmpirePacket(empirePacket).getEmpireId();
 
         assert.deepStrictEqual(empireId, 2);

--- a/test/support/AttackSession.ts
+++ b/test/support/AttackSession.ts
@@ -303,7 +303,7 @@ export class AttackSession {
             .writeUint32LE(0);
         this.sendSequenced(auth.getBuffer());
 
-        await this.next(3); // empire
+        await this.next(2); // empire
         await this.next(331); // player list
         const select = new BufferWriter(PacketHeaderEnum.SELECT_CHARACTER, 2);
         this.sendSequenced(select.writeUint8(0).getBuffer());

--- a/test/unit/core/interface/networking/packets/packets/bidirectional/empire/EmpirePacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/bidirectional/empire/EmpirePacket.test.ts
@@ -12,25 +12,30 @@ describe('EmpirePacket', function () {
     it('should initialize with correct header, name, and size', function () {
         expect(empirePacket.getHeader()).to.equal(PacketHeaderEnum.EMPIRE);
         expect(empirePacket.getName()).to.equal('EmpirePacket');
-        expect(empirePacket.getSize()).to.equal(3);
+        expect(empirePacket.getSize()).to.equal(2);
     });
 
     it('should initialize empireId correctly', function () {
         expect(empirePacket.getEmpireId()).to.equal(1);
     });
 
-    it('should pack data correctly', function () {
+    it('should pack to the client TPacketGCEmpire size of 2 bytes', function () {
         const packedBuffer = empirePacket.pack();
+        expect(packedBuffer).to.have.lengthOf(2);
+        expect(packedBuffer[0]).to.equal(PacketHeaderEnum.EMPIRE);
         expect(packedBuffer[1]).to.equal(1);
-        expect(packedBuffer[2]).to.equal(0);
     });
 
-    it('should unpack data correctly', function () {
+    it('should unpack a client frame (header + empire + sequence) correctly', function () {
         const buffer = Buffer.from([PacketHeaderEnum.EMPIRE, 1, 0]);
         const unpackedPacket = new EmpirePacket({
             empireId: 1,
         });
         unpackedPacket.unpack(buffer);
         expect(unpackedPacket.getEmpireId()).to.equal(1);
+    });
+
+    it('keeps the inbound frame length at header + empire + sequence, independent of the outbound size', function () {
+        expect(empirePacket.getFrameLength()).to.equal(3);
     });
 });


### PR DESCRIPTION
Fixes #223.

## What changes

The bidirectional `EmpirePacket` declared `size: 3` and packed an explicit zero after the empire byte, so the server→client direction put **3** bytes on the wire where the client's `__RecvEmpirePacket` consumes `sizeof(TPacketGCEmpire)` = **2** (`PythonNetworkStreamPhaseLogin.cpp:144-152`). The original sends 2 at all three of its `HEADER_GC_EMPIRE` send sites (`input_db.cpp:158-161, 165-168, 1283-1286`). Sent on every successful token login, right before `CharactersInfoPacket`.

```diff
-            size: 3,
+            size: 2,
...
-        this.bufferWriter.writeUint8(this.empireId).writeUint8(0);
+        this.bufferWriter.writeUint8(this.empireId);
```

## Why the inbound direction is untouched

The declared 3 came from the client→server frame (2-byte `TPacketCGEmpire` + the sequence byte), but inbound framing never reads the declared size: `getFrameLength()` already returns `2 + sequence length` independently. A new spec pins `getFrameLength() === 3` and passes on both sides of the fix — the control that only the outbound buffer shrinks.

One consumer moved in the same change: `test/performance/gameFlow.ts` consumed this packet with `nextMessage(3)` and would have eaten the first byte of the following 331-byte `CharactersInfoPacket`; now `nextMessage(2)`.

## Verification

- `tsc --noEmit` clean; unit **746 passing / 0 failing**.
- Fail-without-fix: exactly **2** failures (declared size, packed length); the frame-length spec passes both ways.
- Merge simulation: clean vs master; pairwise clean in both orders vs all 23 open PRs and vs #222/#224 (submitted together); the three composed give 753/0 + clean tsc.

## Note on scope

Pre-existing on master `9df6b684`; no open PR touches `EmpirePacket.ts` or `gameFlow.ts`. Found in the same declared-size-vs-client-table sweep as #222/#224.
