### PR TITLE
fix(battle): build the victim evade rating from the attacker level, as the original does

### DIFF
--- a/src/core/domain/entities/game/Character.ts
+++ b/src/core/domain/entities/game/Character.ts
@@ -124,8 +124,8 @@ export default abstract class Character extends GameEntity {
         this.affectBitFlag.reset(value);
     }
 
-    getAttackRating() {
-        return Math.min(90, (this.getPoint(PointsEnum.DX) * 4 + this.getPoint(PointsEnum.LEVEL) * 2) / 6);
+    getAttackRating(level: number = this.getPoint(PointsEnum.LEVEL)) {
+        return Math.min(90, Math.floor((this.getPoint(PointsEnum.DX) * 4 + level * 2) / 6));
     }
 
     abstract getHealthPercentage(): number;

--- a/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
+++ b/src/core/domain/entities/game/mob/delegate/battle/MonsterBattle.ts
@@ -337,7 +337,8 @@ export default class MonsterBattle {
 
     private calcAttackRating(victim: Player) {
         const attackerRating = this.attacker.getAttackRating();
-        const victimRating = victim.getAttackRating();
+        // CalcAttackRating feeds the ATTACKER's level into the victim-side term (battle.cpp:227)
+        const victimRating = victim.getAttackRating(this.attacker.getLevel());
         const attackRating =
             (attackerRating + 210.0) / 300.0 - (((victimRating * 2 + 5) / (victimRating + 95)) * 3.0) / 10.0;
         return attackRating;

--- a/src/core/domain/entities/game/player/delegate/battle/PlayerBattleStrategy.ts
+++ b/src/core/domain/entities/game/player/delegate/battle/PlayerBattleStrategy.ts
@@ -23,7 +23,8 @@ export default abstract class PlayerBattleStrategy<Victim extends Character = Ch
 
     protected calcAttackRating(victim: Victim) {
         const attackerRating = this.attacker.getAttackRating();
-        const victimRating = victim.getAttackRating();
+        // CalcAttackRating feeds the ATTACKER's level into the victim-side term (battle.cpp:227)
+        const victimRating = victim.getAttackRating(this.attacker.getLevel());
         const attackRating =
             (attackerRating + 210.0) / 300.0 - (((victimRating * 2 + 5) / (victimRating + 95)) * 3.0) / 10.0;
         return attackRating;

--- a/test/unit/core/domain/entities/game/Character.test.ts
+++ b/test/unit/core/domain/entities/game/Character.test.ts
@@ -73,5 +73,16 @@ describe('Character', () => {
             const character = createCharacter({ dx: 0, level: 0 });
             expect(character.getAttackRating()).to.be.equal(0);
         });
+
+        it('should truncate the division like the original integer /6', () => {
+            const character = createCharacter({ dx: 5, level: 0 });
+            expect(character.getAttackRating()).to.be.equal(3);
+        });
+
+        it('should use the level it is given instead of its own', () => {
+            const character = createCharacter({ dx: 30, level: 1 });
+            expect(character.getAttackRating(70)).to.be.equal(Math.floor((30 * 4 + 70 * 2) / 6));
+            expect(character.getAttackRating()).to.be.equal(Math.floor((30 * 4 + 1 * 2) / 6));
+        });
     });
 });

--- a/test/unit/core/domain/entities/game/battle/AttackRatingSource.test.ts
+++ b/test/unit/core/domain/entities/game/battle/AttackRatingSource.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Character from '@/core/domain/entities/game/Character';
+import PlayerBattleStrategy from '@/core/domain/entities/game/player/delegate/battle/PlayerBattleStrategy';
+import MonsterBattle from '@/core/domain/entities/game/mob/delegate/battle/MonsterBattle';
+import { PointsEnum } from '@/core/enum/PointsEnum';
+
+/**
+ * CalcAttackRating (battle.cpp:211-242) builds the victim-side evade rating
+ * from the ATTACKER's level: `int victim_lv = pkAttacker->GetLevel();` at
+ * line 227. Both battle directions must feed that level through.
+ */
+
+const ratingCall = (proto: unknown, self: unknown, victim: unknown) =>
+    (proto as Record<string, (v: unknown) => number>)['calcAttackRating'].call(self, victim);
+
+const makeRealRated = (dx: number, level: number) => ({
+    getPoint: (point: PointsEnum) => (point === PointsEnum.DX ? dx : point === PointsEnum.LEVEL ? level : 0),
+    getLevel: () => level,
+    getAttackRating(level?: number) {
+        return Character.prototype.getAttackRating.call(this, level);
+    },
+});
+
+describe('attack rating level source (both battle directions)', () => {
+    it('player vs mob: the mob evade rating is built from the player level', () => {
+        const victim = { getAttackRating: sinon.stub().returns(0) };
+        const attacker = { getAttackRating: () => 0, getLevel: () => 70 };
+
+        ratingCall(PlayerBattleStrategy.prototype, { attacker }, victim);
+
+        expect(victim.getAttackRating.calledOnceWith(70)).to.equal(true);
+    });
+
+    it('mob vs player: the player evade rating is built from the mob level', () => {
+        const victim = { getAttackRating: sinon.stub().returns(0) };
+        const attacker = { getAttackRating: () => 0, getLevel: () => 35 };
+
+        ratingCall(MonsterBattle.prototype, { attacker }, victim);
+
+        expect(victim.getAttackRating.calledOnceWith(35)).to.equal(true);
+    });
+
+    it('reproduces the original arithmetic end to end', () => {
+        // attacker: dx 90, level 70 -> iARSrc = min(90, (360 + 140) / 6) = 83
+        // victim:   dx 30, attacker level 70 -> iERSrc = (120 + 140) / 6 = 43
+        // fAR = (83 + 210) / 300, fER = ((43 * 2 + 5) / (43 + 95)) * 3 / 10
+        const attacker = makeRealRated(90, 70);
+        const victim = makeRealRated(30, 5);
+
+        const rating = ratingCall(PlayerBattleStrategy.prototype, { attacker }, victim);
+
+        const expected = (83 + 210) / 300 - ((43 * 2 + 5) / (43 + 95)) * (3 / 10);
+        expect(rating).to.be.closeTo(expected, 1e-9);
+    });
+});


### PR DESCRIPTION
First slice of #258 — item 2 (attack rating). Refs #258; the other three items stay open there.

## The two defects

`CalcAttackRating` (`battle.cpp:211-242`) has a quirk our port smoothed away: **the victim-side evade rating is built from the ATTACKER's level.** Line 227 reads, verbatim:

```cpp
int victim_lv = pkAttacker->GetLevel();
```

Our `Character.getAttackRating()` always used the owner's own level, and both battle directions — `PlayerBattleStrategy.calcAttackRating` (player → mob) and `MonsterBattle.calcAttackRating` (mob → player) — built the victim term from it. Both `/6` divisions are also integer in the C++ (`iARSrc`/`iERSrc` are `int`s), where ours kept the fraction.

It looks like a copy-paste bug on Ymir's side, but it is what 40250 ships, and it has a real effect: the evade term grows with the attacker's own level, so the drift between the two implementations reaches **~14% of the attack multiplier and flips sign with the level gap**. Against real `mobs.json` rows: a level-70 player deals ~13% more per hit than the original on low-level mobs and ~1% less on level-80 mobs; a level-10 player ~11% less on high-level content. Every melee hit in both directions runs through this multiplier. The truncation is a sub-1% correction included for exactness since the line was being rewritten anyway.

## The fix

`getAttackRating` takes the level to use, defaulting to the owner's own:

```ts
getAttackRating(level: number = this.getPoint(PointsEnum.LEVEL)) {
    return Math.min(90, Math.floor((this.getPoint(PointsEnum.DX) * 4 + level * 2) / 6));
}
```

and the two strategies pass `this.attacker.getLevel()` for the victim term. Callers that legitimately rate a character by itself are untouched by the default. A one-line anchor comment sits at each call site pointing at `battle.cpp:227` — without it the code reads like a bug someone would helpfully "fix" back.

Left out on purpose: the original feeds `GetPolymorphPoint(POINT_DX)` rather than raw DX into both sources (`battle.cpp:223,226`) — that belongs with the polymorph recompute work (#246/#258 item 3), not here.

## Verified

- `tsc --noEmit`, eslint, `prettier --check` clean; unit **803 passing, 0 failing** (master alone is 798).
- **Fail-without-fix: the 5 new specs go red** — the two wiring specs (each direction asserts the victim rating is requested with the attacker's level), a reproduction of the original arithmetic end to end (dx 90/lv 70 vs dx 30 → `iARSrc 83, iERSrc 43`), the truncation case and the level-override case. The 4 pre-existing `getAttackRating` specs stay green either way; their inputs happen to divide by 6 exactly.
- Composed with **all 18 open PRs**: 19/19 merge clean, `tsc` clean, unit **951/0**, integration **47/0**. The composition run caught one interaction: #262's attack spec built its fake without `getLevel`, which this PR's rewrite now calls — fixed with a one-line stub pushed to #262 (test-only).
- Pairwise `merge-tree` clean in both orders against #169, #134 and #263, the three open PRs sharing these files.

## Note on scope

Pre-existing on both battle paths; no overlap with the changes in PR #134, which stays inside `resolveAttack`'s damage roll.
