### PR TITLE
fix(battle): refuse melee with a non-weapon and stop reading its proto values as damage

### DIFF
--- a/src/core/domain/entities/game/inventory/Inventory.ts
+++ b/src/core/domain/entities/game/inventory/Inventory.ts
@@ -4,12 +4,14 @@ import Equipment from '@/core/domain/entities/game/inventory/Equipment';
 import Item from '@/core/domain/entities/game/item/Item';
 import { WindowTypeEnum } from '@/core/enum/WindowTypeEnum';
 import { ItemEquipmentSlotEnum } from '@/core/enum/ItemEquipmentSlotEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
 import ItemEquippedEvent from '@/core/domain/entities/game/inventory/events/ItemEquippedEvent';
 import ItemUnequippedEvent from '@/core/domain/entities/game/inventory/events/ItemUnequippedEvent';
 import { GameConfig } from '@/game/infra/config/GameConfig';
 
 const DEFAULT_INVENTORY_WIDTH = 5;
 const DEFAULT_INVENTORY_HEIGHT = 9;
+const NON_WEAPON_DAMAGE_MAX = 1;
 
 export default class Inventory {
     private readonly pages: Array<Page> = [];
@@ -211,6 +213,19 @@ export default class Inventory {
         ];
     }
 
+    private getWeaponPhysicalDamage() {
+        const weapon = this.equipment.getWeapon();
+
+        if (!weapon || weapon.getType() === ItemTypeEnum.ITEM_ROD || weapon.getType() === ItemTypeEnum.ITEM_PICK) {
+            return { min: 0, max: NON_WEAPON_DAMAGE_MAX };
+        }
+
+        return {
+            min: weapon.getValues()[3] ?? 0,
+            max: weapon.getValues()[4] ?? 0,
+        };
+    }
+
     getWeaponValues() {
         return {
             magic: {
@@ -219,8 +234,7 @@ export default class Inventory {
                 bonus: this.equipment.getWeapon()?.getValues()[5] ?? 0,
             },
             physic: {
-                min: this.equipment.getWeapon()?.getValues()[3] ?? 0,
-                max: this.equipment.getWeapon()?.getValues()[4] ?? 0,
+                ...this.getWeaponPhysicalDamage(),
                 bonus: this.equipment.getWeapon()?.getValues()[5] ?? 0,
             },
         };

--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy.ts
@@ -177,7 +177,12 @@ export default class PlayerBattleAgainstMobStrategy extends PlayerBattleStrategy
 
         const weapon = this.attacker.getWeapon();
 
-        if (weapon?.getType() === ItemTypeEnum.ITEM_WEAPON) {
+        if (weapon && weapon.getType() !== ItemTypeEnum.ITEM_WEAPON) {
+            this.logger.info(`[PlayerBattle] Melee attack cant handle item type: ${weapon.getType()}.`);
+            return;
+        }
+
+        if (weapon) {
             switch (weapon.getSubType()) {
                 case ItemSubTypeEnum.WEAPON_SWORD:
                 case ItemSubTypeEnum.WEAPON_DAGGER:

--- a/test/unit/core/domain/entities/game/player/delegate/PlayerNonWeaponAttack.test.ts
+++ b/test/unit/core/domain/entities/game/player/delegate/PlayerNonWeaponAttack.test.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import PlayerBattleAgainstMobStrategy from '@/core/domain/entities/game/player/delegate/battle/PlayerBattleAgainstMobStrategy';
+import { AttackTypeEnum } from '@/core/enum/AttackTypeEnum';
+import { BattleTypeEnum } from '@/core/enum/BattleTypeEnum';
+import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
+import { ItemSubTypeEnum } from '@/core/enum/ItemSubTypeEnum';
+import Player from '@/core/domain/entities/game/player/Player';
+import Monster from '@/core/domain/entities/game/mob/Monster';
+
+const FISHING_POLE_VALUES = [10, 5, 10, 100, 27400, 0];
+const SWORD_VALUES = [0, 15, 19, 13, 15, 0];
+
+const createWeapon = (type: ItemTypeEnum, subType: number, values: Array<number>) => ({
+    getType: () => type,
+    getSubType: () => subType,
+    getValues: () => values,
+});
+
+const createVictim = (taken: Array<number>) => ({
+    getPositionX: () => 0,
+    getPositionY: () => 0,
+    getBattleType: () => BattleTypeEnum.MELEE,
+    getAttackRange: () => 100,
+    getAttackRating: () => 0,
+    getDefense: () => 0,
+    getVirtualId: () => 1,
+    getPoint: () => 0,
+    getResist: () => 0,
+    isRaceByFlag: () => false,
+    isAffectByFlag: () => false,
+    getDrainSp: () => 0,
+    isStoneSkinner: () => false,
+    takeDamage: (_attacker: unknown, damage: number) => taken.push(damage),
+});
+
+const createAttacker = (weapon: unknown) => ({
+    getPositionX: () => 0,
+    getPositionY: () => 0,
+    getWeapon: () => weapon,
+    getAttackRating: () => 0,
+    getAttack: () => 1000,
+    getPoint: () => 0,
+    debugChat: () => {},
+    sendDamageCaused: () => {},
+});
+
+const attack = (weapon: unknown) => {
+    const taken: Array<number> = [];
+    const logger = { info: sinon.stub(), error: sinon.stub() };
+    const strategy = new PlayerBattleAgainstMobStrategy(createAttacker(weapon) as unknown as Player, logger as never);
+
+    strategy.execute(AttackTypeEnum.NORMAL, createVictim(taken) as unknown as Monster);
+
+    return { taken, logger };
+};
+
+describe('player melee attack with a non-weapon in the weapon slot', () => {
+    it('refuses to attack while holding a fishing rod', () => {
+        const rod = createWeapon(ItemTypeEnum.ITEM_ROD, 0, FISHING_POLE_VALUES);
+
+        const { taken, logger } = attack(rod);
+
+        expect(taken, 'a rod must not damage the victim').to.deep.equal([]);
+        expect(logger.info.calledWithMatch(/cant handle item type/), 'and the refusal is logged').to.equal(true);
+    });
+
+    it('refuses to attack while holding a pickaxe', () => {
+        const pick = createWeapon(ItemTypeEnum.ITEM_PICK, 0, [10, 1, 6000, 100, 29101, 0]);
+
+        const { taken } = attack(pick);
+
+        expect(taken, 'a pickaxe must not damage the victim').to.deep.equal([]);
+    });
+
+    it('still attacks with a real weapon', () => {
+        const sword = createWeapon(ItemTypeEnum.ITEM_WEAPON, ItemSubTypeEnum.WEAPON_SWORD, SWORD_VALUES);
+
+        const { taken } = attack(sword);
+
+        expect(taken.length, 'a sword still lands its hit').to.equal(1);
+        expect(taken[0], 'and deals damage').to.be.greaterThan(0);
+    });
+
+    it('still attacks bare handed', () => {
+        const { taken } = attack(null);
+
+        expect(taken.length, 'an empty weapon slot still lands its hit').to.equal(1);
+    });
+
+    it('still refuses a bow, as before', () => {
+        const bow = createWeapon(ItemTypeEnum.ITEM_WEAPON, ItemSubTypeEnum.WEAPON_BOW, SWORD_VALUES);
+
+        const { taken, logger } = attack(bow);
+
+        expect(taken, 'a bow is not a melee weapon').to.deep.equal([]);
+        expect(logger.info.calledWithMatch(/bow attacks/), 'and keeps its own message').to.equal(true);
+    });
+});

--- a/test/unit/core/domain/entities/game/player/delegate/PlayerNonWeaponAttack.test.ts
+++ b/test/unit/core/domain/entities/game/player/delegate/PlayerNonWeaponAttack.test.ts
@@ -41,6 +41,7 @@ const createAttacker = (weapon: unknown) => ({
     getAttackRating: () => 0,
     getAttack: () => 1000,
     getPoint: () => 0,
+    getLevel: () => 1,
     debugChat: () => {},
     sendDamageCaused: () => {},
 });

--- a/test/unit/core/domain/inventory/Inventory.test.ts
+++ b/test/unit/core/domain/inventory/Inventory.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import BitFlag from '@/core/util/BitFlag';
+import { ItemEquipmentSlotEnum } from '@/core/enum/ItemEquipmentSlotEnum';
 import Item from '@/core/domain/entities/game/item/Item';
 import Inventory from '@/core/domain/entities/game/inventory/Inventory';
 import { ItemTypeEnum } from '@/core/enum/ItemTypeEnum';
@@ -54,6 +56,16 @@ function createItem(id: number, dbId: number, size: number = 1) {
 
 function createInventory() {
     return new Inventory({ config: { INVENTORY_PAGES: 2 } as GameConfig, ownerId: 1 });
+}
+
+function equipWeapon(inventory: Inventory, type: ItemTypeEnum, values: Array<number>) {
+    const weapon = createItem(1, 100);
+    sinon.stub(weapon, 'getType').returns(type);
+    sinon.stub(weapon, 'getValues').returns(values);
+
+    inventory.addItemAt(weapon, inventory.size() + ItemEquipmentSlotEnum.WEAPON);
+
+    return weapon;
 }
 
 describe('Inventory', () => {
@@ -162,5 +174,29 @@ describe('Inventory', () => {
 
         expect(inventory.getItem(0)).to.equal(null);
         expect(inventory.haveAvailablePosition(0, 2)).to.equal(true);
+    });
+
+    it('should read the physical damage of a real weapon from its proto values', () => {
+        const inventory = createInventory();
+        const sword = equipWeapon(inventory, ItemTypeEnum.ITEM_WEAPON, [0, 15, 19, 13, 15, 0]);
+
+        expect(sword.getPosition()).to.equal(inventory.size() + ItemEquipmentSlotEnum.WEAPON);
+        expect(inventory.getWeaponValues().physic).to.deep.equal({ min: 13, max: 15, bonus: 0 });
+    });
+
+    it('should not read a fishing rod value3/value4 as physical damage', () => {
+        const inventory = createInventory();
+
+        equipWeapon(inventory, ItemTypeEnum.ITEM_ROD, [10, 5, 10, 100, 27400, 0]);
+
+        expect(inventory.getWeaponValues().physic).to.deep.equal({ min: 0, max: 1, bonus: 0 });
+    });
+
+    it('should not read a pickaxe value3/value4 as physical damage', () => {
+        const inventory = createInventory();
+
+        equipWeapon(inventory, ItemTypeEnum.ITEM_PICK, [10, 1, 6000, 100, 29101, 0]);
+
+        expect(inventory.getWeaponValues().physic).to.deep.equal({ min: 0, max: 1, bonus: 0 });
     });
 });


### PR DESCRIPTION
Fixes #256.

A fishing rod or a pickaxe can be equipped in the weapon slot — both carry `WEAR_WEAPON`, no anti-flags and only a `LIMIT LEVEL 30`, and Fishing Pole+1 (vnum 27400) is sold for 5 000 gold by the live NPC shops 9005/9006. Two independent gaps then let it act as an enormous weapon.

## What the code did

**1. The rod's `value3`/`value4` were read as its damage range.** `Inventory.getWeaponValues()` read slots 3 and 4 with no item-type check, and `calcAttack` folds that roll into the attack grade:

```ts
attack += MathUtil.getRandomInt(physic.min, physic.max) * 2;   // PlayerPoints.ts:1047
```

On a rod those slots are not damage fields — Fishing Pole+1 holds `100` and `27400`, the second being its *downgrade vnum*. So equipping one added **+200 … +54 800** attack grade, where a Sword+0 adds ~28. Pickaxe+0 (29101) is the same shape.

**2. Melee was not refused for a non-weapon.** The subtype `switch`, whose `default` branch is what rejects an unusable weapon, sat *inside* the type test:

```ts
if (weapon?.getType() === ItemTypeEnum.ITEM_WEAPON) {
    switch (weapon.getSubType()) { ...  default: return; }
}
```

An `ITEM_ROD` failed the outer `if`, so the whole switch — including its `return` — was skipped and the hit landed.

## What the original does

It guards on both sides, independently:

- `Item_GetDamage` (`battle.cpp:358-378`) sets `*pdamMin = 0; *pdamMax = 1;` and then `case ITEM_ROD: case ITEM_PICK: return;` **before** it ever reads `GetValue(3)`/`GetValue(4)`. That is the `MONKEY_ROD_ATTACK_BUG_FIX` guard, and it also covers the polymorph branch, which bypasses the check below.
- `CalcMeleeDamage` returns 0 for a non-weapon: `if (pWeapon->GetType() != ITEM_WEAPON) return 0;` (`battle.cpp:387-388`), and `battle_hit` then stops at `if (iDam <= 0) return (BATTLE_DAMAGE);` (`:644-645`), before any attack affect.

This PR ports both.

## Choices worth flagging

- **The rod's range becomes `{0, 1}`, not `{0, 0}`** — that is literally what `Item_GetDamage` leaves in place for a rod or pick. In practice it is 0 or 2 attack grade of jitter. I preferred the faithful value over a clean zero; say the word and I will make it `{0, 0}`.
- **The same `{0, 1}` now also applies to an empty weapon slot**, where the code previously used `0`/`0`. Again this is what the original returns for a null item (the early `if (!pkItem) return;` sits after the defaults are set). It is the one behaviour change here that goes slightly beyond the reported bug; happy to keep bare hands at `0`/`0` if you would rather scope this strictly.
- **The guard lives in `getWeaponValues`, not in `calcAttack`**, so the magic branch and any future consumer inherit it.
- **Magic values are untouched.** A rod's `value1`/`value2` are 5 and 10, comparable to a sword's, so there is no exploit there — but note the original builds `POINT_MAGIC_ATT_GRADE` as `level * 2 + IQ * 2 + bonus` (`char.cpp:2186`) with **no** weapon roll at all. That divergence belongs with the frozen-roll issue, not here.

## Verified

- `npx tsc -p tsconfig.build.json --noEmit` clean, `eslint` and `prettier --check` clean on the four files.
- Unit **806 passing, 0 failing** (master alone is 798).
- **Fail-without-fix**, both ways round: reverting both halves fails exactly the 4 new specs (2 attack, 2 inventory); reverting *only* the melee guard still fails the 2 attack specs, which is the point — the gaps are independent and either one alone leaves the item usable.
- The three regression specs (a sword still lands its hit, bare hands still attack, a bow is still refused with its own message) pass on master too, so they are guards rather than fixture.
- `merge-tree` clean against `1cbaf1ed`; pairwise clean after #180 (shares `Inventory.ts`) and after #169 (shares `PlayerBattleAgainstMobStrategy.ts`).

## Correction after a stock-client run (2026-08-13)

The issue and the first version of this body called this a trivially reachable damage exploit. **On a stock client it is not**, and the overstatement was mine — I have posted the same correction on #256.

Driving the real client with all 19 open PRs composed: equipping the rod and clicking a monster runs the client's *fishing* action, which answers "you cannot fish here" and sends nothing — the server log has zero `AttackPacketHandler` entries for that whole window, so `meleeAttack` is never entered. Pickaxes are refused even earlier, in `CInstanceBase::CanAttack` (`InstanceBase.cpp:1090-1101`): `if (IsHoldingPickAxe()) return false;`, and `IsHoldingPickAxe()` (`:930-935`) tests `PART_WEAPON` against 29101-29110 only — which is exactly why the rod is not caught there and falls into fishing instead.

The same run **did** confirm the fix: with this branch equipping the rod leaves the attack power unchanged, where before it would gain `getRandomInt(100, 27400) * 2`.

So what this PR is worth: the visible stat stops being wrong on any client, and the server stops relying on a client-side check that is not a security boundary — which is why the original guards it server-side too. **Medium rather than high.** The code is unchanged.

## Note on scope

Pre-existing, not from a recent change. It compounds with the frozen weapon roll reported separately — because the roll is cached in `ATTACK_GRADE`, a player could re-equip until a high roll landed and keep it — but that is a different fix and this one stands on its own. The item numbers quoted above were parsed from the shipped `items.json` rather than recalled.

Adjacent things I deliberately left alone, happy to sweep separately: the 10 mount-spear vnums map to `RESIST_SWORD` in `weaponResistanceMapper`, a resistance the original never applies to a lance; and `getWeaponValues` still folds the roll into the grade rather than rolling per hit.
