### PR TITLE
fix(points): clamp attack and movement speed at read time like GetLimitPoint

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -23,6 +23,10 @@ type MovementNodeProvider = () => { x: number; y: number } | null;
 const MOVEMENT_NODE_HANDOFF_RATE = 0.9;
 const SPEED_REFERENCE_DISTANCE = 10_000;
 
+const PLAYER_ATTACK_SPEED_LIMIT = 170;
+const PLAYER_MOVE_SPEED_LIMIT = 200;
+const MOB_SPEED_LIMIT = 250;
+
 export default abstract class Character extends GameEntity {
     protected id: number;
     protected classId: number = 0;
@@ -236,11 +240,7 @@ export default abstract class Character extends GameEntity {
         );
 
         if (animation) {
-            this.movementDuration = AnimationUtil.calcAnimationDuration(
-                animation,
-                this.getPoint(PointsEnum.MOVE_SPEED),
-                distance,
-            );
+            this.movementDuration = AnimationUtil.calcAnimationDuration(animation, this.getMovementSpeed(), distance);
         } else {
             this.movementDuration = 0;
         }
@@ -373,7 +373,8 @@ export default abstract class Character extends GameEntity {
     }
 
     getMovementSpeed() {
-        return this.getPoint(PointsEnum.MOVE_SPEED);
+        const limit = this.isPlayer() ? PLAYER_MOVE_SPEED_LIMIT : MOB_SPEED_LIMIT;
+        return Math.max(0, Math.min(limit, this.getPoint(PointsEnum.MOVE_SPEED)));
     }
 
     /** Null when the class has no run animation, the case gotoInternal() also gives no duration. */
@@ -388,7 +389,7 @@ export default abstract class Character extends GameEntity {
 
         const duration = AnimationUtil.calcAnimationDuration(
             animation,
-            this.getPoint(PointsEnum.MOVE_SPEED),
+            this.getMovementSpeed(),
             SPEED_REFERENCE_DISTANCE,
         );
 
@@ -396,7 +397,8 @@ export default abstract class Character extends GameEntity {
     }
 
     getAttackSpeed() {
-        return this.getPoint(PointsEnum.ATTACK_SPEED);
+        const limit = this.isPlayer() ? PLAYER_ATTACK_SPEED_LIMIT : MOB_SPEED_LIMIT;
+        return Math.max(0, Math.min(limit, this.getPoint(PointsEnum.ATTACK_SPEED)));
     }
 
     getLevel() {

--- a/src/core/domain/entities/game/player/Player.ts
+++ b/src/core/domain/entities/game/player/Player.ts
@@ -1420,8 +1420,8 @@ export default class Player extends Character {
         this.connection?.send(
             new CharacterUpdatePacket({
                 vid: this.virtualId,
-                attackSpeed: this.points.getPoint(PointsEnum.ATTACK_SPEED),
-                moveSpeed: this.points.getPoint(PointsEnum.MOVE_SPEED),
+                attackSpeed: this.getAttackSpeed(),
+                moveSpeed: this.getMovementSpeed(),
                 parts: [this.getBody()?.getId() ?? 0, this.getWeapon()?.getId() ?? 0, 0, this.getHair()?.getId() ?? 0],
                 affects: this.getAffectFlags(),
                 guildId: 0, //TODO
@@ -1435,8 +1435,8 @@ export default class Player extends Character {
         for (const entity of this.nearbyEntities.values()) {
             if (entity instanceof Player) {
                 entity.otherEntityUpdated({
-                    attackSpeed: this.points.getPoint(PointsEnum.ATTACK_SPEED),
-                    moveSpeed: this.points.getPoint(PointsEnum.MOVE_SPEED),
+                    attackSpeed: this.getAttackSpeed(),
+                    moveSpeed: this.getMovementSpeed(),
                     vid: this.virtualId,
                     bodyId: this.getBodyId() ?? 0,
                     weaponId: this.getWeaponId() ?? 0,
@@ -2347,8 +2347,8 @@ export default class Player extends Character {
         this.connection?.send(
             new CharacterUpdatePacket({
                 vid: this.virtualId,
-                attackSpeed: this.points.getPoint(PointsEnum.ATTACK_SPEED),
-                moveSpeed: this.points.getPoint(PointsEnum.MOVE_SPEED),
+                attackSpeed: this.getAttackSpeed(),
+                moveSpeed: this.getMovementSpeed(),
                 parts: parts,
                 affects: this.getAffectFlags(),
                 guildId: 0,
@@ -2370,8 +2370,8 @@ export default class Player extends Character {
                 // Also send CharacterUpdatePacket with the new mount info
                 entity.otherEntityUpdated({
                     vid: this.getVirtualId(),
-                    attackSpeed: this.points.getPoint(PointsEnum.ATTACK_SPEED),
-                    moveSpeed: this.points.getPoint(PointsEnum.MOVE_SPEED),
+                    attackSpeed: this.getAttackSpeed(),
+                    moveSpeed: this.getMovementSpeed(),
                     bodyId: this.getBody()?.getId() ?? 0,
                     weaponId: this.getWeapon()?.getId() ?? 0,
                     hairId: this.getHair()?.getId() ?? 0,

--- a/test/unit/core/domain/entities/game/CharacterSpeedLimit.test.ts
+++ b/test/unit/core/domain/entities/game/CharacterSpeedLimit.test.ts
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+import Character from '@/core/domain/entities/game/Character';
+import Player from '@/core/domain/entities/game/player/Player';
+import Stone from '@/core/domain/entities/game/mob/Stone';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+import { EntityTypeEnum } from '@/core/enum/EntityTypeEnum';
+
+/**
+ * The original clamps speeds at read time in GetLimitPoint (char.cpp:2914-2970):
+ * 170/200 for players, 250 for everything else. Without the clamp the raw
+ * accumulator reaches the uint8 packet fields, and any value above 255 makes
+ * pack() throw ERR_OUT_OF_RANGE, which closes the connection.
+ */
+
+const makeFake = (points: Partial<Record<PointsEnum, number>>, isPlayer: boolean) => ({
+    getPoint: (point: PointsEnum) => points[point] ?? 0,
+    isPlayer: () => isPlayer,
+});
+
+const attackSpeedOf = (points: Partial<Record<PointsEnum, number>>, isPlayer: boolean) =>
+    Character.prototype.getAttackSpeed.call(makeFake(points, isPlayer));
+
+const moveSpeedOf = (points: Partial<Record<PointsEnum, number>>, isPlayer: boolean) =>
+    Character.prototype.getMovementSpeed.call(makeFake(points, isPlayer));
+
+describe('speed limit points (GetLimitPoint port)', () => {
+    it('clamps a player attack speed at 170', () => {
+        // base 150 + the Saw Tooth Knife apply of 114
+        expect(attackSpeedOf({ [PointsEnum.ATTACK_SPEED]: 264 }, true)).to.equal(170);
+    });
+
+    it('clamps a player movement speed at 200', () => {
+        expect(moveSpeedOf({ [PointsEnum.MOVE_SPEED]: 320 }, true)).to.equal(200);
+    });
+
+    it('clamps a mob speed at 250', () => {
+        // Metin of Black (vnum 8005): move_speed 310, attack_speed 305
+        expect(moveSpeedOf({ [PointsEnum.MOVE_SPEED]: 310 }, false)).to.equal(250);
+        expect(attackSpeedOf({ [PointsEnum.ATTACK_SPEED]: 305 }, false)).to.equal(250);
+    });
+
+    it('passes an in-range speed through unchanged', () => {
+        expect(attackSpeedOf({ [PointsEnum.ATTACK_SPEED]: 165 }, true)).to.equal(165);
+        expect(moveSpeedOf({ [PointsEnum.MOVE_SPEED]: 150 }, true)).to.equal(150);
+        expect(moveSpeedOf({ [PointsEnum.MOVE_SPEED]: 240 }, false)).to.equal(240);
+    });
+
+    it('floors a negative accumulator at 0, as GetLimitPoint does', () => {
+        expect(moveSpeedOf({ [PointsEnum.MOVE_SPEED]: -30 }, false)).to.equal(0);
+    });
+});
+
+describe('speed bytes on the wire', () => {
+    const packed: Array<Buffer> = [];
+
+    const makeStone = () => {
+        const stone = Object.create(Stone.prototype);
+        return Object.assign(stone, {
+            getVirtualId: () => 7,
+            getClassId: () => 8005,
+            getEntityType: () => EntityTypeEnum.METIN_STONE,
+            getPoint: (point: PointsEnum) =>
+                point === PointsEnum.MOVE_SPEED ? 310 : point === PointsEnum.ATTACK_SPEED ? 305 : 0,
+            getPositionX: () => 100,
+            getPositionY: () => 100,
+            getEmpire: () => 0,
+            getLevel: () => 1,
+            getName: () => 'Metin of Black',
+            getRotation: () => 0,
+            isDead: () => false,
+        });
+    };
+
+    const makeViewer = () => {
+        const viewer = Object.create(Player.prototype);
+        return Object.assign(viewer, {
+            connection: { send: (packet: { pack: () => Buffer }) => packed.push(packet.pack()) },
+        });
+    };
+
+    beforeEach(() => {
+        packed.length = 0;
+    });
+
+    it('spawns a metin stone without killing the connection', () => {
+        // Without the clamp this throws ERR_OUT_OF_RANGE at writeUint8(310):
+        // the stone protos on the starter maps all carry speeds above 255.
+        Player.prototype.onNearbyEntityAdded.call(makeViewer(), makeStone());
+
+        const spawn = packed[0];
+        expect(spawn, 'the spawn packet must reach the wire').to.be.instanceOf(Buffer);
+        expect(spawn[24], 'movementSpeed byte').to.equal(250);
+        expect(spawn[25], 'attackSpeed byte').to.equal(250);
+    });
+
+    it('updates a player wearing a +114 attack speed dagger without killing the connection', () => {
+        const player = Object.create(Player.prototype);
+        Object.assign(player, {
+            virtualId: 99,
+            points: {
+                getPoint: (point: PointsEnum) =>
+                    point === PointsEnum.ATTACK_SPEED ? 264 : point === PointsEnum.MOVE_SPEED ? 150 : 0,
+            },
+            getEntityType: () => EntityTypeEnum.PLAYER,
+            getBody: () => null,
+            getWeapon: () => null,
+            getHair: () => null,
+            getAffectFlags: () => [0, 0],
+            horse: { getMountVnum: () => 0 },
+            nearbyEntities: new Map(),
+            connection: { send: (packet: { pack: () => Buffer }) => packed.push(packet.pack()) },
+        });
+
+        // Without the clamp this throws ERR_OUT_OF_RANGE at writeUint8(264).
+        Player.prototype.updateView.call(player);
+
+        const update = packed[0];
+        expect(update[13], 'moveSpeed byte').to.equal(150);
+        expect(update[14], 'attackSpeed byte').to.equal(170);
+    });
+});


### PR DESCRIPTION
Fixes #257.

> **Correction (2026-08-12, after the spawn audit):** the first version of this body claimed the metin-stone overflow was live — "walking into view of any metin stone closes the connection". That was wrong, and the reason is a different bug: stone spawn rows are currently discarded by `SpawnManager` (`createMonsters` keeps an entity only `if (entity instanceof Monster)`, and `Stone extends Mob`), so metin stones never enter the world at all. I re-derived the full spawnable set from the live spawn data: **zero currently-spawnable entities carry a speed above 255.** The stone half of this fix is therefore armed-but-latent — and it becomes a prerequisite for the stone-spawn fix, because the moment stones spawn again, an unclamped server would crash every viewer as a metin enters view. The stone-spawn bug is being filed separately with the rest of the spawn audit. The dagger case below was and remains the live crash.

`attackSpeed` and `moveSpeed` accumulate without an upper bound. The original clamps them to 170 / 200 for players. Because both are emitted as a single byte, an accumulator above 255 makes `pack()` throw `ERR_OUT_OF_RANGE` — `Buffer.writeUInt8` does not wrap — and the throw unwinds to the connection handler, which closes the socket.

## The live reachable case

All four jobs start at `initialAttackSpeed: 150` (`jobs.json`), and `items.json` ships **40 items with `APPLY_ATT_SPEED` above 105** — the Saw Tooth Knife family, vnums 1140-1149, at **114** (10 000 gold, `LIMIT_NONE`, wearable by assassins):

```
150 (base) + 114 (dagger) = 264  ->  writeUint8(264) throws  ->  connection closed
```

Equipping the dagger fires `onEquipmentChange` → `updateView()` → `CharacterUpdatePacket`, and the player is disconnected. A cheaper, non-fatal check of the same defect: equip any Sword+0 (vnum 10, `APPLY_ATT_SPEED 22`) and read `POINT_ATT_SPEED` — 172, where the original reports 170. The only reason the dagger does not brick login outright is that spawn resets both speeds to the job base (#251); fixing #251 without this one would turn the per-equip disconnect into a permanent one.

The metin protos carry the same class of value (Metin of Black, 8005, `move_speed 310`; the Cape/Bay stones reach 3087), through `MobPoints` serving the proto raw into the same `writeUint8` — latent today only because of the spawn bug described in the correction above.

## The fix

The issue offered two shapes; this implements the one it recommended — clamp at read time, the way `GetLimitPoint` does. Say the word and I will switch it to write-time.

```ts
// Character.ts
getMovementSpeed() {
    const limit = this.isPlayer() ? PLAYER_MOVE_SPEED_LIMIT : MOB_SPEED_LIMIT;
    return Math.max(0, Math.min(limit, this.getPoint(PointsEnum.MOVE_SPEED)));
}
```

170/200 for players, 250 for everything else, floor at 0 — the literal shape of `char.cpp:2929-2964`. The getters are the funnel every spawn/update packet and every duration calculation goes through, mirroring where the original applies it (`pack.bAttackSpeed = GetLimitPoint(...)` at `char.cpp:838/1002`, `CalculateDuration(GetLimitPoint(...))` at `char.cpp:2802` and `char_state.cpp:1068`). The reads that bypassed the getters now go through them: `updateView` (self + broadcast), the mount update (self + viewers), and the two movement-duration calculations in `Character`. Storage stays unclamped, as in the original (`PointChange` has no cap, `char.cpp:3380-3390`), so a buff pushing past the cap still subtracts back to the right value later.

## What this deliberately does not do

- **`BufferWriter` stays sharp** — an out-of-range write still throws. Making it defensive was question 2 of the issue and deserves its own PR if you want it.
- The base speed of 150 vs the original's 100 (#250), the spawn-time reset (#251) and the stone-spawn bug (spawn audit, being filed) are untouched here.

## Verified

- `tsc --noEmit`, eslint (only the repo's known warnings), `prettier --check` clean.
- Unit **805 passing, 0 failing** (master alone is 798). No existing spec pinned the raw values.
- **Fail-without-fix: 6 of the 7 new specs go red**, the two wire specs with the exact `ERR_OUT_OF_RANGE`. The wire specs drive the real `Player.prototype.onNearbyEntityAdded` with a `Stone` carrying the real 8005 proto speeds, and the real `updateView` with the dagger value, asserting the clamped bytes at their offsets (250/250 and 150/170).
- `merge-tree` clean against `1cbaf1ed`; pairwise-clean against #213, #169, #140, #136, #131 and no file overlap with #262.

## Note on scope

Pre-existing on every path. The mob half looks like a data problem at first sight, but the readme stance on tuning values does not apply: the stone protos are authentic original data that the original engine clamps at read time — the defect is the missing clamp, not the numbers.
