### PR TITLE
fix(world): drop the character from World.players when returning to select

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1224,7 +1224,7 @@ export default class Player extends Character {
         }
     }
 
-    private createTimedEvent(command: 'QUIT' | 'SELECT' | 'LOGOUT', prefix: string) {
+    private createTimedEvent(command: 'QUIT' | 'SELECT' | 'LOGOUT', prefix: string, onComplete?: () => void) {
         if (this.isEventTimerActive(TimedEventsEnum.COUNTDOWN)) {
             this.removeEventTimer(TimedEventsEnum.COUNTDOWN);
             this.chat({
@@ -1272,7 +1272,7 @@ export default class Player extends Character {
                             this.connection?.setState(ConnectionStateEnum.CLOSE);
                             break;
                         case 'SELECT':
-                            this.area?.despawn(this);
+                            onComplete?.();
                             this.connection?.setState(ConnectionStateEnum.SELECT);
                             break;
                     }
@@ -1300,8 +1300,8 @@ export default class Player extends Character {
         return this.createTimedEvent('LOGOUT', 'Logout');
     }
 
-    backToSelect() {
-        return this.createTimedEvent('SELECT', 'Back to Select');
+    backToSelect(onComplete?: () => void) {
+        return this.createTimedEvent('SELECT', 'Back to Select', onComplete);
     }
 
     chat({

--- a/src/game/domain/command/Commands.ts
+++ b/src/game/domain/command/Commands.ts
@@ -165,7 +165,7 @@ export default function createCommands() {
             SelectCommand.getName(),
             {
                 command: SelectCommand,
-                createHandler: () => new SelectCommandHandler(),
+                createHandler: (params) => new SelectCommandHandler(params),
             },
         ],
         [

--- a/src/game/domain/command/command/select/SelectCommandHandler.ts
+++ b/src/game/domain/command/command/select/SelectCommandHandler.ts
@@ -1,9 +1,26 @@
 import CommandHandler from '../../CommandHandler';
 import Player from '@/core/domain/entities/game/player/Player';
 import SelectCommand from './SelectCommand';
+import LeaveGameService from '@/game/domain/service/LeaveGameService';
+import Logger from '@/core/infra/logger/Logger';
 
 export default class SelectCommandHandler extends CommandHandler<SelectCommand> {
+    private readonly leaveGameService: LeaveGameService;
+    private readonly logger: Logger;
+
+    constructor({ leaveGameService, logger }: { leaveGameService: LeaveGameService; logger: Logger }) {
+        super();
+        this.leaveGameService = leaveGameService;
+        this.logger = logger;
+    }
+
     async execute(player: Player) {
-        player.backToSelect();
+        player.backToSelect(() => {
+            this.leaveGameService
+                .execute(player)
+                .catch((err) =>
+                    this.logger.error(`[SelectCommand] Error leaving the world for ${player.getName()}: ${err}`),
+                );
+        });
     }
 }

--- a/test/unit/core/domain/entities/game/player/PlayerBackToSelect.test.ts
+++ b/test/unit/core/domain/entities/game/player/PlayerBackToSelect.test.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Player from '@/core/domain/entities/game/player/Player';
+import LeaveGameService from '@/game/domain/service/LeaveGameService';
+import SelectCommandHandler from '@/game/domain/command/command/select/SelectCommandHandler';
+
+/**
+ * The SELECT countdown used to call area.despawn() directly, which never
+ * clears World.players — only World.despawn() does, and Player cannot reach
+ * World without a DI cycle. The teardown now comes from the command handler,
+ * so these specs drive the real handler and the real countdown together and
+ * assert the outcome: the world no longer knows the name.
+ */
+describe('Player.backToSelect (World.players cleanup)', () => {
+    const SECONDS_TO_LEAVE = 10;
+    const NAME = 'Test';
+
+    const build = () => {
+        const players = new Map<string, unknown>();
+
+        const world = {
+            despawn: (entity: { getName: () => string }) => players.delete(entity.getName()),
+            getPlayerByName: (n: string) => players.get(n),
+        };
+
+        const leaveGameService = new LeaveGameService({
+            world,
+            privateShopService: { closePrivateShop: sinon.stub().resolves() },
+        } as never);
+
+        const player: Record<string, unknown> = {
+            getName: () => NAME,
+            flushSave: sinon.stub().resolves(),
+            getCurrentPrivateShopOwner: () => null,
+            chat: () => {},
+            isPosOneOf: () => true,
+            isEventTimerActive: () => false,
+            removeEventTimer: () => {},
+            addEventTimer: ({ eventFunction }: { eventFunction: (count: number) => void }) => {
+                player.capturedEventFunction = eventFunction;
+            },
+            connection: { setState: sinon.stub() },
+        };
+
+        // Real backToSelect and its private createTimedEvent, so the spec drives
+        // the shipped countdown rather than a re-implementation of it.
+        const proto = Player.prototype as unknown as Record<string, unknown>;
+        player.backToSelect = proto.backToSelect;
+        player.createTimedEvent = proto.createTimedEvent;
+
+        players.set(NAME, player);
+
+        const handler = new SelectCommandHandler({
+            leaveGameService,
+            logger: { error: sinon.stub() },
+        } as never);
+
+        return { players, world, player, handler };
+    };
+
+    const tick = (player: Record<string, unknown>, count: number) =>
+        (player.capturedEventFunction as (n: number) => void)(count);
+
+    it('removes the character from World.players when the countdown fires', async () => {
+        const { world, player, handler } = build();
+
+        await handler.execute(player as unknown as Player);
+        expect(world.getPlayerByName(NAME), 'registered before the countdown').to.equal(player);
+
+        tick(player, SECONDS_TO_LEAVE);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(world.getPlayerByName(NAME), 'the world must forget a character that left for select').to.equal(
+            undefined,
+        );
+    });
+
+    it('flushes the save on the way out, which the direct area despawn skipped', async () => {
+        const { player, handler } = build();
+
+        await handler.execute(player as unknown as Player);
+        tick(player, SECONDS_TO_LEAVE);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect((player.flushSave as sinon.SinonStub).calledOnce, 'flushSave runs before the despawn').to.equal(true);
+    });
+
+    it('still switches the connection to the select phase', async () => {
+        const { player, handler } = build();
+
+        await handler.execute(player as unknown as Player);
+        tick(player, SECONDS_TO_LEAVE);
+
+        const setState = (player.connection as { setState: sinon.SinonStub }).setState;
+        expect(setState.calledOnce, 'the phase switch must not regress').to.equal(true);
+    });
+
+    it('does not leave the world before the countdown reaches zero', async () => {
+        const { world, player, handler } = build();
+
+        await handler.execute(player as unknown as Player);
+        tick(player, 1);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(world.getPlayerByName(NAME), 'still in the world mid-countdown').to.equal(player);
+    });
+});


### PR DESCRIPTION
Fixes #235.

## What changes

The `/phase_select` countdown called `area.despawn()` directly. Only `World.despawn()` deletes the `World.players` entry, so the character stayed registered as online after leaving the world — `getPlayerByName` kept resolving a despawned instance for `/list`, `/goto` and the horse commands, and the entry leaked permanently once the account selected a different character. The SELECT path also skipped the private-shop close and the `flushSave` every other exit route performs, because `LeaveGameService` never ran for it.

This half was described in #149, but the PR that closed it — **#150** (`f253cacc`) — is the commit that introduced the bare `area.despawn()` line, and the `fix #149` keyword closed the issue with this half still live. Owning that plainly.

## Why it is not a one-line change

Injecting `LeaveGameService` into `Player`, the way `SaveCharacterService` already is, does not work: `EntityManager` then depends on it, which depends on `World`, which depends back on `EntityManager`. awilix rejects it at boot with `Could not resolve 'world'. Cyclic dependencies detected` and 25 integration specs fail. I implemented that first and measured it — the cycle is very likely why the direct `area.despawn()` was reached for originally.

So the dependency is inverted rather than added. `createTimedEvent`/`backToSelect` take an optional `onComplete`, and `SelectCommandHandler` — already in the layer where the service resolves — supplies the call:

```ts
async execute(player: Player) {
    player.backToSelect(() => {
        this.leaveGameService
            .execute(player)
            .catch((err) => this.logger.error(`[SelectCommand] Error leaving the world for ${player.getName()}: ${err}`));
    });
}
```

`Player` gains no new dependency, and SELECT now performs the same teardown as logout. `QUIT` and `LOGOUT` are untouched — the parameter is optional and they pass nothing.

## Verification

- `tsc --noEmit` clean; unit **749 / 0**; integration **42 / 0** — the last one matters here, since it is what caught the DI cycle in the rejected approach.
- Fail-without-fix: exactly **2 of 4** specs fail (the world still resolves the name; `flushSave` never runs). The phase-switch and mid-countdown cases pass both ways as controls, so the specs cannot pass by accident.
- The specs drive the **real** `SelectCommandHandler` and the **real** countdown together, and assert the outcome — that the world no longer resolves the name — rather than that a method was called.
- Merge simulation: clean vs master `64458654`, and pairwise clean in both orders against all 27 open PRs.

## Note on scope

Separate from #151, which is the stock client not visually leaving the world on `/phase_select`; that stays open and is unaffected. Whether `QUIT` should also route through `LeaveGameService` is a question I deliberately left alone — it currently relies on the client dropping the connection, which is a different path with its own behaviour.
