### PR TITLE
fix(command): make the horse commands act on the caller only

### DIFF
--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -2248,6 +2248,8 @@ export default class Player extends Character {
     }
 
     toggleRiding() {
+        if (this.isDead() || this.isAffectByFlag(AffectBitsTypeEnum.STUN)) return;
+
         if (this.isHorseRiding()) {
             this.stopRiding();
         } else {

--- a/src/game/domain/command/Commands.ts
+++ b/src/game/domain/command/Commands.ts
@@ -214,7 +214,7 @@ export default function createCommands() {
             UserHorseRideCommand.getName(),
             {
                 command: UserHorseRideCommand,
-                createHandler: (params) => new UserHorseRideCommandHandler(params),
+                createHandler: () => new UserHorseRideCommandHandler(),
             },
         ],
         [

--- a/src/game/domain/command/command/userHorseBack/UserHorseBackCommand.ts
+++ b/src/game/domain/command/command/userHorseBack/UserHorseBackCommand.ts
@@ -1,20 +1,15 @@
 import Command from '../../Command';
-import UserHorseBackCommandValidator from './UserHorseBackCommandValidator';
 
 export default class UserHorseBackCommand extends Command {
-    constructor({ args }: { args: Array<string> }) {
-        super({ args, validator: UserHorseBackCommandValidator });
-    }
-
     static getName() {
         return '/user_horse_back';
     }
 
     static getDescription() {
-        return 'Dismount a player (or yourself) from their horse';
+        return 'Send your horse away';
     }
 
     static getExample() {
-        return '/user_horse_back <targetName>';
+        return '/user_horse_back';
     }
 }

--- a/src/game/domain/command/command/userHorseBack/UserHorseBackCommandHandler.ts
+++ b/src/game/domain/command/command/userHorseBack/UserHorseBackCommandHandler.ts
@@ -1,41 +1,24 @@
 import CommandHandler from '../../CommandHandler';
 import UserHorseBackCommand from './UserHorseBackCommand';
 import Player from '@/core/domain/entities/game/player/Player';
-import World from '@/core/domain/World';
 import Logger from '@/core/infra/logger/Logger';
 import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 
 export default class UserHorseBackCommandHandler extends CommandHandler<UserHorseBackCommand> {
     private readonly logger: Logger;
-    private readonly world: World;
 
-    constructor({ logger, world }: { logger: Logger; world: World }) {
+    constructor({ logger }: { logger: Logger }) {
         super();
         this.logger = logger;
-        this.world = world;
     }
 
-    async execute(player: Player, command: UserHorseBackCommand) {
-        if (!command.isValid()) {
-            player.sendCommandErrors(command.errors());
-            return;
-        }
-
-        const [targetName] = command.getArgs();
-        const target = targetName ? this.world.getPlayerByName(targetName) : player;
-
-        if (!target) {
-            player.chat({ messageType: ChatMessageTypeEnum.INFO, message: `Player '${targetName}' not found.` });
-            return;
-        }
-
-        // Send away the horse entity (only works when NOT riding)
-        if (!target.sendHorseAway()) {
+    async execute(player: Player) {
+        if (!player.sendHorseAway()) {
             player.chat({
                 messageType: ChatMessageTypeEnum.INFO,
                 message: `Cannot send horse away. Either player is currently riding or no horse entity is active.`,
             });
-            this.logger.debug(`[UserHorseBackCommand] sendHorseAway had no effect for ${target.getName()}`);
+            this.logger.debug(`[UserHorseBackCommand] sendHorseAway had no effect for ${player.getName()}`);
         }
     }
 }

--- a/src/game/domain/command/command/userHorseBack/UserHorseBackCommandValidator.ts
+++ b/src/game/domain/command/command/userHorseBack/UserHorseBackCommandValidator.ts
@@ -1,7 +1,0 @@
-import CommandValidator from '../../CommandValidator';
-
-export default class UserHorseBackCommandValidator extends CommandValidator {
-    build() {
-        this.createRule(this.command.getArgs()[0], 'targetName').isOptional().isString().build();
-    }
-}

--- a/src/game/domain/command/command/userHorseRide/UserHorseRideCommand.ts
+++ b/src/game/domain/command/command/userHorseRide/UserHorseRideCommand.ts
@@ -1,20 +1,15 @@
 import Command from '../../Command';
-import UserHorseRideCommandValidator from './UserHorseRideCommandValidator';
 
 export default class UserHorseRideCommand extends Command {
-    constructor({ args }: { args: Array<string> }) {
-        super({ args, validator: UserHorseRideCommandValidator });
-    }
-
     static getName() {
         return '/user_horse_ride';
     }
 
     static getDescription() {
-        return 'Make a player (or yourself) mount their horse';
+        return 'Mount or dismount your horse';
     }
 
     static getExample() {
-        return '/user_horse_ride <targetName>';
+        return '/user_horse_ride';
     }
 }

--- a/src/game/domain/command/command/userHorseRide/UserHorseRideCommandHandler.ts
+++ b/src/game/domain/command/command/userHorseRide/UserHorseRideCommandHandler.ts
@@ -1,34 +1,9 @@
 import CommandHandler from '../../CommandHandler';
 import UserHorseRideCommand from './UserHorseRideCommand';
 import Player from '@/core/domain/entities/game/player/Player';
-import World from '@/core/domain/World';
-import Logger from '@/core/infra/logger/Logger';
-import { ChatMessageTypeEnum } from '@/core/enum/ChatMessageTypeEnum';
 
 export default class UserHorseRideCommandHandler extends CommandHandler<UserHorseRideCommand> {
-    private readonly logger: Logger;
-    private readonly world: World;
-
-    constructor({ logger, world }: { logger: Logger; world: World }) {
-        super();
-        this.logger = logger;
-        this.world = world;
-    }
-
-    async execute(player: Player, command: UserHorseRideCommand) {
-        if (!command.isValid()) {
-            player.sendCommandErrors(command.errors());
-            return;
-        }
-
-        const [targetName] = command.getArgs();
-        const target = targetName ? this.world.getPlayerByName(targetName) : player;
-
-        if (!target) {
-            player.chat({ messageType: ChatMessageTypeEnum.INFO, message: `Player '${targetName}' not found.` });
-            return;
-        }
-
-        target.toggleRiding();
+    async execute(player: Player) {
+        player.toggleRiding();
     }
 }

--- a/src/game/domain/command/command/userHorseRide/UserHorseRideCommandValidator.ts
+++ b/src/game/domain/command/command/userHorseRide/UserHorseRideCommandValidator.ts
@@ -1,7 +1,0 @@
-import CommandValidator from '../../CommandValidator';
-
-export default class UserHorseRideCommandValidator extends CommandValidator {
-    build() {
-        this.createRule(this.command.getArgs()[0], 'targetName').isOptional().isString().build();
-    }
-}

--- a/test/unit/game/domain/command/HorseCommandsSelfOnly.test.ts
+++ b/test/unit/game/domain/command/HorseCommandsSelfOnly.test.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import UserHorseRideCommandHandler from '@/game/domain/command/command/userHorseRide/UserHorseRideCommandHandler';
+import UserHorseBackCommandHandler from '@/game/domain/command/command/userHorseBack/UserHorseBackCommandHandler';
+import UserHorseRideCommand from '@/game/domain/command/command/userHorseRide/UserHorseRideCommand';
+import UserHorseBackCommand from '@/game/domain/command/command/userHorseBack/UserHorseBackCommand';
+import Player from '@/core/domain/entities/game/player/Player';
+import { AffectBitsTypeEnum } from '@/core/enum/AffectBitsTypeEnum';
+
+/**
+ * The original registers both commands as GM_PLAYER and each handler acts on
+ * `ch` alone — do_user_horse_ride / do_user_horse_back take no argument at all
+ * (cmd.cpp:463-464, cmd_general.cpp:42,73).
+ */
+const createPlayer = (overrides: Record<string, unknown> = {}) =>
+    ({
+        getName: () => 'Victim',
+        toggleRiding: sinon.spy(),
+        sendHorseAway: sinon.stub().returns(true),
+        chat: sinon.spy(),
+        sendCommandErrors: sinon.spy(),
+        ...overrides,
+    }) as unknown as Player;
+
+describe('horse commands act on the caller only (issue #234)', () => {
+    describe('/user_horse_ride', () => {
+        it('mounts the caller when a target name is supplied', async () => {
+            const caller = createPlayer({ getName: () => 'Attacker' });
+            const handler = new UserHorseRideCommandHandler();
+
+            await handler.execute(caller, new UserHorseRideCommand({ args: ['Victim'] }));
+
+            expect((caller.toggleRiding as sinon.SinonSpy).calledOnce, 'the caller is the only target').to.equal(true);
+        });
+
+        it('exposes no target in its usage, so the argument cannot be advertised', () => {
+            expect(UserHorseRideCommand.getExample()).to.equal('/user_horse_ride');
+        });
+    });
+
+    describe('/user_horse_back', () => {
+        it('sends the caller own horse away when a target name is supplied', async () => {
+            const caller = createPlayer({ getName: () => 'Attacker' });
+            const handler = new UserHorseBackCommandHandler({ logger: { debug: sinon.spy() } as never });
+
+            await handler.execute(caller, new UserHorseBackCommand({ args: ['Victim'] }));
+
+            expect((caller.sendHorseAway as sinon.SinonStub).calledOnce, 'the caller is the only target').to.equal(
+                true,
+            );
+        });
+    });
+});
+
+describe('mounting is refused while dead or stunned (issue #234)', () => {
+    const buildPlayer = (state: { dead: boolean; stunned: boolean }) => {
+        const player = Object.create(Player.prototype);
+
+        player.isDead = () => state.dead;
+        player.isAffectByFlag = (flag: AffectBitsTypeEnum) => flag === AffectBitsTypeEnum.STUN && state.stunned;
+        player.isHorseRiding = () => false;
+        player.startRiding = sinon.spy();
+        player.stopRiding = sinon.spy();
+
+        return player;
+    };
+
+    it('refuses to mount a dead player, as do_ride does', () => {
+        const player = buildPlayer({ dead: true, stunned: false });
+
+        player.toggleRiding();
+
+        expect(player.startRiding.called, 'a corpse must not mount').to.equal(false);
+    });
+
+    it('refuses to mount a stunned player, as do_ride does', () => {
+        const player = buildPlayer({ dead: false, stunned: true });
+
+        player.toggleRiding();
+
+        expect(player.startRiding.called, 'a stunned player must not mount').to.equal(false);
+    });
+
+    it('still mounts a healthy player', () => {
+        const player = buildPlayer({ dead: false, stunned: false });
+
+        player.toggleRiding();
+
+        expect(player.startRiding.calledOnce, 'the ordinary path must survive the guard').to.equal(true);
+    });
+});


### PR DESCRIPTION
Fixes #234.

## What was wrong

`/user_horse_ride` and `/user_horse_back` accepted a target name and resolved it with `world.getPlayerByName`, so **any player could mount, dismount or despawn any other online player's horse**, from anywhere, knowing only their name.

The original takes no argument at all. Both are registered as `GM_PLAYER` (`cmd.cpp:463-464`) — legitimately available to everyone — and `do_user_horse_ride` / `do_user_horse_back` operate on `ch` alone (`cmd_general.cpp:42,73`).

That is also why **#64 does not cover this**: no staff gate would be correct, because these commands are meant to be public. The argument itself is the defect.

## The change

```diff
-        const [targetName] = command.getArgs();
-        const target = targetName ? this.world.getPlayerByName(targetName) : player;
-        ...
-        target.toggleRiding();
+        player.toggleRiding();
```

With the target gone the validators had nothing left to validate, so they follow the argument out rather than staying registered and inert — the shape the repo already uses for `/logout` and the other argument-less commands, and one instance fewer of the dead-validator pattern I reported in #239.

## The liveness guard, and where I put it

`do_ride` opens with `if (ch->IsDead() || ch->IsStun()) return;` and we had no equivalent, so a corpse could mount and stay flagged as riding through respawn. It now sits in `Player.toggleRiding`, the exact funnel for the three mount commands.

**Deliberately not in `PlayerHorse.startRiding`**, even though that would cover more callers: `restoreRidingState` remounts on login, and the original does not gate its equivalent (`CHorseRider::EnterHorse`). Guarding there would change a path the original leaves open, which is a bigger behaviour change than the bug being fixed. Say the word if you would rather have the wider guard and I will move it.

## Verification

- `tsc --noEmit` clean; unit **751 / 0**; integration **42 / 0**.
- Fail-without-fix: **2** failures with the guard reverted, and **2** more with master's arbitrary-target handler restored — both halves are load-bearing.
- The healthy-player case passes both ways as a control, so the guard cannot have closed the ordinary mount path.
- The specs quote the original's registration and handlers, so the intent is checkable rather than asserted.
- Merge simulation: clean vs master `64458654`, pairwise clean against all 30 open PRs.

## Note on scope

Pre-existing on master; no open PR touches these files. `/horse_ride` and `/ride` already acted on the caller and are unchanged apart from inheriting the guard through `toggleRiding`. The item and stable-master mount paths are untouched, matching the original, which guards the commands rather than the mount routine.
