### PR TITLE
fix(net): send the channel count in ServerStatusPacket, not the byte length

### DIFF
--- a/docs/packets.md
+++ b/docs/packets.md
@@ -843,17 +843,17 @@
 
 **Size:** 9 bytes
 
-**Description:** Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the declared size of 9 only fits the default single channel.
+**Description:** Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the total size is 6 + 3 per channel (9 for the default single channel).
 
 **Fields:**
 
 | Name        | Type       | Size (bytes)   | Description               |
 |-------------|------------|----------------|---------------------------|
 | header | `byte` | 1 | Packet header |
-| size | `int` | 4 | Value produced by calcSize(), 6 + 3 per channel. See notes, the client reads this as a channel count |
+| count | `int` | 4 | Number of channel entries that follow, as the client's state checker loop expects |
 | port | `short` | 2 | Channel port. Repeated once per channel entry |
 | status | `byte` | 1 | Channel status flag, 1 means online. Repeated once per channel entry |
-| isSuccess | `byte` | 1 | Trailing success flag written after the channel entries. The client never reads it |
+| isSuccess | `byte` | 1 | Trailing success flag after the entries, as the original sends; the client discards it |
 
 ---
 

--- a/src/core/interface/networking/packets/packet/out/ServerStatusPacket.ts
+++ b/src/core/interface/networking/packets/packet/out/ServerStatusPacket.ts
@@ -15,13 +15,13 @@ type ServerStatusPacketParams = {
  * @name ServerStatusPacket
  * @header 0xd2
  * @size 9
- * @description Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the declared size of 9 only fits the default single channel.
+ * @description Answers the client channel status request; the 3 byte channel entry (port, status) repeats once per channel and the total size is 6 + 3 per channel (9 for the default single channel).
  * @fields
  *   - {byte} header 1 Packet header
- *   - {int} size 4 Value produced by calcSize(), 6 + 3 per channel. See notes, the client reads this as a channel count
+ *   - {int} count 4 Number of channel entries that follow, as the client's state checker loop expects
  *   - {short} port 2 Channel port. Repeated once per channel entry
  *   - {byte} status 1 Channel status flag, 1 means online. Repeated once per channel entry
- *   - {byte} isSuccess 1 Trailing success flag written after the channel entries. The client never reads it
+ *   - {byte} isSuccess 1 Trailing success flag after the entries, as the original sends; the client discards it
  */
 
 export default class ServerStatusPacket extends PacketOut {
@@ -43,18 +43,14 @@ export default class ServerStatusPacket extends PacketOut {
         super({
             header: PacketHeaderEnum.SERVER_STATUS,
             name: 'ServerStatusPacket',
-            size: 9, //fixed for now
+            size: 6 + status.length * 3,
         });
         this.status = status;
         this.isSuccess = isSuccess ? 1 : 0;
     }
 
-    calcSize() {
-        return 6 + this.status.length * 3;
-    }
-
     pack() {
-        this.bufferWriter.writeUint32LE(this.calcSize());
+        this.bufferWriter.writeUint32LE(this.status.length);
         this.status.forEach((s) => {
             this.bufferWriter.writeUint16LE(s.port).writeUint8(s.status);
         });

--- a/test/unit/core/interface/networking/packets/packets/out/ServerStatusPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/out/ServerStatusPacket.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import ServerStatusPacket from '@/core/interface/networking/packets/packet/out/ServerStatusPacket';
+import PacketHeaderEnum from '@/core/enum/PacketHeaderEnum';
+
+/**
+ * The client's CServerStateChecker::Update reads header (1), an int it uses
+ * as the CHANNEL COUNT (4), then count x TChannelStatus {short port; BYTE
+ * status} (3 each); the original server appends one success byte after the
+ * entries (input_db.cpp RespondChannelStatus). Total = 6 + 3 per channel.
+ */
+describe('ServerStatusPacket', () => {
+    it('initializes with the SERVER_STATUS header', () => {
+        const packet = new ServerStatusPacket();
+        expect(packet.getHeader()).to.equal(PacketHeaderEnum.SERVER_STATUS);
+        expect(packet.getName()).to.equal('ServerStatusPacket');
+    });
+
+    it('packs one channel into 9 bytes with the entry count in the count field', () => {
+        const buffer = new ServerStatusPacket({
+            status: [{ port: 13001, status: 1 }],
+            isSuccess: true,
+        }).pack();
+
+        expect(buffer).to.have.lengthOf(9);
+        expect(buffer.readUInt8(0), 'header').to.equal(PacketHeaderEnum.SERVER_STATUS);
+        expect(buffer.readUInt32LE(1), 'channel count, not byte size').to.equal(1);
+        expect(buffer.readUInt16LE(5), 'port').to.equal(13001);
+        expect(buffer.readUInt8(7), 'status').to.equal(1);
+        expect(buffer.readUInt8(8), 'success flag').to.equal(1);
+    });
+
+    it('packs two channels into 12 bytes so the client loop reads both and terminates', () => {
+        const buffer = new ServerStatusPacket({
+            status: [
+                { port: 13001, status: 1 },
+                { port: 13010, status: 0 },
+            ],
+            isSuccess: true,
+        }).pack();
+
+        expect(buffer).to.have.lengthOf(12);
+        expect(buffer.readUInt32LE(1), 'channel count').to.equal(2);
+        expect(buffer.readUInt16LE(5), 'first port').to.equal(13001);
+        expect(buffer.readUInt8(7), 'first status').to.equal(1);
+        expect(buffer.readUInt16LE(8), 'second port').to.equal(13010);
+        expect(buffer.readUInt8(10), 'second status').to.equal(0);
+        expect(buffer.readUInt8(11), 'success flag').to.equal(1);
+    });
+});


### PR DESCRIPTION
Fixes #224.

## What changes

`ServerStatusPacket` wrote `calcSize()` — its own byte length — into the 4-byte field the client's `CServerStateChecker::Update` consumes as the **number of channel entries** (`ServerStateChecker.cpp:86`, `for (int i = 0; i < nSize; i++)`). The original writes the entry count there, with the same trailing success byte we already send (`input_db.cpp:2631-2648`, `RespondChannelStatus`).

```diff
-    calcSize() {
-        return 6 + this.status.length * 3;
-    }
-
     pack() {
-        this.bufferWriter.writeUint32LE(this.calcSize());
+        this.bufferWriter.writeUint32LE(this.status.length);
```

and the declared size stops being hardcoded at 9: it is now `6 + status.length * 3`, so a multi-channel reply no longer overruns its own buffer (`pack()` previously threw past byte 9 on a two-channel list).

## What the wrong value did

With 9 in the count field the client parses entry 0 correctly — which is why the server list still shows CH1 NORM — then stalls its loop waiting for eight more entries that never arrive. `Initialize()`, the clean disconnect, is never reached; the state-checker socket lingers until our 60s keepalive kills it. For one channel the fixed packet is `d2 01 00 00 00 c9 32 01 01` — identical in shape to the original's reply.

This packet never travels through the client's main dispatcher: `HEADER_GC_RESPOND_CHANNELSTATUS` = 210 is deliberately absent from the `CheckPacket` map and handled only on the state checker's own raw socket, so the blast radius is exactly the server-select status display.

## Verification

- `tsc --noEmit` clean; unit **748 passing / 0 failing** (745 + 3 new).
- New spec packs one channel (9 bytes, count 1, entries and success byte at the client's offsets) and two channels (12 bytes, count 2). Fail-without-fix: exactly **2** failures — the count field reads 9, and the two-channel case throws instead of packing.
- Merge simulation: clean vs master; pairwise clean in both orders vs all 23 open PRs and vs #222/#223 (submitted together); the three composed give 753/0 + clean tsc.

## Note on scope

Pre-existing on master `9df6b684`; no open PR touches this packet. `calcSize()` had no other caller. Found in the same out-packet sweep as #222/#223.
