### PR TITLE
fix(auth): read the login password at its 17-byte struct width

### DIFF
--- a/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
+++ b/src/core/interface/networking/packets/packet/in/loginRequest/LoginRequestPacket.ts
@@ -34,7 +34,7 @@ export default class LoginRequestPacket extends PacketIn {
     unpack(buffer: Buffer) {
         this.bufferReader.setBuffer(buffer);
         this.username = this.bufferReader.readString(31);
-        this.password = this.bufferReader.readString(16);
+        this.password = this.bufferReader.readString(17);
         this.key = this.bufferReader.readUInt32LE();
         this.validate();
         return this;

--- a/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
+++ b/test/unit/core/interface/networking/packets/packets/in/login/LoginRequestPacket.test.ts
@@ -25,22 +25,40 @@ describe('LoginRequestPacket', function () {
         expect(loginRequestPacket.getKey()).to.equal(123456);
     });
 
-    it('should unpack data correctly', function () {
-        const buffer = Buffer.alloc(60);
-        buffer.writeUint8(0, 0);
-        buffer.write('testUser\0', 1, 'ascii');
-        buffer.write('testPass\0', 32, 'ascii');
-        buffer.writeUInt32LE(123456, 48);
+    // The wire layout is the client's TPacketCGLogin3 (#pragma pack(1)):
+    // header@0, login[31]@1, passwd[17]@32, adwClientKey[4]@49 = 65 bytes.
+    const clientFrame = ({ username, password, key }: { username: string; password: string; key: number }) => {
+        const buffer = Buffer.alloc(65);
+        buffer.writeUint8(PacketHeaderEnum.LOGIN_REQUEST, 0);
+        buffer.write(username, 1, 'ascii');
+        buffer.write(password, 32, 'ascii');
+        buffer.writeUInt32LE(key, 49);
+        buffer.writeUInt32LE(0xdeadbeef, 53);
+        buffer.writeUInt32LE(0xcafebabe, 57);
+        buffer.writeUInt32LE(0x12345678, 61);
+        return buffer;
+    };
 
-        const unpackedPacket = new LoginRequestPacket({
-            key: 0,
-            password: '',
-            username: '',
-        });
-        unpackedPacket.unpack(buffer);
+    const unpacked = (frame: Buffer) => new LoginRequestPacket({ key: 0, password: '', username: '' }).unpack(frame);
 
-        expect(unpackedPacket.getUsername()).to.equal('testUser');
-        expect(unpackedPacket.getPassword()).to.equal('testPass');
-        expect(unpackedPacket.getKey()).to.equal(123456);
+    it('should unpack the fields at the client struct offsets', function () {
+        const packet = unpacked(clientFrame({ username: 'testUser', password: 'testPass', key: 123456 }));
+
+        expect(packet.getUsername()).to.equal('testUser');
+        expect(packet.getPassword()).to.equal('testPass');
+        expect(packet.getKey()).to.equal(123456);
+    });
+
+    it('should read the client key from adwClientKey[0], not one byte early', function () {
+        const packet = unpacked(clientFrame({ username: 'user', password: 'pass', key: 0x11223344 }));
+
+        expect(packet.getKey()).to.equal(0x11223344);
+    });
+
+    it('should read a maximum-length 16 character password intact', function () {
+        const packet = unpacked(clientFrame({ username: 'user', password: 'abcdefghijklmnop', key: 7 }));
+
+        expect(packet.getPassword()).to.equal('abcdefghijklmnop');
+        expect(packet.getKey()).to.equal(7);
     });
 });


### PR DESCRIPTION
Fixes #229.

## What changes

One field width in `LoginRequestPacket.unpack`:

```diff
-        this.password = this.bufferReader.readString(16);
+        this.password = this.bufferReader.readString(17);
```

The client's `TPacketCGLogin3` declares `passwd[PASS_MAX_NUM + 1]` = 17 bytes at offset 32, so the key DWORD that follows was being read one byte early — `getKey()` returned `(adwClientKey[0] & 0xFFFFFF) << 8`, measured with the real class (`0x11223344` in, `0x22334400` out). With the fix the read lands on `adwClientKey[0]` exactly.

## What this does and does not change today

Nothing observable changes: the password parsed correctly at every legal length even before (the login UI caps at 16 chars and `AccountConnector.cpp` forces `pwd[16] = '\0'`, so the short read always captured the full string), and the garbled key is consumed by nobody — the handler reads only username/password and `LoginService` mints its own token. The fix is protocol fidelity plus removing the trap: the original XORs all four `adwClientKey` DWORDs into the handshake key material and matches them on reconnect (`input_auth.cpp`), so any future implementation of that binding would have inherited a value that fails every comparison, with no error near the cause.

The remaining three key DWORDs stay unread deliberately — nothing consumes them, and modelling them can come with the feature that needs them. The frame total was always right (65 + sequence = 66), so framing is untouched.

## The spec that pinned the bug

The old unpack case hand-built a frame with the key at offset 48 — the misread offset — and asserted the wrong value round-trips. Rewritten against the client struct offsets (`login[31]@1`, `passwd[17]@32`, `adwClientKey[4]@49`), with non-zero bytes in `adwClientKey[1..3]` so any off-by-one bleeds into an assertion, plus a 16-character-password case documenting the NUL guarantee the parser depends on.

## Verification

- `tsc --noEmit` clean; unit **747 / 0** (745 − 1 rewritten + 3 new); integration **42 / 0** (the live login path).
- Fail-without-fix: exactly **3** failures, all on the key assertion; the password assertions pass both ways.
- Merge simulation: clean vs master and pairwise clean in both orders against all 26 open PRs.

## Note on scope

This is the field-layout follow-up promised in the #214 retraction. The other 15 fixed-size in-packets were swept the same way and landed field-exact — this was the only layout defect. The unexplained residual byte behind the login frame (also from #214) remains unexplained; this change does not touch framing and cannot affect it.
